### PR TITLE
fix: Markdown link render to work with hash

### DIFF
--- a/content/cli/workspaces.md
+++ b/content/cli/workspaces.md
@@ -98,7 +98,7 @@ A mono repo uses the concept of a workspace to manage its member entities. Works
 - an **application**: a full Nest application including a `main.ts` file to bootstrap the application. Aside from compile and build considerations, an application-type project within a workspace is functionally identical to an application within a _standard mode_ structure.
 - a **library**: a library is a way of packaging a general purpose set of features (modules, providers, controllers, etc.) that can be used within other projects. A library cannot run on its own, and has no `main.ts` file. Read more about libraries [here](/cli/libraries).
 
-All workspaces have a **default project** (which should be an application-type project). This is defined by the top-level `"root"` property in the `nest-cli.json` file, which points at the root of the default project (see <a href="/cli/monorepo#cli-properties">CLI properties</a> below for more details). Usually, this is the **standard mode** application you started with, and later converted to a monorepo using `nest generate app`. When you follow these steps, this property is populated automatically.
+All workspaces have a **default project** (which should be an application-type project). This is defined by the top-level `"root"` property in the `nest-cli.json` file, which points at the root of the default project (see [CLI properties](/cli/monorepo#cli-properties) below for more details). Usually, this is the **standard mode** application you started with, and later converted to a monorepo using `nest generate app`. When you follow these steps, this property is populated automatically.
 
 Default projects are used by `nest` commands like `nest build` and `nest start` when a project name is not supplied.
 

--- a/tools/transforms/content-package/services/renderer/link.renderer.ts
+++ b/tools/transforms/content-package/services/renderer/link.renderer.ts
@@ -5,12 +5,17 @@ export function applyLinkRenderer(renderer: Renderer) {
 
   const link = (href: string, title: string, text: string) => {
     if (!href.includes('http') && !href.includes('mailto')) {
-      return (originalLinkRenderer.call(
+      const link = (originalLinkRenderer.call(
         renderer,
         href,
         title,
         text
-      ) as string).replace('href', 'routerLink');
+      ) as string);
+
+      if (link.includes('#')) {
+        return link;
+      }
+      return link.replace('href', 'routerLink');
     }
 
     if (href.includes('http') && !href.includes('mailto')) {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Other... Please describe:
```

## What is the current behavior?
If the developer uses `[Link](/my-link#test)` it would get compiled into `<a routerLink="/my-link%23test">Link</a>` (`routerLink` does not work with hashes).

Issue Number: N/A


## What is the new behavior?
Links with hashes will get compiled `<a href="/my-link#test">Link</a>`

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
This PR was an attempt to remove all the "dangling links" Dgeni warnings. Unfortunately, these warnings seem to occur because of the "redirectTo" inside the Angular Router. Dgeni does not know that these URLs exist. This  can be fixed after #549, therefore I did not pursue this further.