### PR TITLE
Specify warning for using a glob path in typeorm entities

### DIFF
--- a/content/techniques/sql.md
+++ b/content/techniques/sql.md
@@ -55,7 +55,7 @@ The `forRoot()` method accepts the same configuration object as `createConnectio
 }
 ```
 
-> warning **Warning** Static glob paths (e.g. `dist/**/*.entity{{ '{' }} .ts,.js{{ '}' }}`) won't work properly with [webpack](https://webpack.js.org/).
+> warning **Warning** Static glob paths (e.g. `dist/**/*.entity{{ '{' }} .ts,.js{{ '}' }}`) won't work properly with [webpack hot reloading](https://docs.nestjs.com/techniques/hot-reload).
 
 Then, we can call `forRoot()` without any options:
 


### PR DESCRIPTION
It isn't clear why using a glob path won't work properly with webpack. Adding text to specify that it is hot reloading what won't work and changing the link to a nestjs doc page.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

Documentation
