### PR TITLE
docs(@nestjs/mongoose) Change 'Mongoose' to 'ORM' on some lines

### DIFF
--- a/src/app/homepage/pages/techniques/mongo/mongo.component.html
+++ b/src/app/homepage/pages/techniques/mongo/mongo.component.html
@@ -1,11 +1,11 @@
 <div class="content">
   <h3>Mongo</h3>
   <p>
-    There are two ways of dealing with the MongoDB database. You can either use a <a href="https://github.com/Mongoose/Mongoose"
-      target="blank">Mongoose</a> that provides a MongoDB support or <a href="http://mongoosejs.com" target="blank">Mongoose</a>
+    There are two ways of dealing with the MongoDB database. You can either use an <a href="https://github.com/typeorm/typeorm"
+      target="blank">ORM</a> that provides a MongoDB support or <a href="http://mongoosejs.com" target="blank">Mongoose</a>
     which is the most popular <a href="https://www.mongodb.org/" target="blank">MongoDB</a> object modeling tool. If you
-    wanna stay with the <strong>Mongoose</strong> you can follow <a routerLink="/techniques/sql">these steps</a>. Otherwise,
-    we'll use a dedicated <code>@nestjs/mongoose</code> package.
+    wanna stay with the <strong>ORM</strong> you can follow <a routerLink="/techniques/sql">these steps</a>. Otherwise,
+    we'll use the dedicated <code>@nestjs/mongoose</code> package.
   </p>
   <p>
     Firstly, we need to install all of the required dependencies:


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Other... Please describe:
```

## What is the current behavior?
The Techniques/Mongo page seems to be refering to an ORM different than Mongoose (specifically TypeORM) but it mentions and links to Mongoose. Which makes it seem as if it's comparing Mongoose with itself.

Issue Number: N/A


## What is the new behavior?
Just changed some of the lines to refer to TypeORM instead of Mongoose, to make it more clear.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information