### PR TITLE
Mongo async config section uses "useString" method from configService

### DIFF
--- a/content/techniques/mongo.md
+++ b/content/techniques/mongo.md
@@ -205,7 +205,7 @@ Like other [factory providers](https://docs.nestjs.com/fundamentals/custom-provi
           const schema = CatsSchema;
           schema.pre('save', () =>
             console.log(
-              `${configService.getString('APP_NAME')}: Hello from pre save`,
+              `${configService.get<string>('APP_NAME')}: Hello from pre save`,
             ),
           );
           return schema;
@@ -303,7 +303,7 @@ Like other [factory providers](https://docs.nestjs.com/fundamentals/custom-provi
 MongooseModule.forRootAsync({
   imports: [ConfigModule],
   useFactory: async (configService: ConfigService) => ({
-    uri: configService.getString('MONGODB_URI'),
+    uri: configService.get<string>('MONGODB_URI'),
   }),
   inject: [ConfigService],
 });


### PR DESCRIPTION

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ X] Other... Please describe: Outdated documentation section.
```
I guess "useString" method existed before but it doesn't anymore. The async configuration section in mongo still uses it tough.
