### PR TITLE
ApplicationModule changed to AppModule

### DIFF
--- a/content/microservices/basics.md
+++ b/content/microservices/basics.md
@@ -24,10 +24,10 @@ To instantiate a microservice, use the `createMicroservice()` method of the `Nes
 @@filename(main)
 import { NestFactory } from '@nestjs/core';
 import { Transport } from '@nestjs/microservices';
-import { ApplicationModule } from './app.module';
+import { AppModule } from './app.module';
 
 async function bootstrap() {
-  const app = await NestFactory.createMicroservice(ApplicationModule, {
+  const app = await NestFactory.createMicroservice(AppModule, {
     transport: Transport.TCP,
   });
   app.listen(() => console.log('Microservice is listening'));


### PR DESCRIPTION
## PR Type
Other - documentation update

What kind of change does this PR introduce?
Update code example in docs, ApplicationModule fails, Nest CLI uses AppModule (which seems to be the correct import)
