### PR TITLE
fix(terminus): bad TerminusOptions import

### DIFF
--- a/content/recipes/terminus.md
+++ b/content/recipes/terminus.md
@@ -82,7 +82,7 @@ Once we have set up our `TerminusOptionsService`, we can import the `TerminusMod
 @@filename(app.module)
 import { Module } from '@nestjs/common';
 import { TerminusModule } from '@nestjs/terminus';
-import { TerminusOptions } from './terminus-options.service';
+import { TerminusOptionsService } from './terminus-options.service';
 
 @Module({
   imports: [


### PR DESCRIPTION
In the sample code provide, in app.module.ts code imports TerminusOptions,
but TS says that terminus-options.service has no exported members
TerminusOptions if we use the sample code above for terminus-options.service.ts
This commit fix it, the good import should be TerminusOptionsService.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x ] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

In the sample code provide, in app.module.ts code imports TerminusOptions,
but TS says that terminus-options.service has no exported members
TerminusOptions


## What is the new behavior?

Sample code has been modified to now import the good TerminusOptionsService

## Does this PR introduce a breaking change?
```
[ ] Yes
[x ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information