### PR TITLE
fix(custom-decorators): Missing export word

### DIFF
--- a/src/app/homepage/pages/custom-decorators/custom-decorators.component.ts
+++ b/src/app/homepage/pages/custom-decorators/custom-decorators.component.ts
@@ -11,7 +11,7 @@ export class CustomDecoratorsComponent {
     return `
 import { createRouteParamDecorator } from '@nestjs/common';
 
-const User = createRouteParamDecorator((data, req) => {
+export const User = createRouteParamDecorator((data, req) => {
   return req.user;
 });`;
   }
@@ -20,7 +20,7 @@ const User = createRouteParamDecorator((data, req) => {
     return `
 import { createRouteParamDecorator } from '@nestjs/common';
 
-const User = createRouteParamDecorator((data, req) => {
+export const User = createRouteParamDecorator((data, req) => {
   console.log(data); // test
   return req.user;
 });`;


### PR DESCRIPTION
If a reader copy/paste the example of custom-decorators, it require the reserved word "export" when it want use the custom-decorator (import from another file).