### PR TITLE
feat(A11Y): improve a11y on toc component

### DIFF
--- a/src/app/homepage/homepage.component.html
+++ b/src/app/homepage/homepage.component.html
@@ -12,8 +12,8 @@
   <app-menu [class.opened]="isSidebarOpened" perfectScrollbar></app-menu>
   <div class="container" [class.wide]="!isSidebarOpened">
     <div class="page-wrapper">
-      <router-outlet (activate)="onRouteActivate($event)"></router-outlet>
       <app-toc [contentReference]="contentRef"></app-toc>
+      <router-outlet (activate)="onRouteActivate($event)"></router-outlet>
     </div>
     <div class="sponsors-wrapper">
       <div class="sponsors-container">

--- a/src/app/shared/components/toc/toc.component.html
+++ b/src/app/shared/components/toc/toc.component.html
@@ -4,9 +4,10 @@
       *ngFor="let item of headings; trackBy: trackById; let index = index"
       [attr.id]="item.id"
       [class.current]="index === activeId"
-      (click)="navigateToAnchor(item.elementRef)"
-    >
-      {{ item.textContent }}
+      >
+      <a href="{{ currentURL() }}#{{ item.elementRef.id }}">
+        {{ item.textContent }}
+      </a>
     </li>
   </ul>
 </div>

--- a/src/app/shared/components/toc/toc.component.ts
+++ b/src/app/shared/components/toc/toc.component.ts
@@ -135,14 +135,8 @@ export class TocComponent implements OnInit, OnDestroy, OnChanges {
       pageWrapperHeight - tocWrapperHeight - this.scrollTopOffset;
   }
 
-  navigateToAnchor(elementRef: HTMLElement) {
-    if (elementRef) {
-      elementRef.scrollIntoView({
-        behavior: 'smooth',
-        block: 'start',
-      });
-      this.findCurrentHeading();
-    }
+  currentURL(): string {
+    return window.location.href.split('#')[0];
   }
 
   checkViewportBoundaries() {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -4,6 +4,10 @@
 @import './scss/variables.scss';
 @import './scss/utils.scss';
 
+:root {
+  scroll-behavior: smooth;
+}
+
 body {
   font-size: 16px;
   font-weight: 400;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently the toc component has two problems related with a11y (accessibility):
- Is not focusable
- Does not indicate where you are going to go (you can not the preview URL)

## What is the new behavior?
The new improvements are:
- The toc elements are focusable
- You can see where you are going to go (you can see the URL)
- When you select a title, the focus is transferred to the title to continue browsing
- The focus flow is changed
  - ![image](https://user-images.githubusercontent.com/7026066/58147542-a5903580-7c20-11e9-91aa-740575aa36a5.png)
  - Now you pass from the navbar (N° 2) to the toc component (N° 3), because has no sense to pass through all the article to go there.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->