### PR TITLE
doc() No Schema without at least one query

### DIFF
--- a/content/graphql/quick-start.md
+++ b/content/graphql/quick-start.md
@@ -166,7 +166,7 @@ GraphQLModule.forRoot({
 
 The `autoSchemaFile` indicates a path where your automatically generated schema will be created. Additionally, you can pass the `buildSchemaOptions` property - an options object which will be passed in to the `buildSchema()` function (from the `type-graphql` package).
 
-Please keep in mind that you have to create a query to start generating a schema, a mutation or subscription will not work.
+> info **Hint** A query must be created before schema generation takes place. A mutation or subscription will otherwise not work as expected.
 
 A fully working sample is available [here](https://github.com/nestjs/nest/tree/master/sample/23-type-graphql).
 

--- a/content/graphql/quick-start.md
+++ b/content/graphql/quick-start.md
@@ -166,6 +166,8 @@ GraphQLModule.forRoot({
 
 The `autoSchemaFile` indicates a path where your automatically generated schema will be created. Additionally, you can pass the `buildSchemaOptions` property - an options object which will be passed in to the `buildSchema()` function (from the `type-graphql` package).
 
+Please keep in mind that you have to create a query to start generating a schema, a mutation or subscription will not work.
+
 A fully working sample is available [here](https://github.com/nestjs/nest/tree/master/sample/23-type-graphql).
 
 #### Async configuration


### PR DESCRIPTION
Inform the user that it is impossible to start generating a schema without at least one query, in case they want to start with a mutation. It's actually a very plausible thing to want to start with a mutation, a login for exemple, so this is useful to know in the getting started.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] Other... Please describe: Documentation
```

## What is the current behavior?
While following getting started, it feels weird that you are not able to generate a schema without a query if the doc doesn't say so

Issue Number: N/A


## What is the new behavior?
The documentation now says so

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
