### PR TITLE
docs(techniques): fix misunderstanding about "forbidNonWhitelisted"

### DIFF
--- a/content/techniques/validation.md
+++ b/content/techniques/validation.md
@@ -107,7 +107,7 @@ app.useGlobalPipes(
 );
 ```
 
-This setting will enable auto-stripping of non-whitelisted (without any decorator on top of them) properties. However, if you want to stop the request processing entirely, and return an error response to the user, use `forbidNonWhitelisted` instead.
+This setting will enable auto-stripping of non-whitelisted (without any decorator on top of them) properties. However, if you want to stop the request processing entirely, and return an error response to the user, use `forbidNonWhitelisted` in combination with `whitelist`.
 
 #### Auto payload transforming
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[X] Other... Please describe: Documentation
```

## Other information

From reading the docs I understood that you need to use `forbidNonWhitelisted` INSTEAD of `whitelist` but then the NestJS server does not stop processing the request. To stop processing the request `whitelist` must be enabled AND `forbidNonWhitelisted` must be enabled too.

**Example:**

```ts
app.useGlobalPipes(new ValidationPipe({
  forbidNonWhitelisted: true,
  transform: true,
  whitelist: true,
}));
```