### PR TITLE
Removed trailing project text.

### DIFF
--- a/content/introduction.md
+++ b/content/introduction.md
@@ -26,7 +26,7 @@ $ nest new project-name
 Alternatively, to install the TypeScript starter project with **Git**:
 
 ```bash
-$ git clone https://github.com/nestjs/typescript-starter.git project
+$ git clone https://github.com/nestjs/typescript-starter.git
 $ cd project
 $ npm install
 $ npm run start


### PR DESCRIPTION
There was text after the github repository link that shouldn't be there,
```
$ git clone https://github.com/nestjs/typescript-starter.git **project**
```

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Other... Please describe:
```

## What is the current behavior?
There is a trailing "project" after the Github repository link.
$ git clone https://github.com/nestjs/typescript-starter.git <font style="red">project</font>

Issue Number: 870


## What is the new behavior?
I have removed the trailing project to get the below result:
$ git clone https://github.com/nestjs/typescript-starter.git

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information