### PR TITLE
bugfix(@nestjs/swagger) change docs to tell to install the package swagger-ui-express

### DIFF
--- a/content/recipes/swagger.md
+++ b/content/recipes/swagger.md
@@ -9,7 +9,7 @@ The [OpenAPI](https://swagger.io/specification/) (Swagger) specification is a po
 Firstly you have to install the required package:
 
 ```bash
-$ npm install --save @nestjs/swagger
+$ npm install --save swagger-ui-express @nestjs/swagger
 ```
 
 #### Bootstrap


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The Nest [Swagger documentation](https://docs.nestjs.com/recipes/swagger) does not tell the user to install `swagger-ui-express` even though it's a mandatory dependency.


## What is the new behavior?
The documentaation now contains a line saying `npm install swagger-ui-express`


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information