### PR TITLE
Add required package swagger-ui-express to swagger install docs

### DIFF
--- a/content/recipes/swagger.md
+++ b/content/recipes/swagger.md
@@ -6,10 +6,16 @@ The [OpenAPI](https://swagger.io/specification/) (Swagger) specification is a po
 
 #### Installation
 
-Firstly you have to install the required package:
+Firstly, you have to install the required packages:
 
 ```bash
-$ npm install --save @nestjs/swagger
+$ npm install --save @nestjs/swagger swagger-ui-express
+```
+
+If you are using fastify, you have to install `fastify-swagger` instead of `swagger-ui-express`:
+
+```bash
+$ npm install --save @nestjs/swagger fastify-swagger
 ```
 
 #### Bootstrap


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
```

## What is the current behavior?
Since nestjs/swagger#218, swagger-ui-express has to be installed manually when using express. When it is not installed, you get the message `The "swagger-ui-express" package is missing. Please, make sure to install this library ($ npm install swagger-ui-express) to take advantage of SwaggerModule.` This change should be reflected in the docs.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```