### PR TITLE
docs(recipes/swagger) important notes about OAuth2 added

### DIFF
--- a/content/recipes/swagger.md
+++ b/content/recipes/swagger.md
@@ -315,7 +315,7 @@ async create(@Body() createCatDto: CreateCatDto) {
 }
 ```
 
-#### Authentication
+#### Authentication: Bearer
 
 You can enable the bearer authorization using `addBearerAuth()` method of the `DocumentBuilder` class. Then to restrict the chosen route or entire controller, use `@ApiBearerAuth()` decorator.
 
@@ -329,6 +329,28 @@ export class CatsController {}
 That's how the OpenAPI documentation should look like now:
 
 <figure><img src="/assets/swagger-auth.gif" /></figure>
+
+#### Authentication: OAuth2
+
+You can enable the OAuth2 authorization using `addOAuth2()` method of the `DocumentBuilder` class. Then to restrict the chosen route or entire controller, use `@ApiOAuth2Auth()` decorator.
+
+```typescript
+@ApiUseTags('cats')
+@ApiOAuth2Auth()
+@Controller('cats')
+export class CatsController {}
+```
+
+Important moment about Swagger UI bootstrapping in case of you serve it on non-root path.
+To make final redirect step from OAuth2 provider to Swagger UI workable you need to override default `oauth2RedirectUrl` parameter:
+
+```typescript
+SwaggerModule.setup(path, app, document, {
+  swaggerOptions: {
+    oauth2RedirectUrl: `${yourHostOrigin}/${path}/oauth2-redirect.html`
+  }
+});
+```
 
 #### File upload
 


### PR DESCRIPTION
Authorization chapter has been expanded with OAuth2 setup and one more important case I spent more 2 hours searching in different repos sources to solve it

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Other... Please describe:
```

## What is the current behavior?
No docs about setup OAuth2 using `@nestjs/swagger`

Issue Number: N/A

## What is the new behavior?
Authorization chapter has been expanded with OAuth2 setup and one more important case I spent more 2 hours searching in different repos sources to solve it

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```