### PR TITLE
Pipes: (fix) deprecated import of HttpException

### DIFF
--- a/src/app/homepage/pages/pipes/pipes.component.ts
+++ b/src/app/homepage/pages/pipes/pipes.component.ts
@@ -64,8 +64,7 @@ export class CreateCatDto {
 
   get fullValidationPipe() {
     return `
-import { HttpException } from '@nestjs/core';
-import { PipeTransform, Pipe, ArgumentMetadata, HttpStatus } from '@nestjs/common';
+import { PipeTransform, Pipe, ArgumentMetadata, BadRequestException } from '@nestjs/common';
 import { validate } from 'class-validator';
 import { plainToClass } from 'class-transformer';
 
@@ -79,7 +78,7 @@ export class ValidationPipe implements PipeTransform<any> {
       const object = plainToClass(metatype, value);
       const errors = await validate(object);
       if (errors.length > 0) {
-          throw new HttpException('Validation failed', HttpStatus.BAD_REQUEST);
+          throw new BadRequestException('Validation failed');
       }
       return value;
     }

--- a/src/app/homepage/pages/pipes/pipes.component.ts
+++ b/src/app/homepage/pages/pipes/pipes.component.ts
@@ -120,15 +120,14 @@ bootstrap();`;
 
   get parseIntPipe() {
     return `
-import { HttpException } from '@nestjs/core';
-import { PipeTransform, Pipe, ArgumentMetadata, HttpStatus } from '@nestjs/common';
+import { PipeTransform, Pipe, ArgumentMetadata, HttpStatus, BadRequestException } from '@nestjs/common';
 
 @Pipe()
 export class ParseIntPipe implements PipeTransform<string> {
   async transform(value: string, metadata: ArgumentMetadata) {
     const val = parseInt(value, 10);
     if (isNaN(val)) {
-      throw new HttpException('Validation failed', HttpStatus.BAD_REQUEST);
+      throw new BadRequestException('Validation failed');
     }
     return val;
   }
@@ -137,15 +136,14 @@ export class ParseIntPipe implements PipeTransform<string> {
 
   get parseIntPipeJs() {
     return `
-import { HttpException } from '@nestjs/core';
-import { Pipe, HttpStatus } from '@nestjs/common';
+import { Pipe, HttpStatus, BadRequestException} from '@nestjs/common';
 
 @Pipe()
 export class ParseIntPipe {
   async transform(value, metadata) {
     const val = parseInt(value, 10);
     if (isNaN(val)) {
-      throw new HttpException('Validation failed', HttpStatus.BAD_REQUEST);
+      throw new BadRequestException('Validation failed');
     }
     return val;
   }


### PR DESCRIPTION
Hi,

I've just been through this part of the tutorial and noticed that a deprecated import was used.
Indeed, `HttpException` is now part of `@nestjs/common` instead of `@nestjs/core`.
Moreover, as a dedicated exception class now exists for this particular usecase (`BadRequestException`), I just thought it would be a good idea to use it.