### PR TITLE
Remove semicolons from example .env file

### DIFF
--- a/content/techniques/configuration.md
+++ b/content/techniques/configuration.md
@@ -72,8 +72,8 @@ export class ConfigModule {}
 The `ConfigModule` registers a `ConfigService` and exports it as well. Additionally, we passed a path to the `.env` file. This path will be different depending on actual execution environment. Now you can simply inject `ConfigService` anywhere, and pull out a particular value based on a passed key. Sample `.env` file could look like below:
 
 ```typescript
-DATABASE_USER = test;
-DATABASE_PASSWORD = test;
+DATABASE_USER = test
+DATABASE_PASSWORD = test
 ```
 
 #### Using the ConfigService


### PR DESCRIPTION
The semicolons in the .env file provided in the documentation are not
required. (The .env file is not a TypeScript or JavaScript file.)
Moreover, in the example provided, with the semicolon present, the value
for e.g. the DATABASE_USER environment variable will end up being the
string "test;", not "test". Presumably the latter is what is actually
intended.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] Other... Please describe: Documentation
```

## What is the current behavior?

The example code for setting up environment variables using a `.env` file misleading suggests that each line in the `.env` file should end in a semicolon. In the example, the `DATABASE_USER` environment variable will end up with the value `"test;"`, not `"test"`. Presumably the latter is what's actually intended.

Issue Number: N/A


## What is the new behavior?

The environment variables in the example `.env` file no longer end up with values that are strings ending in semicolons.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information