### PR TITLE
docs(common): remove return await syntax

### DIFF
--- a/content/graphql/guards-interceptors.md
+++ b/content/graphql/guards-interceptors.md
@@ -12,7 +12,7 @@ You can use either [guards](/guards), [interceptors](/interceptors), [filters](/
 @Query('author')
 @UseGuards(AuthGuard)
 async getAuthor(@Args('id', ParseIntPipe) id: number) {
-  return await this.authorsService.findOneById(id);
+  return this.authorsService.findOneById(id);
 }
 ```
 
@@ -22,7 +22,7 @@ As you can see, GraphQL works pretty well with both guards and pipes. Thanks to 
 @Mutation()
 @UseInterceptors(EventsInterceptor)
 async upvotePost(@Args('postId') postId: number) {
-  return await this.postsService.upvoteById({ id: postId });
+  return this.postsService.upvoteById({ id: postId });
 }
 ```
 

--- a/content/graphql/mutations.md
+++ b/content/graphql/mutations.md
@@ -16,17 +16,17 @@ export class AuthorResolver {
 
   @Query('author')
   async getAuthor(@Args('id') id: number) {
-    return await this.authorsService.findOneById(id);
+    return this.authorsService.findOneById(id);
   }
 
   @Mutation()
   async upvotePost(@Args('postId') postId: number) {
-    return await this.postsService.upvoteById({ id: postId });
+    return this.postsService.upvoteById({ id: postId });
   }
 
   @ResolveProperty('posts')
   async getPosts(@Parent() { id }) {
-    return await this.postsService.findAll({ authorId: id });
+    return this.postsService.findAll({ authorId: id });
   }
 }
 ```
@@ -76,18 +76,18 @@ export class AuthorResolver {
 
   @Query(returns => Author, { name: 'author' })
   async getAuthor(@Args({ name: 'id', type: () => Int }) id: number) {
-    return await this.authorsService.findOneById(id);
+    return this.authorsService.findOneById(id);
   }
 
   @Mutation(returns => Post)
   async upvotePost(@Args({ name: 'postId', type: () => Int }) postId: number) {
-    return await this.postsService.upvoteById({ id: postId });
+    return this.postsService.upvoteById({ id: postId });
   }
 
   @ResolveProperty('posts')
   async getPosts(@Parent() author) {
     const { id } = author;
-    return await this.postsService.findAll({ authorId: id });
+    return this.postsService.findAll({ authorId: id });
   }
 }
 ```

--- a/content/graphql/resolvers-map.md
+++ b/content/graphql/resolvers-map.md
@@ -37,13 +37,13 @@ export class AuthorResolver {
 
   @Query()
   async author(@Args('id') id: number) {
-    return await this.authorsService.findOneById(id);
+    return this.authorsService.findOneById(id);
   }
 
   @ResolveProperty()
   async posts(@Parent() author) {
     const { id } = author;
-    return await this.postsService.findAll({ authorId: id });
+    return this.postsService.findAll({ authorId: id });
   }
 }
 ```
@@ -57,7 +57,7 @@ The `@Resolver()` decorator does not affect queries and mutations (neither `@Que
 @ResolveProperty()
 async posts(@Parent() author) {
   const { id } = author;
-  return await this.postsService.findAll({ authorId: id });
+  return this.postsService.findAll({ authorId: id });
 }
 ```
 
@@ -75,13 +75,13 @@ export class AuthorResolver {
 
   @Query('author')
   async getAuthor(@Args('id') id: number) {
-    return await this.authorsService.findOneById(id);
+    return this.authorsService.findOneById(id);
   }
 
   @ResolveProperty('posts')
   async getPosts(@Parent() author) {
     const { id } = author;
-    return await this.postsService.findAll({ authorId: id });
+    return this.postsService.findAll({ authorId: id });
   }
 }
 ```
@@ -192,13 +192,13 @@ export class AuthorResolver {
 
   @Query(returns => Author)
   async author(@Args({ name: 'id', type: () => Int }) id: number) {
-    return await this.authorsService.findOneById(id);
+    return this.authorsService.findOneById(id);
   }
 
   @ResolveProperty()
   async posts(@Parent() author) {
     const { id } = author;
-    return await this.postsService.findAll({ authorId: id });
+    return this.postsService.findAll({ authorId: id });
   }
 }
 ```
@@ -215,13 +215,13 @@ export class AuthorResolver {
 
   @Query(returns => Author, { name: 'author' })
   async getAuthor(@Args({ name: 'id', type: () => Int }) id: number) {
-    return await this.authorsService.findOneById(id);
+    return this.authorsService.findOneById(id);
   }
 
   @ResolveProperty('posts')
   async getPosts(@Parent() author) {
     const { id } = author;
-    return await this.postsService.findAll({ authorId: id });
+    return this.postsService.findAll({ authorId: id });
   }
 }
 ```

--- a/content/graphql/subscriptions.md
+++ b/content/graphql/subscriptions.md
@@ -28,13 +28,13 @@ export class AuthorResolver {
 
   @Query('author')
   async getAuthor(@Args('id') id: number) {
-    return await this.authorsService.findOneById(id);
+    return this.authorsService.findOneById(id);
   }
 
   @ResolveProperty('posts')
   async getPosts(@Parent() author) {
     const { id } = author;
-    return await this.postsService.findAll({ authorId: id });
+    return this.postsService.findAll({ authorId: id });
   }
 
   @Subscription()
@@ -145,13 +145,13 @@ export class AuthorResolver {
 
   @Query(returns => Author, { name: 'author' })
   async getAuthor(@Args({ name: 'id', type: () => Int }) id: number) {
-    return await this.authorsService.findOneById(id);
+    return this.authorsService.findOneById(id);
   }
 
   @ResolveProperty('posts')
   async getPosts(@Parent() author) {
     const { id } = author;
-    return await this.postsService.findAll({ authorId: id });
+    return this.postsService.findAll({ authorId: id });
   }
 
   @Subscription(returns => Comment)

--- a/content/guards.md
+++ b/content/guards.md
@@ -35,7 +35,7 @@ import { Injectable } from '@nestjs/common';
 export class AuthGuard {
   async canActivate(context) {
     const request = context.switchToHttp().getRequest();
-    return await validateRequest(request);
+    return validateRequest(request);
   }
 }
 ```

--- a/content/pipes.md
+++ b/content/pipes.md
@@ -385,13 +385,13 @@ We can simply tie this pipe to the selected param as shown below:
 @@filename()
 @Get(':id')
 async findOne(@Param('id', new ParseIntPipe()) id) {
-  return await this.catsService.findOne(id);
+  return this.catsService.findOne(id);
 }
 @@switch
 @Get(':id')
 @Bind(Param('id', new ParseIntPipe()))
 async findOne(id) {
-  return await this.catsService.findOne(id);
+  return this.catsService.findOne(id);
 }
 ```
 
@@ -401,13 +401,13 @@ If you prefer you can use the `ParseUUIDPipe` which is responsible for parsing a
 @@filename()
 @Get(':id')
 async findOne(@Param('id', new ParseUUIDPipe()) id) {
-  return await this.catsService.findOne(id);
+  return this.catsService.findOne(id);
 }
 @@switch
 @Get(':id')
 @Bind(Param('id', new ParseUUIDPipe()))
 async findOne(id) {
-  return await this.catsService.findOne(id);
+  return this.catsService.findOne(id);
 }
 ```
 

--- a/content/recipes/mongodb.md
+++ b/content/recipes/mongodb.md
@@ -121,11 +121,11 @@ export class CatsService {
 
   async create(createCatDto: CreateCatDto): Promise<Cat> {
     const createdCat = new this.catModel(createCatDto);
-    return await createdCat.save();
+    return createdCat.save();
   }
 
   async findAll(): Promise<Cat[]> {
-    return await this.catModel.find().exec();
+    return this.catModel.find().exec();
   }
 }
 @@switch
@@ -140,11 +140,11 @@ export class CatsService {
 
   async create(createCatDto) {
     const createdCat = new this.catModel(createCatDto);
-    return await createdCat.save();
+    return createdCat.save();
   }
 
   async findAll() {
-    return await this.catModel.find().exec();
+    return this.catModel.find().exec();
   }
 }
 ```

--- a/content/recipes/prisma.md
+++ b/content/recipes/prisma.md
@@ -144,7 +144,7 @@ export class UsersResolver {
 
   @Query('users')
   async getUsers(@Args() args, @Info() info): Promise<User[]> {
-    return await this.prisma.query.users(args, info);
+    return this.prisma.query.users(args, info);
   }
 }
 ```

--- a/content/recipes/sql-sequelize.md
+++ b/content/recipes/sql-sequelize.md
@@ -110,7 +110,7 @@ export class CatsService {
     @Inject('CATS_REPOSITORY') private readonly catsRepository: typeof Cat) {}
 
   async findAll(): Promise<Cat[]> {
-    return await this.catsRepository.findAll<Cat>();
+    return this.catsRepository.findAll<Cat>();
   }
 }
 ```

--- a/content/recipes/sql-typeorm.md
+++ b/content/recipes/sql-typeorm.md
@@ -123,7 +123,7 @@ export class PhotoService {
   ) {}
 
   async findAll(): Promise<Photo[]> {
-    return await this.photoRepository.find();
+    return this.photoRepository.find();
   }
 }
 ```

--- a/content/techniques/mongo.md
+++ b/content/techniques/mongo.md
@@ -76,11 +76,11 @@ export class CatsService {
 
   async create(createCatDto: CreateCatDto): Promise<Cat> {
     const createdCat = new this.catModel(createCatDto);
-    return await createdCat.save();
+    return createdCat.save();
   }
 
   async findAll(): Promise<Cat[]> {
-    return await this.catModel.find().exec();
+    return this.catModel.find().exec();
   }
 }
 @@switch
@@ -97,11 +97,11 @@ export class CatsService {
 
   async create(createCatDto) {
     const createdCat = new this.catModel(createCatDto);
-    return await createdCat.save();
+    return createdCat.save();
   }
 
   async findAll() {
-    return await this.catModel.find().exec();
+    return this.catModel.find().exec();
   }
 }
 ```


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[x] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Other... Please describe:
```

## What is the current behavior?

Currently, there are 37 locations across 11 files in the docs that use `return await`, which is [considered a bad practice](https://eslint.org/docs/rules/no-return-await). 

## What is the new behavior?

No use of `return await` in the docs

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Search and replace was done by VSCode. 