### PR TITLE
Fix deprecated decorator for interceptors

### DIFF
--- a/src/app/homepage/pages/interceptors/interceptors.component.html
+++ b/src/app/homepage/pages/interceptors/interceptors.component.html
@@ -1,7 +1,7 @@
 <div class="content">
    <h3>Interceptors</h3>
    <p>
-     An interceptor is a class annotated with the <code>@Interceptor()</code> decorator.
+     An interceptor is a class annotated with the <code>@Injectable()</code> decorator.
      The interceptor should implement the <code>NestInterceptor</code> interface.
    </p>
    <figure><img src="/assets/Interceptors_1.png" /></figure>


### PR DESCRIPTION
Since version 5, the `@Interceptor()` is deprecated and `@Injectable()` is expected.