### PR TITLE
Update compression import style

### DIFF
--- a/content/techniques/compression.md
+++ b/content/techniques/compression.md
@@ -17,7 +17,7 @@ $ npm i --save compression
 Once the installation is complete, apply the compression middleware as global middleware.
 
 ```typescript
-import * as compression from 'compression';
+import compression from 'compression';
 // somewhere in your initialization file
 app.use(compression());
 ```


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[x] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

importing compression as `import * as compression from compression` results in the following error

```
src/main.ts:43:10 - error TS2349: This expression is not callable.
import * as compression from 'compression';
      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    Type originates at this import. A namespace-style import cannot be called or constructed, and will cause a failure at runtime. Consider using a default import or import require here instead.


Found 1 error.
```