### PR TITLE
docs(): add polymorphic array swagger example

### DIFF
--- a/content/recipes/swagger.md
+++ b/content/recipes/swagger.md
@@ -339,6 +339,7 @@ pet: Cat | Dog;
 ```
 
 If you want to define a polymorphic array (i.e., an array whose members span multiple schemas), you should use a raw definition (see above) to define your type by hand.
+
 ```typescript
 type Pet = Cat | Dog;
 

--- a/content/recipes/swagger.md
+++ b/content/recipes/swagger.md
@@ -338,7 +338,7 @@ In order to combine schemas, you can use `oneOf`, `anyOf` or `allOf` keywords ([
 pet: Cat | Dog;
 ```
 
-If you want to define a polymorphic array (i.e. an array whose members span multiple schemas), you should use a raw definition (see above) to define your type by hand.
+If you want to define a polymorphic array (i.e., an array whose members span multiple schemas), you should use a raw definition (see above) to define your type by hand.
 ```typescript
 type Pet = Cat | Dog;
 

--- a/content/recipes/swagger.md
+++ b/content/recipes/swagger.md
@@ -350,7 +350,7 @@ type Pet = Cat | Dog;
       { $ref: getSchemaPath(Dog) },
     ],
   },
-});
+})
 pets: Pet[];
 ```
 

--- a/content/recipes/swagger.md
+++ b/content/recipes/swagger.md
@@ -338,6 +338,22 @@ In order to combine schemas, you can use `oneOf`, `anyOf` or `allOf` keywords ([
 pet: Cat | Dog;
 ```
 
+If you want to define a polymorphic array (i.e. an array whose members span multiple schemas), you should use a raw definition (see above) to define your type by hand.
+```typescript
+type Pet = Cat | Dog;
+
+@ApiProperty({
+  type: 'array',
+  items: {
+    oneOf: [
+      { $ref: getSchemaPath(Cat) },
+      { $ref: getSchemaPath(Dog) },
+    ],
+  },
+});
+pets: Pet[];
+```
+
 > info **Hint** `getSchemaPath()` function is imported from `@nestjs/swagger`.
 
 Both `Cat` and `Dog` must be defined as extra models using the `@ApiExtraModels()` decorator (at the class-level).


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[X] Other... Please describe: documentation addition
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
There currently is no specific example of how to use NestJS Swagger annotations to annotate an API property that is a polymorphic array (i.e. an array whose members may be of different types). 
Issue Number: N/A


## What is the new behavior?
I propose to add an example that shows how to use a raw schema definition to annotate a polymorphic array, specifying the possible types that it may include.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information