### PR TITLE
docs(microservices): fix anchor to queueOptions in rabbitmq docs

### DIFF
--- a/content/microservices/rabbitmq.md
+++ b/content/microservices/rabbitmq.md
@@ -68,7 +68,7 @@ The `options` property is specific to the chosen transporter. The <strong>Rabbit
   </tr>
   <tr>
     <td><code>queueOptions</code></td>
-    <td>Additional queue options (read more <a href="https://www.squaremobius.net/amqp.node/channel_api.html#assertQueue" rel="nofollow" target="_blank">here</a>)</td>
+    <td>Additional queue options (read more <a href="https://www.squaremobius.net/amqp.node/channel_api.html#channel_assertQueue" rel="nofollow" target="_blank">here</a>)</td>
   </tr>
   <tr>
     <td><code>socketOptions</code></td>


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
Commit fixes anchor in queueOptions of the rabbitmq microservice docs.
Link now points to the right anchor `#channel_assertQueue` instead of  `#assertQueue`.

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[X] Other: Docs
```

## What is the current behavior?
QueueOptions link only redirected to top of the page, not to a specific section.

## What is the new behavior?
QueueOptions link now redirects to the correct section, for better readability and reduced search effort.

## Does this PR introduce a breaking change?
```
[ ] Yes
[c] No
```
