### PR TITLE
Add mongoose typings to installation instructions

### DIFF
--- a/content/techniques/mongo.md
+++ b/content/techniques/mongo.md
@@ -5,7 +5,7 @@ Nest supports two methods for integrating with the [MongoDB](https://www.mongodb
 Start by installing the required dependencies:
 
 ```bash
-$ npm install --save @nestjs/mongoose mongoose
+$ npm install --save @nestjs/mongoose mongoose @types/mongoose
 ```
 
 Once the installation process is complete, we can import the `MongooseModule` into the root `AppModule`.


### PR DESCRIPTION
Closes https://github.com/nestjs/docs.nestjs.com/issues/577

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] Other... Please describe: documentation correction
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: 577

MongoDB instructions do not include `@types/mongoose` with the `npm install`. Some users have reported issues with that, as swaps certain types for `any` (see issue).

## What is the new behavior?

Installation instructions now include `@types/mongoose` among the other dependencies.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->