### PR TITLE
docs(database): show app.service file to inject sequelize object

### DIFF
--- a/content/techniques/sql.md
+++ b/content/techniques/sql.md
@@ -735,7 +735,7 @@ The `forRoot()` method supports all the configuration properties exposed by the 
 Once this is done, the `Sequelize` object will be available to inject across the entire project (without needing to import any modules), for example:
 
 ```typescript
-@@filename(app.module)
+@@filename(app.service)
 import { Injectable } from '@nestjs/common';
 import { Sequelize } from 'sequelize-typescript';
 


### PR DESCRIPTION
- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] Other... Please describe: Database documentation updated.
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
It shows `app.module.ts` filename for the code snippet but code itself reflects `app.service.ts` file

Issue Number: N/A


## What is the new behavior?
I changed `app.module` filename as `app.service`

## Does this PR introduce a breaking change?
```
[ ] Yes
[x ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information