### PR TITLE
improvement(docs): another argument name

### DIFF
--- a/content/graphql/resolvers-map.md
+++ b/content/graphql/resolvers-map.md
@@ -237,7 +237,7 @@ However, the `number` type doesn't give `type-graphql` enough information about 
 Moreover, you can create a dedicated `AuthorArgs` class:
 
 ```typescript
-@Args() id: AuthorArgs
+@Args() args: AuthorArgs
 ```
 
 With the following body:


### PR DESCRIPTION
It looks a little strange that the argument is called `id`, although in fact it is a class that contains different properties, one of which is `id`.