### PR TITLE
docs(content): fix e2e socket.io-redis tests for multiple app instances

### DIFF
--- a/content/websockets/adapter.md
+++ b/content/websockets/adapter.md
@@ -39,11 +39,11 @@ Once the package is installed, we can create a `RedisIoAdapter` class.
 import { IoAdapter } from '@nestjs/platform-socket.io';
 import redisIoAdapter from 'socket.io-redis';
 
-const redisAdapter = redisIoAdapter({ host: 'localhost', port: 6379 });
-
 export class RedisIoAdapter extends IoAdapter {
   createIOServer(port: number, options?: any): any {
     const server = super.createIOServer(port, options);
+    const redisAdapter = redisIoAdapter({ host: 'localhost', port: 6379 });
+    
     server.adapter(redisAdapter);
     return server;
   }


### PR DESCRIPTION
Fixes multiple app instances in e2e tests not connecting properly to socket.io-redis by reinitialising redisIOAdapter on createIOServer.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Other... Please describe:
```

## What is the current behavior?
E2E tests on mulitple app instances connected via socket.io-redis do not connect properly and cannot receive messages. This is due to the apps sharing the same `redisAdapter` instance as shown in the docs. 

## What is the new behavior?
E2E tests on mulitple app instances connected via socket.io-redis now create their own `redisAdapter` instance and can communicate correctly.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information
None.