### PR TITLE
docs(microservices): add subscribe option to kafka docs

### DIFF
--- a/content/microservices/kafka.md
+++ b/content/microservices/kafka.md
@@ -72,6 +72,16 @@ The `options` property is specific to the chosen transporter. The <strong>Kafka<
       >)</td>
   </tr>
   <tr>
+    <td><code>subscribe</code></td>
+    <td>Subscribe configuration options (read more
+      <a
+        href="https://kafka.js.org/docs/consuming#frombeginning"
+        rel="nofollow"
+        target="blank"
+        >here</a
+      >)</td>
+  </tr>
+  <tr>
     <td><code>producer</code></td>
     <td>Producer configuration options (read more
       <a


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/nestjs/nest/issues/3739


## What is the new behavior?
KafkaOptions includes support for the [kafka.js subscribe fromBeginning option](https://kafka.js.org/docs/consuming#a-name-from-beginning-a-frombeginning).

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
See related PR: https://github.com/nestjs/nest/pull/4146