### PR TITLE
the default value of NODE_ENV should be development

### DIFF
--- a/content/techniques/configuration.md
+++ b/content/techniques/configuration.md
@@ -65,7 +65,7 @@ import { ConfigService } from './config.service';
   providers: [
     {
       provide: ConfigService,
-      useValue: new ConfigService(`${process.env.NODE_ENV}.env`),
+      useValue: new ConfigService(`${process.env.NODE_ENV || 'development'}.env`),
     },
   ],
   exports: [ConfigService],


### PR DESCRIPTION
If we don't set NODE_ENV's value, it'll be undefined, then the service will try to read the `undefined.env` file which is supposed to be `development.env`, so its value needs to be `development` by default.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[X] Other... Please describe:
    [X] Docs
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information