### PR TITLE
mention another way to consume OpenAPIObject document

### DIFF
--- a/content/openapi/introduction.md
+++ b/content/openapi/introduction.md
@@ -64,6 +64,8 @@ The `SwaggerModule` automatically reflects all of your endpoints. Note that the 
 
 > info **Hint** To generate and download a Swagger JSON file, navigate to `http://localhost:3000/api-json` in your browser (assuming that your Swagger documentation is available under `http://localhost:3000/api`).
 
+> `const document` above is a serializable object conforming to [OpenAPI Document](https://swagger.io/specification/#openapi-document). Instead of hosting it via HTTP, you could also save it as a json / yaml file, and consume it in different ways.
+
 #### Example
 
 A working example is available [here](https://github.com/nestjs/nest/tree/master/sample/11-swagger).


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md

## PR Type

What kind of change does this PR introduce?

[x] Document

## What is the current behavior?

People unfamiliar with OpenAPI may fail to realize other ways to use the `OpenAPIObject` object (at least in my own case).

## What is the new behavior?

It is clearer that one could save the OpenAPI document as a file, rather than serving it over HTTP with `SwaggerModule.setup`.

## Does this PR introduce a breaking change?

[ ] Yes
[x] No

## Other information

The use I described in this patch worked in my project but I'm not very confident though. Can somebody confirm this usage?