### PR TITLE
docs(controllers) fix anchor link to Status codes on controllers page

### DIFF
--- a/content/controllers.md
+++ b/content/controllers.md
@@ -52,7 +52,7 @@ In our example above, when a GET request is made to this endpoint, Nest routes t
       <br /> Furthermore, the response's <strong>status code</strong> is always 200 by default, except for POST
       requests
       which use 201. We can easily change this behavior by adding the <code>@HttpCode(...)</code>
-      decorator at a handler-level (see <a href='#status-code'>Status codes</a>).
+      decorator at a handler-level (see <a href='controllers#status-code'>Status codes</a>).
     </td>
   </tr>
   <tr>


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfils the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Other... Please describe:
```

## What is the current behaviour?
Clicking 'Status codes' anchor link on controllers page does not work correctly, attempting to take the user to https://docs.nestjs.com/#status-code

Issue Number: N/A


## What is the new behaviour?
Clicking the link correctly takes user to the anchor point for status codes on the controllers page.


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information