### PR TITLE
Improve docs about using Logger

### DIFF
--- a/content/techniques/logger.md
+++ b/content/techniques/logger.md
@@ -189,8 +189,6 @@ import { Injectable, Scope, Logger } from '@nestjs/common';
 
 @Injectable({ scope: Scope.TRANSIENT })
 export class MyLogger extends Logger {
-  // Implement custom methods or extend default methods here,
-  // for example:
   customLog() {
     this.log('Please feed the cat!');
   }

--- a/content/techniques/logger.md
+++ b/content/techniques/logger.md
@@ -165,6 +165,7 @@ class MyService {
 ```
 
 In the default logger `context` is printed in the square brackets, like `NestFactory` in the example below:
+
 ```bash
 [Nest] 19096   - 12/08/2019, 7:12:59 AM   [NestFactory] Starting Nest application...
 ```

--- a/content/techniques/logger.md
+++ b/content/techniques/logger.md
@@ -169,11 +169,11 @@ In the default logger implementation, `context` is printed in the square bracket
 [Nest] 19096   - 12/08/2019, 7:12:59 AM   [NestFactory] Starting Nest application...
 ```
 
-If we supply a custom logger via `app.useLogger`, it will actually be used by Nest automatically.
-That means that our code remains implementation agnostic, while we can easily substitute the default logger for our custom one by calling `app.useLogger`.
-That way if we follow the steps from previous section and call `app.useLogger(app.get(MyLogger))`, the following calls to `this.logger.log` from `MyService` would result in calls to method `log` from `MyLogger` instance.
+If we supply a custom logger via `app.useLogger()`, it will actually be used by Nest internally. That means that our code remains implementation agnostic, while we can easily substitute the default logger for our custom one by calling `app.useLogger()`.
 
-This should be suitable for most cases. But if you need more customization for the Logger (like adding and calling custom methods), please follow to the next section. 
+That way if we follow the steps from the previous section and call `app.useLogger(app.get(MyLogger))`, the following calls to `this.logger.log()` from `MyService` would result in calls to method `log` from `MyLogger` instance.
+
+This should be suitable for most cases. But if you need more customization (like adding and calling custom methods), move to the next section. 
 
 #### Injecting a custom logger
 

--- a/content/techniques/logger.md
+++ b/content/techniques/logger.md
@@ -148,8 +148,7 @@ You can also inject this `MyLogger` provider in your feature classes, thus ensur
 
 We can combine several of the techniques above to provide consistent behavior and formatting across both Nest system logging and our own application event/message logging.
 
-The best practice is to instantiate `Logger` class from `@nestjs/common` in each of our services. 
-We can supply our service name as the `context` argument in the `Logger` constructor, like so:
+A good practice is to instantiate `Logger` class from `@nestjs/common` in each of our services. We can supply our service name as the `context` argument in the `Logger` constructor, like so:
 
 ```typescript
 import { Logger, Injectable } from '@nestjs/common';

--- a/content/techniques/logger.md
+++ b/content/techniques/logger.md
@@ -177,7 +177,6 @@ This should be suitable for most cases. But if you need more customization (like
 
 #### Injecting a custom logger
 
-
 To start, extend the built-in logger with code like the following. We supply the `scope` option as configuration metadata for the `Logger` class, specifying a [transient](/fundamentals/injection-scopes) scope, to ensure that we'll have a unique instance of the `MyLogger` in each feature module. In this example, we do not extend the individual `Logger` methods (like `log()`, `warn()`, etc.), though you may choose to do so.
 
 ```typescript

--- a/content/techniques/logger.md
+++ b/content/techniques/logger.md
@@ -155,7 +155,7 @@ import { Logger, Injectable } from '@nestjs/common';
 
 @Injectable()
 class MyService {
-  logger = new Logger(MyService.name);
+  private readonly logger = new Logger(MyService.name);
   
   doSomething() {
     this.logger.log('Doing something...');

--- a/content/techniques/logger.md
+++ b/content/techniques/logger.md
@@ -177,10 +177,6 @@ This should be suitable for most cases. But if you need more customization (like
 
 #### Injecting a custom logger
 
-Sometimes you may want to add custom methods to your logger class.
-In order to use these methods you'll have to inject a custom logger to your services.
-We can use a [transient](/fundamentals/injection-scopes) scope for the logger so that each one of our services has its own custom context.
-If we maintain the `LoggerService` interface in our custom logger, we can still set our logger globally with `app.useLogger`.
 
 To start, extend the built-in logger with code like the following. We supply the `scope` option as configuration metadata for the `Logger` class, specifying a [transient](/fundamentals/injection-scopes) scope, to ensure that we'll have a unique instance of the `MyLogger` in each feature module. In this example, we do not extend the individual `Logger` methods (like `log()`, `warn()`, etc.), though you may choose to do so.
 

--- a/content/techniques/logger.md
+++ b/content/techniques/logger.md
@@ -246,8 +246,7 @@ app.useLogger(new MyLogger());
 await app.listen(3000);
 ```
 
-Be mindful that if you supply `logger: false` to `NestFactory.create`, nothing will be logged until you call `useLogger`, so you may miss some important initialization errors.
-If you don't mind that some of your initial messages will be logged with the default logger, you can just omit the `logger: false` option.
+Be mindful that if you supply `logger: false` to `NestFactory.create`, nothing will be logged until you call `useLogger`, so you may miss some important initialization errors. If you don't mind that some of your initial messages will be logged with the default logger, you can just omit the `logger: false` option.
 
 #### Use external logger
 

--- a/content/techniques/logger.md
+++ b/content/techniques/logger.md
@@ -163,7 +163,7 @@ class MyService {
 }
 ```
 
-In the default logger `context` is printed in the square brackets, like `NestFactory` in the example below:
+In the default logger implementation, `context` is printed in the square brackets, like `NestFactory` in the example below:
 
 ```bash
 [Nest] 19096   - 12/08/2019, 7:12:59 AM   [NestFactory] Starting Nest application...

--- a/content/techniques/logger.md
+++ b/content/techniques/logger.md
@@ -105,7 +105,7 @@ You can tell Nest to use your extended logger for system logging by passing an i
 
 For more advanced logging functionality, you'll want to take advantage of dependency injection. For example, you may want to inject a `ConfigService` into your logger to customize it, and in turn inject your custom logger into other controllers and/or providers. To enable dependency injection for your custom logger, create a class that implements `LoggerService` and register that class as a provider in some module. For example, you can
 
-1. Define a `MyLogger` class that either extends the built-in `Logger` or completely overrides it, as shown in previous sections.
+1. Define a `MyLogger` class that either extends the built-in `Logger` or completely overrides it, as shown in previous sections. Be sure to implement the `LoggerService` interface.
 2. Create a `LoggerModule` as shown below, and provide `MyLogger` from that module.
 
 ```typescript
@@ -133,30 +133,68 @@ await app.listen(3000);
 
 Here we use the `get()` method on the `NestApplication` instance to retrieve the singleton instance of the `MyLogger` object. This technique is essentially a way to "inject" an instance of a logger for use by Nest. The `app.get()` call retrieves the singleton instance of `MyLogger`, and depends on that instance being first injected in another module, as described above.
 
-You can also inject this `MyLogger` provider in your feature classes, thus ensuring consistent logging behavior across both Nest system logging and application logging. See <a href="techniques/logger#using-the-logger-for-application-logging">Using the logger for application logging</a> below for more information.
+The only downside of this solution is that your first initialization messages won't be printed anywhere at all, so in rare cases you may miss some important initialization errors.
+Alternatively you can print first initialization messages using default logger, and then switch to your custom one:
 
-The only downside of this solution is that your first initialization messages won't be handled by your logger instance, though, it shouldn't really matter at this point.
+```typescript
+const app = await NestFactory.create(ApplicationModule);
+app.useLogger(app.get(MyLogger));
+await app.listen(3000);
+``` 
+
+You can also inject this `MyLogger` provider in your feature classes, thus ensuring consistent logging behavior across both Nest system logging and application logging. See <a href="techniques/logger#using-the-logger-for-application-logging">Using the logger for application logging</a> and <a href="techniques/logger#injecting-a-custom-logger">Injecting a custom logger</a> below for more information.
 
 #### Using the logger for application logging
 
-We can combine several of the techniques above to provide consistent behavior and formatting across both Nest system logging and our own application event/message logging. In this section, we'll achieve this with the following steps:
+We can combine several of the techniques above to provide consistent behavior and formatting across both Nest system logging and our own application event/message logging.
 
-1. We extend the built-in logger and customize the `context` portion of the log message (e.g., the phrase `NestFactory` in square brackets in the log line shown below).
+The best practice is to instantiate `Logger` class from `@nestjs/common` in each of our services. 
+We can supply our service name as the `context` argument in the `Logger` constructor, like so:
 
+```typescript
+import { Logger, Injectable } from '@nestjs/common';
+
+@Injectable()
+class MyService {
+  logger = new Logger(MyService.name);
+  
+  doSomething() {
+    this.logger.log('Doing something...');
+  }
+}
+```
+
+In the default logger `context` is printed in the square brackets, like `NestFactory` in the example below:
 ```bash
 [Nest] 19096   - 12/08/2019, 7:12:59 AM   [NestFactory] Starting Nest application...
 ```
 
-2. We inject a [transient](/fundamentals/injection-scopes) instance of the `Logger` into our feature modules so that each one has its own custom context.
-3. We supply this extended logger for Nest to use for system logging.
+If we supply a custom logger via `app.useLogger`, it will actually be used by Nest automatically.
+That means that our code remains implementation agnostic, while we can easily substitute the default logger for our custom one by calling `app.useLogger`.
+That way if we follow the steps from previous section and call `app.useLogger(app.get(MyLogger))`, the following calls to `this.logger.log` from `MyService` would result in calls to method `log` from `MyLogger` instance.
 
-To start, extend the built-in logger with code like the following. We supply the `scope` option as configuration metadata for the `Logger` class, specifying a [transient](/fundamentals/injection-scopes) scope, to ensure that we'll have a unique instance of the `Logger` in each feature module. In this example, we do not extend the individual `Logger` methods (like `log()`, `warn()`, etc.), though you may choose to do so.
+This should be suitable for most cases. But if you need more customization for the Logger (like adding and calling custom methods), please follow to the next section. 
+
+#### Injecting a custom logger
+
+Sometimes you may want to add custom methods to your logger class.
+In order to use these methods you'll have to inject a custom logger to your services.
+We can use a [transient](/fundamentals/injection-scopes) scope for the logger so that each one of our services has its own custom context.
+If we maintain the `LoggerService` interface in our custom logger, we can still set our logger globally with `app.useLogger`.
+
+To start, extend the built-in logger with code like the following. We supply the `scope` option as configuration metadata for the `Logger` class, specifying a [transient](/fundamentals/injection-scopes) scope, to ensure that we'll have a unique instance of the `MyLogger` in each feature module. In this example, we do not extend the individual `Logger` methods (like `log()`, `warn()`, etc.), though you may choose to do so.
 
 ```typescript
 import { Injectable, Scope, Logger } from '@nestjs/common';
 
 @Injectable({ scope: Scope.TRANSIENT })
-export class MyLogger extends Logger {}
+export class MyLogger extends Logger {
+  // Implement custom methods or extend default methods here,
+  // for example:
+  customLog() {
+    this.log('Please feed the cat!');
+  }
+}
 ```
 
 Next, create a `LoggerModule` with a construction like this:
@@ -172,7 +210,7 @@ import { MyLogger } from './my-logger.service';
 export class LoggerModule {}
 ```
 
-Next, import the `LoggerModule` into your feature module. Then set the logger context, and start using the context-aware custom logger, like this:
+Next, import the `LoggerModule` into your feature module. Since we extended default `Logger` we have the convenience of using `setContext` method. So we can start using the context-aware custom logger, like this:
 
 ```typescript
 import { Injectable } from '@nestjs/common';
@@ -183,11 +221,16 @@ export class CatsService {
   private readonly cats: Cat[] = [];
 
   constructor(private myLogger: MyLogger) {
+    // Due to transient scope, CatsService has its own unique instance of MyLogger,
+    // so setting context here will not affect other instances in other services 
     this.myLogger.setContext('CatsService');
   }
 
   findAll(): Cat[] {
+    // You can call all the default methods
     this.myLogger.warn('About to return cats!');
+    // And your custom methods
+    this.myLogger.customLog();
     return this.cats;
   }
 }
@@ -202,6 +245,9 @@ const app = await NestFactory.create(ApplicationModule, {
 app.useLogger(new MyLogger());
 await app.listen(3000);
 ```
+
+Be mindful that if you supply `logger: false` to `NestFactory.create`, nothing will be logged until you call `useLogger`, so you may miss some important initialization errors.
+If you don't mind that some of your initial messages will be logged with the default logger, you can just omit the `logger: false` option.
 
 #### Use external logger
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Other... Please describe:
```

## What is the current behavior?

I was trying to integrate [`nestjs-pino`](https://github.com/iamolegga/nestjs-pino) (json logger) in my app in the best possible way, and struggled a little bit since nestjs docs don't quite clearly explain how to best use custom logger in your app services.

The example with transient scopes seems strange to me because why would I inject custom logger to my services if I am already setting it as globally default using `app.useLogger`. If I am switching loggers, I would have to do search and replace across all application. Also, I've noticed that when I use default `Logger` from `@nestjs/common` it actually uses the custom logger from `app.useLogger`. This was not clear to me, so I started digging.

I found this amazing Stack Overflow answer https://stackoverflow.com/a/52907695/4601673 but didn't quite get how Nest can use custom logger from `app.useLogger` if I am instantiating `Logger` from `@nestjs/common` in my class. 

So I digged through the source. If we look how `app.useLogger` is implemented (https://github.com/nestjs/nest/blob/67e15afbf33364ac6dcf0ade58d26aade7c2eb1f/packages/core/nest-application-context.ts#L123), it actually calls static method `Logger.overrideLogger` of the `Logger` from `@nestjs/common` which changes the static property `Logger.instance` (https://github.com/nestjs/nest/blob/01dfe29458a2851e42efe8d5b4d614caf9935742/packages/common/services/logger.service.ts#L70).

Now, if we look, how `Logger` itself is implemented, whenever you call instance methods like `log`/`warn`, it actually calls the related method from the saved `Logger.instance` (https://github.com/nestjs/nest/blob/01dfe29458a2851e42efe8d5b4d614caf9935742/packages/common/services/logger.service.ts#L108).

Basically, by calling `app.useLogger` we set the logger which will be used through the default `Logger` instances from `@nestjs/common`. So there is no need to inject custom logger if we only use methods from `LoggerService` interface.

If we dig more into nestjs source code, the logger is actually used the same way, as provided in the SO anwser linked above, so I think that is how it should be. As I see it, nestjs itself and possible third-party libraries would just use `Logger` from `@nestjs/common` and assume its implementation agnosticity. And application developer could substitute any custom logger they want via `app.useLogger`.

Here are some examples of `new Logger` usage from nestjs repo: https://github.com/nestjs/nest/blob/fc05b244a8a0db15ef60e612c9e2afe0290f995a/packages/core/errors/exception-handler.ts#L5, https://github.com/nestjs/nest/blob/eedd9df6e42aa035d14c2e861f401269d26d4d4f/sample/27-scheduling/src/tasks/tasks.service.ts#L6



Also I have found that passing `logger: false` to the `NestFactory.create` can swallow some important initialization errors which are logged before `app.useLogger`. This was really not obvious from the docs.

## What is the new behavior?

I have created a separate section in the docs, explaining how the logger instantiation works when custom logger is used:
```typescript
import { Logger, Injectable } from '@nestjs/common';

@Injectable()
class MyService {
  logger = new Logger(MyService.name);
  
  doSomething() {
    // Actually uses MyLogger
    this.logger.log('Doing something...');
  }
}
```

```typescript
const app = await NestFactory.create(ApplicationModule);
app.useLogger(app.get(MyLogger));
await app.listen(3000);
``` 



I have repurposed existing section about injecting custom logger with transient scope into some kind of an advanced example where user may want to use custom logging methods which are not provided by the `LoggerService` interface.

I have also added explicit warning about using `logger: false`, maybe it will save someone hours of debugging.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

I have preserved the original section name so links should not be broken.

## Other information

Since I am not a native english speaker, there may be some stylistic errors in my descriptions. Please tell me about them so I can improve.

In short, I want to promote the best practice of using `new Logger` since it fells more consistent than just injecting your logger into your own services. For example, if all library authors use this pattern, it would be easy for me as an app developer to customize logger behavior consistently across all application.

