### PR TITLE
Fix wrong ormconfig.json in sql docs

### DIFF
--- a/src/app/homepage/pages/techniques/sql/sql.component.ts
+++ b/src/app/homepage/pages/techniques/sql/sql.component.ts
@@ -40,7 +40,7 @@ export class ApplicationModule {}`;
   "password": "root",
   "database": "test",
   "entities": ["src/**/**.entity{.ts,.js}"],
-  "autoSchemaSync": true
+  "synchronize": true
 }`;
   }
 


### PR DESCRIPTION
`autoSchemaSync` option has renamed to `synchronize`
https://github.com/nestjs/typeorm/issues/3#issuecomment-354224898