### PR TITLE
useGlobalGuards clarification for websockets and microservices

### DIFF
--- a/src/app/homepage/pages/microservices/guards/guards.component.html
+++ b/src/app/homepage/pages/microservices/guards/guards.component.html
@@ -7,6 +7,10 @@
   <blockquote class="info">
     <strong>Hint</strong> The <code>RpcException</code> class is exposed from <code>@nestjs/microservices</code> package.
   </blockquote>
+  <blockquote>
+    <strong>Notice</strong> The
+    <code>useGlobalGuards()</code> method doesn't set up guards for microservices.
+  </blockquote>
   <h4>Binding guards</h4>
   <p>
     Here is an example that makes use of a <strong>method-scoped</strong> guard (class-scoped works either):

--- a/src/app/homepage/pages/websockets/guards/guards.component.html
+++ b/src/app/homepage/pages/websockets/guards/guards.component.html
@@ -7,6 +7,10 @@
   <blockquote class="info">
     <strong>Hint</strong> The <code>WsException</code> class is exposed from <code>@nestjs/websockets</code> package.
   </blockquote>
+  <blockquote>
+    <strong>Notice</strong> The
+    <code>useGlobalGuards()</code> method doesn't set up guards for gateways.
+  </blockquote>
   <h4>Binding guards</h4>
   <p>
     Here is an example that makes use of a <strong>method-scoped</strong> guard (class-scoped works either):


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
I think we need to notify users who reads `microservices/guards` and `websockets/guards` that `useGlobalGuards()` method doesn't set up guards for microservices and websockets, because `There is no difference` string at the beginning of the text makes user think that `useGlobalGuards()` will also work.
<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] Other... Please describe: docs
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information