### PR TITLE
docs(graphql/quick-start): Clarify use of generate-typings script

### DIFF
--- a/content/graphql/quick-start.md
+++ b/content/graphql/quick-start.md
@@ -111,7 +111,7 @@ GraphQLModule.forRoot({
 }),
 ```
 
-However, generating type definitions on each application start may not be necessary. Instead, we might prefer to have full control, produce typings only when a dedicated command has been executed. In this case, we can create our own script, let's say `generate-typings.ts`:
+However, generating type definitions on each application start may not be necessary. Instead, we might prefer to have full control, produce typings only when a dedicated command has been executed. In this case, we can create our own script, let's say `src/generate-typings.ts`:
 
 ```typescript
 import { GraphQLDefinitionsFactory } from '@nestjs/graphql';
@@ -125,10 +125,10 @@ definitionsFactory.generate({
 });
 ```
 
-Afterward, simply run your file:
+Afterward, simply run your file from your project's root directory:
 
 ```bash
-ts-node generate-typings
+ts-node src/generate-typings
 ```
 
 > info **Hint** You can also compile a script beforehand and use `node` executable instead.


### PR DESCRIPTION
This clarifies that the generate-typings.ts file needs to live within
the src subfolder of the project and is run from the project's root
directory.

Before, if the user created the file in the project's root folder, the
build output in the dist subfolder would be altered such that it
reflects the structure of the project root folder.
This in turn breaks the npm scripts, such as npm run start:dev, as it
expects main.js to live in dist/ instead of dist/src, where it ends up
if the user creates the script file in the project root folder.

Signed-off-by: Felix Kaechele <fkaechel@cisco.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information