### PR TITLE
docs(cli): added pnpm to cli usages page

### DIFF
--- a/content/cli/usages.md
+++ b/content/cli/usages.md
@@ -31,7 +31,7 @@ Creates and initializes a new Nest project. Prompts for package manager.
 | `--dry-run`                           | Reports changes that would be made, but does not change the filesystem.<br/> Alias: `-d`                        |
 | `--skip-git`                          | Skip git repository initialization.<br/> Alias: `-g`                                                            |
 | `--skip-install`                      | Skip package installation.<br/> Alias: `-s`                                                                     |
-| `--package-manager [package-manager]` | Specify package manager. Use `npm` or `yarn`. Package manager must be installed globally.<br/> Alias: `-p`      |
+| `--package-manager [package-manager]` | Specify package manager. Use `npm`, `yarn`, or `pnpm`. Package manager must be installed globally.<br/> Alias: `-p`      |
 | `--language [language]`               | Specify programming language (`TS` or `JS`).<br/> Alias: `-l`                                                   |
 | `--collection [collectionName]`       | Specify schematics collection. Use package name of installed npm package containing schematic.<br/> Alias: `-c` |
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] Other... Please describe: documentation/feature
```

## What is the current behavior?
Docs only shows npm and yarn.

## What is the new behavior?
Docs will show pnpm as well.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Related to [https://github.com/nestjs/nest-cli/pull/788](https://github.com/nestjs/nest-cli/pull/788). Obviously, this should be accepted and released only once the related nest-cli PR is accepted and released.