### PR TITLE
docs(prisma) update deprecated methods

### DIFF
--- a/content/recipes/prisma.md
+++ b/content/recipes/prisma.md
@@ -263,11 +263,11 @@ import { PrismaClient } from '@prisma/client';
 export class PrismaService extends PrismaClient
   implements OnModuleInit, OnModuleDestroy {
   async onModuleInit() {
-    await this.connect();
+    await this.$connect();
   }
 
   async onModuleDestroy() {
-    await this.disconnect();
+    await this.$disconnect();
   }
 }
 ```


### PR DESCRIPTION
Since prisma client appended the connect() and disconnect() methods with a $, the current docs throw a deprecation warning.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Prisma Client throws deprecation warnings on the connect() and disconnect() methods
Issue Number: N/A


## What is the new behavior?
No deprecation warnings

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information