### PR TITLE
docs(performance): consistent variable naming for app module

### DIFF
--- a/content/techniques/performance.md
+++ b/content/techniques/performance.md
@@ -43,7 +43,7 @@ By default, Fastify listens only on the `localhost 127.0.0.1` interface ([read m
 ```typescript
 async function bootstrap() {
   const app = await NestFactory.create<NestFastifyApplication>(
-    ApplicationModule,
+    AppModule,
     new FastifyAdapter()
   );
   await app.listen(3000, '0.0.0.0');


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The adapter portion of the documentation refers to the `AppModule` as both `AppModule` and `ApplicationModule`.

Issue Number: N/A


## What is the new behavior?
Both examples use a consistent variable name - `AppModule`

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```