### PR TITLE
docs: add missing request object decorators

### DIFF
--- a/content/controllers.md
+++ b/content/controllers.md
@@ -103,7 +103,7 @@ The request object represents the HTTP request and has properties for the reques
 <table>
   <tbody>
     <tr>
-      <td><code>@Request()</code></td>
+      <td><code>@Request(), @Req()</code></td>
       <td><code>req</code></td></tr>
     <tr>
       <td><code>@Response(), @Res()</code><span class="table-code-asterisk">*</span></td>
@@ -136,6 +136,10 @@ The request object represents the HTTP request and has properties for the reques
     <tr>
       <td><code>@Ip()</code></td>
       <td><code>req.ip</code></td>
+    </tr>
+    <tr>
+      <td><code>@HostParam()</code></td>
+      <td><code>req.hosts</code></td>
     </tr>
   </tbody>
 </table>

--- a/content/custom-decorators.md
+++ b/content/custom-decorators.md
@@ -15,11 +15,11 @@ Nest provides a set of useful **param decorators** that you can use together wit
 <table>
   <tbody>
     <tr>
-      <td><code>@Request()</code></td>
+      <td><code>@Request(), @Req()</code></td>
       <td><code>req</code></td>
     </tr>
     <tr>
-      <td><code>@Response()</code></td>
+      <td><code>@Response(), @Res()</code></td>
       <td><code>res</code></td>
     </tr>
     <tr>
@@ -49,6 +49,10 @@ Nest provides a set of useful **param decorators** that you can use together wit
     <tr>
       <td><code>@Ip()</code></td>
       <td><code>req.ip</code></td>
+    </tr>
+    <tr>
+      <td><code>@HostParam()</code></td>
+      <td><code>req.hosts</code></td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] Docs
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The docs show request object decorators, but the table is incomplete in both places.

Issue Number: N/A


## What is the new behavior?

The request object decorator table is complete in both places. `HostParam` has been added and the shortcuts `@Req` and `@Res()` are mentioned.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

I skipped `UploadedFile` and `UploadedFiles` because they didn't seem to be directly off of Express. If they should be added, what should the corresponding platform-specific objects be for them?