### PR TITLE
docs(sql.md): Update service

### DIFF
--- a/content/techniques/sql.md
+++ b/content/techniques/sql.md
@@ -156,8 +156,8 @@ export class PhotoService {
     private readonly photoRepository: Repository<Photo>,
   ) {}
 
-  async findAll(): Promise<Photo[]> {
-    return await this.photoRepository.find();
+  findAll(): Promise<Photo[]> {
+    return this.photoRepository.find();
   }
 }
 @@switch
@@ -172,8 +172,8 @@ export class PhotoService {
     this.photoRepository = photoRepository;
   }
 
-  async findAll() {
-    return await this.photoRepository.find();
+  findAll() {
+    return this.photoRepository.find();
   }
 }
 ```


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[x] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Other... Please describe:
```

## What is the current behavior?
From https://docs.nestjs.com/techniques/database
<!-- Describe how the issue manifests. -->
```typescript
import { Injectable } from '@nestjs/common';
import { InjectRepository } from '@nestjs/typeorm';
import { Repository } from 'typeorm';
import { Photo } from './photo.entity';

@Injectable()
export class PhotoService {
  constructor(
    @InjectRepository(Photo)
    private readonly photoRepository: Repository<Photo>,
  ) {}

  async findAll(): Promise<Photo[]> {
    return await this.photoRepository.find();
  }
}
```

## What is the new behavior?

```typescript
import { Injectable } from '@nestjs/common';
import { InjectRepository } from '@nestjs/typeorm';
import { Repository } from 'typeorm';
import { Photo } from './photo.entity';

@Injectable()
export class PhotoService {
  constructor(
    @InjectRepository(Photo)
    private readonly photoRepository: Repository<Photo>,
  ) {}

  findAll(): Promise<Photo[]> {
    return this.photoRepository.find();
  }
}
```

In this case async function declaration with await is not necessary, because 
```typescript
 findAll(): Promise<Photo[]> {
    return this.photoRepository.find();
  }
```
has already returned promise.

In addition, function with async declaration return promise anyway, so we don't need to await promise in order to get value and again wrap it to promise.


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

https://github.com/nestjs/docs.nestjs.com/issues/385