### PR TITLE
docs(interceptors):  Update interceptors.md, extend timeout interceptor

### DIFF
--- a/content/interceptors.md
+++ b/content/interceptors.md
@@ -331,7 +331,7 @@ import { Observable, throwError, TimeoutError } from 'rxjs';
 import { catchError, timeout } from 'rxjs/operators';
 
 @Injectable()
-export class TimeoutInterceptor implements NestInterceptor {
+export class TimeoutInterceptor {
   intercept(context, next) {
     return next.handle().pipe(
       timeout(5000),


### PR DESCRIPTION
Add customizable logic to timeout interceptor.
 Now, just before timeout is thrown, additional actions (like releasing resources) can be taken.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] Other... Please describe: Documentation
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?

Extend sample timeout interceptor. Now can easily add additional logic before throwing `ReqestTimeoutException`.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information