### PR TITLE
docs(microservices): add hint for grpc transport enum location

### DIFF
--- a/src/app/homepage/pages/microservices/grpc/grpc.component.html
+++ b/src/app/homepage/pages/microservices/grpc/grpc.component.html
@@ -20,6 +20,9 @@ $ npm i --save grpc @grpc/proto-loader</code></pre>
   <blockquote class="info">
     <strong>Hint</strong> The <code>join()</code> function is imported from <code>path</code> package.
   </blockquote>
+  <blockquote class="info">
+    <strong>Hint</strong> <code>Transport.GRPC</code> is imported from <code>@nestjs/microservices</code> .
+  </blockquote>
   <h4>Options</h4>
   <p>
     There are a bunch of available options that determine a transporter behavior.


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
docs

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other... Please describe:

## What is the current behavior?
Under the "Transporter" section at the very top it's not clear where to get `Transport.GRPC` from. I had to dig into the library to find it. 
https://docs.nestjs.com/microservices/grpc

Issue Number: N/A

## What is the new behavior?
There is a hint that describes where to import `Transport.GRPC` from

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No
## Other information