### PR TITLE
fix(graphql/quick-start): change wrong class name

### DIFF
--- a/src/app/homepage/pages/graphql/quick-start/quick-start.component.ts
+++ b/src/app/homepage/pages/graphql/quick-start/quick-start.component.ts
@@ -16,7 +16,7 @@ import { GraphQLModule } from '@nestjs/graphql';
 @Module({
   imports: [GraphQLModule],
 })
-export class ApplicationModule implements NestModule {
+export class AppModule implements NestModule {
   configure(consumer: MiddlewareConsumer) {
     consumer
       .apply(graphqlExpress(req => ({ schema: {}, rootValue: req })))
@@ -34,7 +34,7 @@ import { GraphQLModule } from '@nestjs/graphql';
 @Module({
   imports: [GraphQLModule],
 })
-export class ApplicationModule {
+export class AppModule {
   configure(consumer) {
     consumer
       .apply(graphqlExpress(req => ({ schema: {}, rootValue: req })))
@@ -52,7 +52,7 @@ import { GraphQLModule, GraphQLFactory } from '@nestjs/graphql';
 @Module({
   imports: [GraphQLModule],
 })
-export class ApplicationModule implements NestModule {
+export class AppModule implements NestModule {
   constructor(private readonly graphQLFactory: GraphQLFactory) {}
 
   configure(consumer: MiddlewareConsumer) {
@@ -76,7 +76,7 @@ import { GraphQLModule, GraphQLFactory } from '@nestjs/graphql';
 @Module({
   imports: [GraphQLModule],
 })
-export class ApplicationModule {
+export class AppModule {
   constructor(graphQLFactory) {
     this.graphQLFactory = graphQLFactory;
   }


### PR DESCRIPTION
I catch this error:
Nest cannot create the module instance. The frequent reason of this exception is the circular dependency between modules. Use forwardRef() to avoid it (read more https://docs.nestjs.com/advanced/circular-dependency). Scope []