### PR TITLE
docs(graphql): fix typo and prose

### DIFF
--- a/content/graphql/guards-interceptors.md
+++ b/content/graphql/guards-interceptors.md
@@ -1,8 +1,8 @@
 ### Tooling
 
-In the GraphQL world, a lot of articles complain how to handle stuff like **authentication**, or **side-effects** of operations. Should we put it inside the business logic? Shall we use a higher-order function to enhance queries and mutations as well, for example, with an authorization logic? Or maybe use [schema directives](https://www.apollographql.com/docs/apollo-server/v2/features/directives.html). There is no single answer anyway.
+In the GraphQL world, a lot of articles contemplate how to handle stuff like **authentication**, or **side-effects** of operations. Should we put it inside the business logic? Shall we use a higher-order function to enhance queries and mutations as well, for example, with authorization logic? Or maybe use [schema directives](https://www.apollographql.com/docs/apollo-server/v2/features/directives.html). There is no single answer.
 
-Nest ecosystem is trying to help with this issue using existing features like [guards](/guards) and [interceptors](/interceptors). The idea behind them is to reduce redundancy and also, supply you with tooling that helps creating well-structured, readable, and consistent applications.
+Nest ecosystem is trying to help with this issue using existing features like [guards](/guards) and [interceptors](/interceptors). The idea behind them is to reduce redundancy and also, supply you with tooling that helps create well-structured, readable, and consistent applications.
 
 #### Overview
 
@@ -43,7 +43,7 @@ export class AuthGuard implements CanActivate {
 }
 ```
 
-`GqlExecutionContext` exposes corresponding methods for each argument, like `getArgs()`, `getContext()`, and so on. Now we can effortlessly pick up every argument specific for currently processed request.
+`GqlExecutionContext` exposes corresponding methods for each argument, like `getArgs()`, `getContext()`, and so on. Now we can effortlessly pick up every argument specific for the currently processed request.
 
 #### Exception filters
 
@@ -61,7 +61,7 @@ export class HttpExceptionFilter implements GqlExceptionFilter {
 
 > info **Hint** Both `GqlExceptionFilter` and `GqlArgumentsHost` are imported from the `@nestjs/graphql` package.
 
-However, you don't have an access to the native `response` object in this case (as in the HTTP app).
+However, you don't have access to the native `response` object in this case (as in the HTTP app).
 
 #### Custom decorators
 


### PR DESCRIPTION
This PR makes a few changes to the prose of this doc in order to sound more natural :)

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[X] Other... Please describe:
  [X] Docs
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information