### PR TITLE
ServerMqtt uses `url` option only

### DIFF
--- a/content/microservices/mqtt.md
+++ b/content/microservices/mqtt.md
@@ -19,16 +19,14 @@ To use the MQTT transporter, pass the following options object to the `createMic
 const app = await NestFactory.createMicroservice<MicroserviceOptions>(ApplicationModule, {
   transport: Transport.MQTT,
   options: {
-    host: 'localhost',
-    port: 1883,
+    url: 'mqtt://localhost:1883',
   },
 });
 @@switch
 const app = await NestFactory.createMicroservice(ApplicationModule, {
   transport: Transport.MQTT,
   options: {
-    host: 'localhost',
-    port: 1883,
+    url: 'mqtt://localhost:1883',
   },
 });
 ```
@@ -53,8 +51,7 @@ One method for creating an instance is to use use the `ClientsModule`. To create
         name: 'MATH_SERVICE',
         transport: Transport.MQTT,
         options: {
-          host: 'localhost',
-          port: 1883,
+          url: 'mqtt://localhost:1883',
         }
       },
     ]),


### PR DESCRIPTION
Constructor in class [`ServerMqtt`](https://github.com/nestjs/nest/blob/107b243c8b7d00c428c4ab9740dad074ec4af89d/packages/microservices/server/server-mqtt.ts#L26) uses only `url` option. See also https://stackoverflow.com/a/57137251

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

Updated documentation

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Other... Please describe:
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```