### PR TITLE
Update Joi example to current version (16.*) by fixing deprecated Joi…

### DIFF
--- a/content/pipes.md
+++ b/content/pipes.md
@@ -137,7 +137,7 @@ $ npm install --save @hapi/joi
 $ npm install --save-dev @types/hapi__joi
 ```
 
-In the code sample below, we create a simple class that takes a schema as a `constructor` argument. We then apply the `Joi.validate()` method, which validates our incoming argument against the provided schema.
+In the code sample below, we create a simple class that takes a schema as a `constructor` argument. We then apply the `schema.validate()` method, which validates our incoming argument against the provided schema.
 
 As noted earlier, a **validation pipe** either returns the value unchanged, or throws an exception.
 
@@ -146,7 +146,6 @@ In the next section, you'll see how we supply the appropriate schema for a given
 
 ```typescript
 @@filename()
-import * as Joi from '@hapi/joi';
 import { PipeTransform, Injectable, ArgumentMetadata, BadRequestException } from '@nestjs/common';
 
 @Injectable()
@@ -154,7 +153,7 @@ export class JoiValidationPipe implements PipeTransform {
   constructor(private readonly schema: Object) {}
 
   transform(value: any, metadata: ArgumentMetadata) {
-    const { error } = Joi.validate(value, this.schema);
+    const { error } = this.schema.validate(value);
     if (error) {
       throw new BadRequestException('Validation failed');
     }
@@ -162,7 +161,6 @@ export class JoiValidationPipe implements PipeTransform {
   }
 }
 @@switch
-import * as Joi from '@hapi/joi';
 import { Injectable, BadRequestException } from '@nestjs/common';
 
 @Injectable()
@@ -172,7 +170,7 @@ export class JoiValidationPipe {
   }
 
   transform(value, metadata) {
-    const { error } = Joi.validate(value, this.schema);
+    const { error } = this.schema.validate(value);
     if (error) {
       throw new BadRequestException('Validation failed');
     }


### PR DESCRIPTION
….validate usage

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Docs show example which is using deprecated `Joi.validate()` as per https://github.com/hapijs/joi/issues/1941


## What is the new behavior?
Docs show example with current way of usage which is calling `validate()` directly on schema.

