### PR TITLE
docs(first-steps.md) remove extra extension from main.ts

### DIFF
--- a/content/first-steps.md
+++ b/content/first-steps.md
@@ -43,7 +43,7 @@ Here's a brief overview of those core files:
 The `main.ts` includes an async function, which will **bootstrap** our application:
 
 ```typescript
-@@filename(main.ts)
+@@filename(main)
 
 import { NestFactory } from '@nestjs/core';
 import { ApplicationModule } from './app.module';


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] Other... Please describe:
```
While skimiing through the `first-steps`in the documentation, I've found that it's written `main.ts.ts` in the file name which confused me.
![Screenshot from 2019-04-09 00-51-27](https://user-images.githubusercontent.com/7776002/55749084-f88f9e00-5a61-11e9-8615-0b3cf2b59a9b.png)

This PR makes that `main.ts`.
## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently, in the `first-steps` the file name shows `main.ts.ts`
Issue Number: N/A


## What is the new behavior?
This PR removes the extra `.ts`, hence the file name will show `main.ts`

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information