### PR TITLE
fix(docs): Inline default apollo install

### DIFF
--- a/content/graphql/quick-start.md
+++ b/content/graphql/quick-start.md
@@ -9,10 +9,9 @@ In this chapter, we assume a basic understanding of GraphQL, and focus on how to
 Start by installing the required packages:
 
 ```bash
-$ npm i @nestjs/graphql graphql-tools graphql
+$ npm i @nestjs/graphql graphql-tools graphql apollo-server-express
 ```
-
-Depending on what underlying platform you use (Express or Fastify), you must also install either `apollo-server-express` or `apollo-server-fastify`.
+> info **Hint** If using Fastify, instead of installing `apollo-server-express`, you should install `apollo-server-fastify`.
 
 #### Overview
 


### PR DESCRIPTION
I totally missed the text below, I think this change makes the default experience better, since that's express and also makes the fastify option stand out.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] Other... Please describe: docs
```

## What is the current behavior?
Easy to miss the installation of apollo server in quick start.


## What is the new behavior?
The default experience installs the correct thing, and the experience for those using fastify is highlighted.

