### PR TITLE
docs(introduction) add default URL for the local server

### DIFF
--- a/content/introduction.md
+++ b/content/introduction.md
@@ -32,6 +32,8 @@ $ npm install
 $ npm run start
 ```
 
+Open your browser and navigate to `http://localhost:3000/`.
+
 To install the JavaScript flavor of the starter project, use `javascript-starter.git` in the command sequence above.
 
 You can also manually create a new project from scratch by installing the core and supporting files with **npm** (or **yarn**). In this case, of course, you'll be responsible for creating the project boilerplate files yourself.


### PR DESCRIPTION
docs(introduction): add default URL for the local server

The documentation does not include what URL to use for the default development server. This information is also not part of the startup output. I had to look in the source code to figure out what port the server is using by default.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] Other... Please describe:
```

## What is the current behavior?

The introduction does not include the URL for the local development server.

Issue Number: N/A

## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information