### PR TITLE
Update graphql/mapped-types.md

### DIFF
--- a/content/graphql/mapped-types.md
+++ b/content/graphql/mapped-types.md
@@ -35,7 +35,7 @@ export class UpdateUserInput extends PartialType(CreateUserInput) {}
 
 > info **Hint** The `PartialType()` function is imported from the `@nestjs/graphql` package.
 
-The `PartialType()` function takes an optional second argument that is a reference to the decorator factory of the child class. In the example above, we are extending `CreateUserInput` which is annotated with the `@InputType()` decorator. We didn't need to pass `InputType` as the second argument since the child class is also annotated with `@InputType()`. If you want to extend a class decorated with `@ObjectType`, pass `InputType` as the second argument. For example:
+The `PartialType()` function takes an optional second argument that is a reference to a decorator factory.  This argument can be used to change the decorator function applied to the resulting (*child*) class.  If not specified, the child class effectively uses the same decorator as the *parent* class (the class referenced in the first argument).  In the example above, we are extending `CreateUserInput` which is annotated with the `@InputType()` decorator.  Since we want `UpdateUserInput` to also be treated as if it were decorated with `@InputType()`, we didn't need to pass `InputType` as the second argument. If the parent and child types are different, (e.g., the parent is decorated with `@ObjectType`), we would  pass `InputType` as the second argument. For example:
 
 ```typescript
 @InputType()

--- a/content/graphql/mapped-types.md
+++ b/content/graphql/mapped-types.md
@@ -35,11 +35,11 @@ export class UpdateUserInput extends PartialType(CreateUserInput) {}
 
 > info **Hint** The `PartialType()` function is imported from the `@nestjs/graphql` package.
 
-The `PartialType()` function takes an optional second argument that is a reference to the decorator factory of the type being extended. In the example above, we are extending `CreateUserInput` which is annotated with the `@InputType()` decorator. We didn't need to pass `InputType` as the second argument since it's the default value. If you want to extend a class decorated with `@ObjectType`, pass `ObjectType` as the second argument. For example:
+The `PartialType()` function takes an optional second argument that is a reference to the decorator factory of the child class. In the example above, we are extending `CreateUserInput` which is annotated with the `@InputType()` decorator. We didn't need to pass `InputType` as the second argument since the child class is also annotated with `@InputType()`. If you want to extend a class decorated with `@ObjectType`, pass `InputType` as the second argument. For example:
 
 ```typescript
 @InputType()
-export class UpdateUserInput extends PartialType(User, ObjectType) {}
+export class UpdateUserInput extends PartialType(User, InputType) {}
 ```
 
 #### Pick


### PR DESCRIPTION
The second argument to PickType/OmitType/PartialType should be the decorator factory of the derived class not the base class.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] Other... Please describe: Docs fix
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information