### PR TITLE
fix(page): see bookmark anchors when are focused

### DIFF
--- a/src/app/homepage/homepage.component.scss
+++ b/src/app/homepage/homepage.component.scss
@@ -84,10 +84,11 @@
   h4 {
     a {
       @include opacity(0);
-      padding-left: 0.35em;
+      margin-left: 0.10em;
+      padding: 0 0.25rem;
     }
     span:hover + a,
-    span + a:hover {
+    span + a:hover,a:focus {
       @include opacity(1);
     }
     &::before {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #361 


## What is the new behavior?
Solves the problem expressed on the issue.
Now when you using the keyboard and access the bookmark anchor is visible

> ![ezgif-2-7c2e1254cbbe](https://user-images.githubusercontent.com/7026066/56079950-cb742000-5dc0-11e9-81c8-ce84932280c3.gif)

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information