### PR TITLE
Add a small note to the Transactions section

### DIFF
--- a/content/techniques/sql.md
+++ b/content/techniques/sql.md
@@ -364,7 +364,7 @@ A database transaction symbolizes a unit of work performed within a database man
 
 There are many different strategies to handle [TypeORM transactions](https://typeorm.io/#/transactions). We recommend using the `QueryRunner` class because it gives full control over the transaction.
 
-First, we need to inject the `Connection` object into a class in the normal way:
+First, we need to inject the `Connection` object into a class in the normal way (in custom repositories we need to inject `EntityManager`):
 
 ```typescript
 @Injectable()


### PR DESCRIPTION
To run a transaction we need to inject the `Connection` object into a service, but to keep the database-related code inside a (custom) repository we need to inject the `EntityManager`, since custom repositories are being instantiated by `typeorm` and not by `@nestjs/core` and therefore can't use the NestJS dependency injection.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: [#493 (at @nestjs/typeorm)](https://github.com/nestjs/typeorm/issues/493)


## What is the new behavior?
Mention that custom repositories need to use the `EntityManager` object-

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information