### PR TITLE
Changed autoSchemaSync to synchronize (new way according to typeorm)

### DIFF
--- a/src/app/homepage/pages/recipes/sql-typeorm/sql-typeorm.component.ts
+++ b/src/app/homepage/pages/recipes/sql-typeorm/sql-typeorm.component.ts
@@ -11,7 +11,7 @@ export class SqlTypeormComponent extends BasePageComponent {
     return `
 $ npm install --save typeorm mysql`;
   }
-  
+
   get databaseProviders() {
     return `
 import { createConnection } from 'typeorm';
@@ -29,7 +29,7 @@ export const databaseProviders = [
       entities: [
           __dirname + '/../**/*.entity{.ts,.js}',
       ],
-      autoSchemaSync: true,
+      synchronize: true,
     }),
   },
 ];`;


### PR DESCRIPTION
The documentation as is (npm install --save typeorm mysql) will not work. autoShcemaSync has been changed to synchronize: http://typeorm.io/#/connection-options.