### PR TITLE
docs: fix typo in swagger docs

### DIFF
--- a/src/app/homepage/pages/recipes/swagger/swagger.component.html
+++ b/src/app/homepage/pages/recipes/swagger/swagger.component.html
@@ -113,7 +113,7 @@ $ npm run start</code></pre>
   </p>
   <figure><img src="/assets/swagger-cats.png" /></figure>
   <p>
-    While <code>http://localhost:3000/api/docs</code> will expose a SwaggerUI for your Dogs:
+    While <code>http://localhost:3000/api/dogs</code> will expose a SwaggerUI for your Dogs:
   </p>
   <figure><img src="/assets/swagger-dogs.png" /></figure>
   <blockquote class="warning">


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] Other... Please describe: docs
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

The `Multiple specifications` in the **swagger** section invite to the user to navigate to the
`http://localhost:3000/api/docs` to see the SwaggerUI for the `Dogs` endpoint but the specified URL is wrong. Seems to be a typo.


## What is the new behavior?

Set the URL to navigate to see the SwaggerUI for the Dogs to `http://localhost:3000/api/dogs`.


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information