### PR TITLE
Update crud.md to update the documentation.

### DIFF
--- a/content/recipes/crud.md
+++ b/content/recipes/crud.md
@@ -155,15 +155,17 @@ Another feature that is worth mentioning is "relations". In your CRUD controller
   model: {
     type: Hero,
   },
-  join: {
-    profile: {
-      exclude: ['secret'],
-    },
-    faction: {
-      eager: true,
-      only: ['name'],
-    },
-  },
+  query: {
+    join: {
+      profile: {
+        exclude: ['secret'],
+      },
+      faction: {
+        eager: true,
+        only: ['name'],
+      },
+    }
+  }  
 })
 @Controller('heroes')
 export class HeroesController {


### PR DESCRIPTION
The 'join' key no longer exists in 'CrudOptions', it must be inside of 'query'.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] Other... Please describe:
The documentation was outdated.
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
There was an error in typescript: Object literal may only specify known properties, and 'join' does not exist in type 'CrudOptions'

Issue Number: N/A


## What is the new behavior?
Using 'join' inside 'query' solves the problem. 

## Does this PR introduce a breaking change?
```
[ ] Yes
[ X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information