### PR TITLE
import fix for new version of socket.io-redis

### DIFF
--- a/content/websockets/adapter.md
+++ b/content/websockets/adapter.md
@@ -37,7 +37,7 @@ Once the package is installed, we can create a `RedisIoAdapter` class.
 
 ```typescript
 import { IoAdapter } from '@nestjs/platform-socket.io';
-import * as redisIoAdapter from 'socket.io-redis';
+import redisIoAdapter from 'socket.io-redis';
 
 const redisAdapter = redisIoAdapter({ host: 'localhost', port: 6379 });
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] Other... Please describe: Documentation
```

## What is the current behavior?
Trying to import socket.io-redis with 

```
import * as redisAdapter from 'socket.io-redis';
```

results in:

```
const redisAdapter = redisIoAdapter(REDIS_CONNECT_CONFIG);
                     ^
TypeError: redisIoAdapter is not a function
```

## What is the new behavior?

Changing it to 

```
import redisAdapter from 'socket.io-redis';
```

Works and the Nest server starts up correctly.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```