### PR TITLE
docs(swagger): add api extension to swagger docs

### DIFF
--- a/content/recipes/swagger.md
+++ b/content/recipes/swagger.md
@@ -546,6 +546,14 @@ class FileUploadDto {
 }
 ```
 
+#### Extensions
+
+To add an Extension to a request use the `@ApiExtension()` decorator. The extension name must be prefixed with `x-`.
+
+```typescript
+@ApiExtension('x-foo', { hello: 'world' })
+```
+
 #### Decorators
 
 All of the available OpenAPI decorators have an `Api` prefix to distinguish them from the core decorators. Below is a full list of the exported decorators along with a designation of the level at which the decorator may be applied.
@@ -570,6 +578,7 @@ All of the available OpenAPI decorators have an `Api` prefix to distinguish them
 | `@ApiProperty()`         | Model               |
 | `@ApiPropertyOptional()` | Model               |
 | `@ApiHideProperty()`     | Model               |
+| `@ApiExtension()`        | Method              |
 
 #### Plugin
 


### PR DESCRIPTION
This commit adds documentation for Open API Extensions via the `@ApiExtension` decorator as per 
[https://github.com/nestjs/swagger/pull/536](https://github.com/nestjs/swagger/pull/536).

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Adds docs for: [https://github.com/nestjs/swagger/pull/536](https://github.com/nestjs/swagger/pull/536)


## What is the new behavior?
Adds docs for `@ApiExtension` decorator.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information