### PR TITLE
docs: Fix recommended CLI command for generating CatsService

### DIFF
--- a/src/app/homepage/pages/components/components.component.html
+++ b/src/app/homepage/pages/components/components.component.html
@@ -33,7 +33,7 @@
   <pre [class.hide]="!catsServiceT.isJsActive"><code class="language-typescript">{{ catsServiceJs }}</code></pre>
   <blockquote class="info">
     <strong>Hint</strong>
-    To create a service using CLI, simply execute <code>$ nest g service cats/cats</code> command.
+    To create a service using CLI, simply execute <code>$ nest g service cats</code> command.
   </blockquote>
   <p>
     Here's a <code>CatsService</code>, a basic class with one property and two methods. The only new trait is that it


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] Other: Documentation
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The current documentation recommends to use `nest g service cats/cats` but this generates an additional `cats` directory under `cats` such that you get a path like `src/cats/cats/cats.service.ts`.

Issue Number: N/A


## What is the new behavior?

Based on what I have read I think it should result in a path like `src/cats/cats.service.ts`. Hence, the new command should be `nest g service cats`.


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information