### PR TITLE
docs(cli): add preserveWatchOutput in cli section

### DIFF
--- a/content/cli/usages.md
+++ b/content/cli/usages.md
@@ -129,7 +129,7 @@ $ nest start <name> [options]
 | `--path [path]`         | Path to `tsconfig` file. <br/>Alias `-p`                                                                             |
 | `--config [path]`       | Path to `nest-cli` configuration file. <br/>Alias `-c`                                                               |
 | `--watch`               | Run in watch mode (live-reload) <br/>Alias `-w`                                                                      |
-| `--preserveWatchOutput` | Keep outdated console output in watch mode instead of clearing the screen.                                           |
+| `--preserveWatchOutput` | Keep outdated console output in watch mode instead of clearing the screen. (`tsc` watch mode only)                   |
 | `--watchAssets`         | Run in watch mode (live-reload), watching non-TS files (assets). See [Assets](cli/monorepo#assets) for more details. |
 | `--debug [hostport]`    | Run in debug mode (with --inspect flag) <br/>Alias `-d`                                                              |
 | `--webpack`             | Use webpack for compilation.                                                                                         |

--- a/content/cli/usages.md
+++ b/content/cli/usages.md
@@ -124,17 +124,18 @@ $ nest start <name> [options]
 
 ##### Options
 
-| Option               | Description                                                                                                          |
-| -------------------- | -------------------------------------------------------------------------------------------------------------------- |
-| `--path [path]`      | Path to `tsconfig` file. <br/>Alias `-p`                                                                             |
-| `--config [path]`    | Path to `nest-cli` configuration file. <br/>Alias `-c`                                                               |
-| `--watch`            | Run in watch mode (live-reload) <br/>Alias `-w`                                                                      |
-| `--watchAssets`      | Run in watch mode (live-reload), watching non-TS files (assets). See [Assets](cli/monorepo#assets) for more details. |
-| `--debug [hostport]` | Run in debug mode (with --inspect flag) <br/>Alias `-d`                                                              |
-| `--webpack`          | Use webpack for compilation.                                                                                         |
-| `--webpackPath`      | Path to webpack configuration.                                                                                       |
-| `--tsc`              | Force use `tsc` for compilation.                                                                                     |
-| `--exec [binary]`    | Binary to run (default: `node`). <br/>Alias `-e`                                                                     |
+| Option                  | Description                                                                                                          |
+| ----------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `--path [path]`         | Path to `tsconfig` file. <br/>Alias `-p`                                                                             |
+| `--config [path]`       | Path to `nest-cli` configuration file. <br/>Alias `-c`                                                               |
+| `--watch`               | Run in watch mode (live-reload) <br/>Alias `-w`                                                                      |
+| `--preserveWatchOutput` | Keep outdated console output in watch mode instead of clearing the screen.                                           |
+| `--watchAssets`         | Run in watch mode (live-reload), watching non-TS files (assets). See [Assets](cli/monorepo#assets) for more details. |
+| `--debug [hostport]`    | Run in debug mode (with --inspect flag) <br/>Alias `-d`                                                              |
+| `--webpack`             | Use webpack for compilation.                                                                                         |
+| `--webpackPath`         | Path to webpack configuration.                                                                                       |
+| `--tsc`                 | Force use `tsc` for compilation.                                                                                     |
+| `--exec [binary]`       | Binary to run (default: `node`). <br/>Alias `-e`                                                                     |
 
 #### nest add
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/nestjs/nest-cli/issues/587


## What is the new behavior?
Add `preserveWatchOutput` in CLI usage section. Description are getting from [typescript official docs](https://www.typescriptlang.org/docs/handbook/compiler-options.html)

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information