### PR TITLE
docs(mongo): mention need for extending Cat interface

### DIFF
--- a/content/techniques/mongo.md
+++ b/content/techniques/mongo.md
@@ -58,7 +58,7 @@ import { CatSchema } from './schemas/cat.schema';
 export class CatsModule {}
 ```
 
-The `MongooseModule` provides the `forFeature()` method to configure the module, including defining which models should be registered in the current scope. If you also want to use the models in another module, add MongooseModule to the `exports` section of `CatsModule` and import `CatsModule` in the other module.
+The `MongooseModule` provides the `forFeature()` method to configure the module, including defining which models should be registered in the current scope. If you also want to use the models in another module, add MongooseModule to the `exports` section of `CatsModule` and import `CatsModule` in the other module.  
 
 Once you've registered the schema, you can inject a `Cat` model into the `CatsService` using the `@InjectModel()` decorator:
 
@@ -105,6 +105,19 @@ export class CatsService {
   }
 }
 ```
+
+Also, don't forget to `extend` your `Cat` interface declaration from mongoose `Document`:
+
+```typescript
+import { Document } from 'mongoose';
+
+export interface Cat extends Document {
+  readonly name: string;
+  readonly age: number;
+  readonly breed: string;
+}
+```
+
 
 #### Connection
 


### PR DESCRIPTION
The following line will create not very user friendly compilation errors because of the incorrect Cat interface declaration:
```
constructor(@InjectModel('Cat') private readonly catModel: Model<Cat>) {}
```
The `Cats` example is used almost everywhere through the documentation, but it's not stated anywhere in the docs that you have to `extend` the interface from the mongoose `Document`. Surely, it can be easily fixed by looking at the official example, but that step is not quite straightforward, and, in my opinion, should be mentioned explicitly.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information