### PR TITLE
Corrected command to generate new application

### DIFF
--- a/content/cli/usages.md
+++ b/content/cli/usages.md
@@ -55,7 +55,7 @@ $ nest g <schematic> <name> [options]
 
 | Name          | Alias | Description                                                                                         |
 | ------------- | ----- | --------------------------------------------------------------------------------------------------- |
-| `application` |       | Generate a new application within a monorepo (converting to monorepo if it's a standard structure). |
+| `app`         |       | Generate a new application within a monorepo (converting to monorepo if it's a standard structure). |
 | `library`     | `lib` | Generate a new library within a monorepo (converting to monorepo if it's a standard structure).     |
 | `class`       | `cl`  | Generate a new class.                                                                               |
 | `controller`  | `co`  | Generate a controller declaration.                                                                  |


### PR DESCRIPTION
Corrected command for generating an application within a monorepo. As stated [here](https://docs.nestjs.com/cli/monorepo) the correct one is `app` - while `application` seems to create a new nest-application with its own package.json

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[X] Other... Please describe: Updated documentation
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```