### PR TITLE
bugfix(docs) adjust toc height

### DIFF
--- a/src/app/shared/components/toc/toc.component.scss
+++ b/src/app/shared/components/toc/toc.component.scss
@@ -8,7 +8,7 @@
   position: fixed;
   top: 90px;
   right: 20px;
-  max-height: 350px;
+  max-height: 600px;
 
   @media print {
     display: none;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Documentation

## Other information

@kamilmysliwiec Addresses #587 Sets max height for TOC section to 600px;