### PR TITLE
Update hot-reload.md to work with monorepo

### DIFF
--- a/content/recipes/hot-reload.md
+++ b/content/recipes/hot-reload.md
@@ -28,7 +28,7 @@ const StartServerPlugin = require('start-server-webpack-plugin');
 module.exports = function(options) {
   return {
     ...options,
-    entry: ['webpack/hot/poll?100', './src/main.ts'],
+    entry: ['webpack/hot/poll?100', options.entry],
     watch: true,
     externals: [
       nodeExternals({
@@ -39,7 +39,7 @@ module.exports = function(options) {
       ...options.plugins,
       new webpack.HotModuleReplacementPlugin(),
       new webpack.WatchIgnorePlugin([/\.js$/, /\.d\.ts$/]),
-      new StartServerPlugin({ name: 'main.js' }),
+      new StartServerPlugin({ name: options.output.filename }),
     ],
   };
 };

--- a/content/recipes/hot-reload.md
+++ b/content/recipes/hot-reload.md
@@ -69,7 +69,7 @@ bootstrap();
 To simplify the execution process, add a script to your `package.json` file.
 
 ```json
-"start:dev": "nest build --watch --webpack --webpackPath webpack-hmr.config.js"
+"start:dev": "nest build --webpack --webpackPath webpack-hmr.config.js"
 ```
 
 Now simply open your command line and run the following command:


### PR DESCRIPTION
In a monorepo with multiple apps the paths should not be hardcoded:

- `entry: ['webpack/hot/poll?100', './src/main.ts']` should be `entry: ['webpack/hot/poll?100', './apps/appname/src/main.ts']`
- `new StartServerPlugin({ name: 'main.js' })` should be `new StartServerPlugin({ name: 'apps/appname/main.js' })`

Depending on which app has been started.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[X] Other... Please describe: Updated documentation
```

## What is the current behavior?
Hardcoded paths

## What is the new behavior?
Dynamic paths

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```