### PR TITLE
docs(logger): adds back warning of custom logger

### DIFF
--- a/content/techniques/logger.md
+++ b/content/techniques/logger.md
@@ -135,6 +135,8 @@ Here we use the `get()` method on the `NestApplication` instance to retrieve the
 
 You can also inject this `MyLogger` provider in your feature classes, thus ensuring consistent logging behavior across both Nest system logging and application logging. See <a href="techniques/logger#using-the-logger-for-application-logging">Using the logger for application logging</a> below for more information.
 
+The only downside of this solution is that your first initialization messages won't be handled by your logger instance, though, it shouldn't really matter at this point.
+
 #### Using the logger for application logging
 
 We can combine several of the techniques above to provide consistent behavior and formatting across both Nest system logging and our own application event/message logging. In this section, we'll achieve this with the following steps:


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] Other... Please describe:
```

Adds back in a small portion of [this commit](https://github.com/nestjs/docs.nestjs.com/commit/a70b7a36b6d5571390fdb489370490709a31ad0c#diff-8af34d7d4d6dc9a3e6868c745bd543bf)
that warns when a custom logger is used and `logger: false` is set,
that Nest cannot use the custom logger for the instantiation of the
server.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently there is no warning of using a custom logger when it comes to instantiating the Nest server.

Issue Number: #1270 


## What is the new behavior?

There is now a warning about using a custom logger when instantiating the Nest server.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information