### PR TITLE
docs(security): rate-limiting behind load balancers

### DIFF
--- a/content/techniques/security.md
+++ b/content/techniques/security.md
@@ -82,4 +82,12 @@ app.use(
 );
 ```
 
+When there is a load balancer or reverse proxy between the server and the internet, Express may need to be configured to trust the headers set by the proxy in order to get the correct IP for the end user. To do so, first use the [Express Platform interface](https://docs.nestjs.com/first-steps#platform) when creating your `app` instance, then enable the [`trust proxy` setting](https://expressjs.com/en/guide/behind-proxies.html):
+
+ ```typescript
+const app = await NestFactory.create<NestExpressApplication>(AppModule);
+// see https://expressjs.com/en/guide/behind-proxies.html
+app.set('trust proxy', 1)
+```
+
 > info **Hint** If you use the `FastifyAdapter`, consider using [fastify-rate-limit](https://github.com/fastify/fastify-rate-limit) instead.

--- a/content/techniques/security.md
+++ b/content/techniques/security.md
@@ -82,7 +82,7 @@ app.use(
 );
 ```
 
-When there is a load balancer or reverse proxy between the server and the internet, Express may need to be configured to trust the headers set by the proxy in order to get the correct IP for the end user. To do so, first use the [Express Platform interface](https://docs.nestjs.com/first-steps#platform) when creating your `app` instance, then enable the [`trust proxy` setting](https://expressjs.com/en/guide/behind-proxies.html):
+When there is a load balancer or reverse proxy between the server and the internet, Express may need to be configured to trust the headers set by the proxy in order to get the correct IP for the end user. To do so, first use the `NestExpressApplication` platform [interface](https://docs.nestjs.com/first-steps#platform) when creating your `app` instance, then enable the [trust proxy](https://expressjs.com/en/guide/behind-proxies.html) setting:
 
  ```typescript
 const app = await NestFactory.create<NestExpressApplication>(AppModule);


### PR DESCRIPTION
Explain how to use express-rate-limit when behind a reverse proxy or load balancer.

Fixes https://github.com/nestjs/docs.nestjs.com/issues/1065
Fixes https://github.com/nfriedly/express-rate-limit/issues/176

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] Other... Please describe: docs
```

## What is the current behavior?
It may be unclear how to use the recommended rate-limiter when behind a proxy or load balancer.

Issue Number: #1065


## What is the new behavior?
The documentation explains the necessary configuration and provides a code sample

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information