### PR TITLE
Fixed ParseIntPipe

### DIFF
--- a/src/app/homepage/pages/pipes/pipes.component.ts
+++ b/src/app/homepage/pages/pipes/pipes.component.ts
@@ -218,7 +218,7 @@ import { PipeTransform, Injectable, ArgumentMetadata, HttpStatus, BadRequestExce
 
 @Injectable()
 export class ParseIntPipe implements PipeTransform<string, number> {
-  async transform(value: string, metadata: ArgumentMetadata): number {
+  transform(value: string, metadata: ArgumentMetadata): number {
     const val = parseInt(value, 10);
     if (isNaN(val)) {
       throw new BadRequestException('Validation failed');

--- a/src/app/homepage/pages/pipes/pipes.component.ts
+++ b/src/app/homepage/pages/pipes/pipes.component.ts
@@ -234,7 +234,7 @@ import { Injectable, BadRequestException} from '@nestjs/common';
 
 @Injectable()
 export class ParseIntPipe {
-  async transform(value, metadata) {
+  transform(value, metadata) {
     const val = parseInt(value, 10);
     if (isNaN(val)) {
       throw new BadRequestException('Validation failed');


### PR DESCRIPTION
```javascript
export class ParseIntPipe implements PipeTransform<string, number> {
  async transform(value: string, metadata: ArgumentMetadata): number {
    //                                                        ^ wrong type if is an async function
  }
}
```
transform is a async function. The return type of an async function must be the global ```Promise<T>``` type.

I removed async in PR. Async function is redundant in this case.