### PR TITLE
chore: add docs change type to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,6 +14,7 @@ What kind of change does this PR introduce?
 [ ] Code style update (formatting, local variables)
 [ ] Refactoring (no functional changes, no api changes)
 [ ] Build related changes
+[ ] Docs
 [ ] Other... Please describe:
 ```
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] Docs
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

In the PR template, there's a list of PR types and it wasn't obvious what to pick for an update to a markdown file in `content/`. I checked past PRs and saw many people filling in `Docs` as a custom type.

Issue Number: N/A


## What is the new behavior?

Docs is now an option in that list.

Since this is a docs site, I think this is a little unclear. `docs` makes sense since the PR is updating the docs, but from the perspective of the docs site, perhaps it's considered a feature or bugfix. However, feature or bugfix could also be considered to be part of the mechanics of the docs site rather than the content (e.g. security fix, layout change, etc.).

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information