### PR TITLE
docs(graphql): remove duplicated file extension in code block

### DIFF
--- a/content/graphql/resolvers-map.md
+++ b/content/graphql/resolvers-map.md
@@ -539,7 +539,7 @@ type Query {
 Conventionally, we would prefer to decouple these, using names like `getAuthor()` or `getPosts()` for our resolver methods. We can easily do this by passing the mapping name as an argument to the decorator, as shown below:
 
 ```typescript
-@@filename(authors/authors.resolver.ts)
+@@filename(authors/authors.resolver)
 @Resolver('Author')
 export class AuthorsResolver {
   constructor(
@@ -565,7 +565,7 @@ export class AuthorsResolver {
 Assuming that we use the schema first approach and have enabled the typings generation feature (with `outputAs: 'class'` as shown in the [previous](/graphql/quick-start) chapter), once you run the application it will generate the following file (in the location you specified in the `GraphQLModule.forRoot()` method. For example, in `src/graphql.ts`)
 
 ```typescript
-@@filename(graphql.ts)
+@@filename(graphql)
 export class Author {
   id: number;
   firstName?: string;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

In the Resolvers of  GraphQL part, there are typo error in some code blocks showing duplicated file extensions.


## What is the new behavior?

The name of the file(or path) displayed correctly

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information