### PR TITLE
docs(content): Async configuration port type fix

### DIFF
--- a/content/techniques/sql.md
+++ b/content/techniques/sql.md
@@ -617,7 +617,7 @@ TypeOrmModule.forRootAsync({
   useFactory: (configService: ConfigService) => ({
     type: 'mysql',
     host: configService.get<string>('HOST'),
-    port: configService.get<string>('PORT'),
+    port: configService.get<number>('PORT'),
     username: configService.get<string>('USERNAME'),
     password: configService.get<string>('PASSWORD'),
     database: configService.get<string>('DATABASE'),


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x ] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x ] Other... Please describe:
```

## What is the current behavior?
When using Type ORM Async configuration like shown [here](https://docs.nestjs.com/techniques/database#async-configuration), There is a TypeScript error because "port" needs to be of type `number` not `string`.

Issue Number: N/A


## What is the new behavior?
Port is now of type 'number' so no TypeScript Error

## Does this PR introduce a breaking change?
```
[ ] Yes
[ x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information