### PR TITLE
docs(gRPC): fix typos with gRPC stream section

### DIFF
--- a/content/microservices/grpc.md
+++ b/content/microservices/grpc.md
@@ -330,8 +330,8 @@ syntax = "proto3";
 package hello;
 
 service HelloService {
-  rpc BidiHello(stream HelloRequest) returns (stream HelloResponse)
-  rpc LotsOfGreetings(stream HelloRequest) returns (HelloResponse)
+  rpc BidiHello(stream HelloRequest) returns (stream HelloResponse);
+  rpc LotsOfGreetings(stream HelloRequest) returns (HelloResponse);
 }
 
 message HelloRequest {
@@ -392,7 +392,7 @@ According to the service definition (in the `.proto` file), the `BidiHello` meth
 
 ```typescript
 const helloService = this.client.getService<HelloService>('HelloService');
-const helloRequest$ = new ReplySubject<HelloRequest>();
+const helloRequest$ = new ReplaySubject<HelloRequest>();
 
 helloRequest$.next({ greeting: 'Hello (1)!' });
 helloRequest$.next({ greeting: 'Hello (2)!' });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] Other... Please describe: Docs typo fix
```

## What is the current behavior?
- Invalid gRPC .proto file in within the streaming section (missing semicolons)
- Typo on RxJS ReplySubject -> ReplaySubject

Issue Number: N/A

## What is the new behavior?
- No typos

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information
N/A