### PR TITLE
Incorrect types in Custom Decorator example

### DIFF
--- a/content/custom-decorators.md
+++ b/content/custom-decorators.md
@@ -68,9 +68,8 @@ In order to make your code more readable and transparent, you can create a `@Use
 import { createParamDecorator, ExecutionContext } from '@nestjs/common';
 
 export const User = createParamDecorator(
-  (data: unknown, ctx: ExecutionContext) => {
-    const request = ctx.switchToHttp().getRequest();
-    return request.user;
+  (data: never, { user }: Request) => {
+    return user;
   },
 );
 ```
@@ -112,20 +111,14 @@ Let's define a decorator that takes a property name as key, and returns the asso
 import { createParamDecorator, ExecutionContext } from '@nestjs/common';
 
 export const User = createParamDecorator(
-  (data: string, ctx: ExecutionContext) => {
-    const request = ctx.switchToHttp().getRequest();
-    const user = request.user;
-
+  (data: keyof Request['user'], { user }: Request) => {
     return data ? user && user[data] : user;
   },
 );
 @@switch
 import { createParamDecorator } from '@nestjs/common';
 
-export const User = createParamDecorator((data, ctx) => {
-  const request = ctx.switchToHttp().getRequest();
-  const user = request.user;
-
+export const User = createParamDecorator((data, { user }) => {
   return data ? user && user[data] : user;
 });
 ```


### PR DESCRIPTION
It may have something to do with my particular combination of guards though, but when I tried to use example from docs to get req.user, I got an `ctx.switchToHttp() is not a function` error. I took a look at the actual object in debugger and it appears to be `Request` (or `Express.Request`, in my case; if that's indeed the case by default I'll update the changes)

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ x ] Other... Please describe: Documentation
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[ x ] No
```