### PR TITLE
fix(hot-reload): fix wrong links from localhost to docs.nestjs.com

### DIFF
--- a/content/techniques/hot-reload.md
+++ b/content/techniques/hot-reload.md
@@ -6,7 +6,7 @@ The highest impact on your application's bootstrapping process has a **TypeScrip
 
 ### With CLI
 
-If you are using the [Nest CLI](http://localhost:4200/cli/overview), the configuration process is pretty straightforward. The CLI wraps `webpack`, which allows use the `HotModuleReplacementPlugin`.
+If you are using the [Nest CLI](https://docs.nestjs.com/cli/overview), the configuration process is pretty straightforward. The CLI wraps `webpack`, which allows use the `HotModuleReplacementPlugin`.
 
 #### Installation
 
@@ -81,7 +81,7 @@ $ npm run start
 
 ### Without CLI
 
-If you are not using the [Nest CLI](http://localhost:4200/cli/overview), the configuration will be slightly more complex (will require more manual steps).
+If you are not using the [Nest CLI](https://docs.nestjs.com/cli/overview), the configuration will be slightly more complex (will require more manual steps).
 
 #### Installation
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] Other... Please describe: update documentation
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
There are two wrong links lead to `localhost:4200` instead of `docs.nestjs.com` in the `content/techniques/hot-reload.md` file.

Issue Number: #814 

## What is the new behavior?
The Links lead to correct page

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->