### PR TITLE
Add exclude endpoint decorator

### DIFF
--- a/src/app/homepage/pages/recipes/swagger/swagger.component.html
+++ b/src/app/homepage/pages/recipes/swagger/swagger.component.html
@@ -2,7 +2,7 @@
     <h3>OpenAPI (Swagger)</h3>
     <h5>This chapter applies only to TypeScript</h5>
     <p>
-      The <a href="https://swagger.io/specification/" target="blank">OpenAPI</a> (Swagger) specification is a powerful definition format to describe RESTful APIs. 
+      The <a href="https://swagger.io/specification/" target="blank">OpenAPI</a> (Swagger) specification is a powerful definition format to describe RESTful APIs.
       Nest provides a dedicated <a href="https://github.com/nestjs/swagger" target="blank">module</a> to work with it.
     </p>
     <h4>Installation</h4>
@@ -147,6 +147,10 @@ $ npm run start</code></pre>
       </tr>
       <tr>
         <td><code>@ApiImplicitHeader()</code></td>
+        <td>Method</td>
+      </tr>
+      <tr>
+        <td><code>@ApiExcludeEndpoint()</code></td>
         <td>Method</td>
       </tr>
       <tr>

--- a/src/app/homepage/pages/recipes/swagger/swagger.component.html
+++ b/src/app/homepage/pages/recipes/swagger/swagger.component.html
@@ -2,7 +2,7 @@
     <h3>OpenAPI (Swagger)</h3>
     <h5>This chapter applies only to TypeScript</h5>
     <p>
-      The <a href="https://swagger.io/specification/" target="blank">OpenAPI</a> (Swagger) specification is a powerful definition format to describe RESTful APIs.
+      The <a href="https://swagger.io/specification/" target="blank">OpenAPI</a> (Swagger) specification is a powerful definition format to describe RESTful APIs. 
       Nest provides a dedicated <a href="https://github.com/nestjs/swagger" target="blank">module</a> to work with it.
     </p>
     <h4>Installation</h4>


### PR DESCRIPTION
Hi,

I added the decorator to exclude an endpoint just like you asked in #https://github.com/nestjs/swagger/pull/93. I only added it in the decorator list, as it's self-explanatory enough, I didn't feel the need to add a new paragraph.

As usual if you see anything wrong, let me know.

