### PR TITLE
docs(@nestjs) replace `npm run start` with `npm start`

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Navigate to `http://localhost:4200/`. The app will automatically reload if you c
 
 ```
 $ npm install
-$ npm run start
+$ npm start
 ```
 
 ## Build

--- a/src/app/homepage/pages/first-steps/first-steps.component.html
+++ b/src/app/homepage/pages/first-steps/first-steps.component.html
@@ -93,7 +93,7 @@ $ nest new project</code></pre>
       Once the installation process is complete, you can run the following command to start the HTTP server:
     </p>
     <pre><code class=" language-bash ">
-$ npm run start</code></pre>
+$ npm start</code></pre>
     <p>
       This command starts the HTTP server on the port defined inside the <code>src/main.ts</code> file. While the application
       is running, open your browser and navigate to <code>http://localhost:3000/</code>. You should see the <code>Hello world!</code>      message.

--- a/src/app/homepage/pages/introduction/introduction.component.html
+++ b/src/app/homepage/pages/introduction/introduction.component.html
@@ -32,12 +32,12 @@ $ nest new project-name</code></pre>
 $ git clone https://github.com/nestjs/typescript-starter.git project
 $ cd project
 $ npm install
-$ npm run start</code></pre>
+$ npm start</code></pre>
   <pre [class.hide]="!starter.isJsActive"><code class="language-bash">
 $ git clone https://github.com/nestjs/javascript-starter.git project
 $ cd project
 $ npm install
-$ npm run start</code></pre>
+$ npm start</code></pre>
 
   <p>Or start a new project from scratch with <strong>npm</strong> (or <strong>yarn</strong>):</p>
   <pre><code class="language-bash">

--- a/src/app/homepage/pages/recipes/swagger/swagger.component.html
+++ b/src/app/homepage/pages/recipes/swagger/swagger.component.html
@@ -32,7 +32,7 @@ $ npm install --save @nestjs/swagger</code></pre>
       Now you can run the following command to start the HTTP server:
     </p>
     <pre><code class="language-bash">
-$ npm run start</code></pre>
+$ npm start</code></pre>
     <p>
       While the application is running, open your browser and navigate to <code>http://localhost:3000/api</code>. You should see similar page:
     </p>


### PR DESCRIPTION
I simply replaced `npm run start` with `npm start` in the documentation since `run` is redundant