### PR TITLE
docs(task-scheduling): change seconds argument

### DIFF
--- a/content/techniques/task-scheduling.md
+++ b/content/techniques/task-scheduling.md
@@ -286,12 +286,12 @@ clearInterval(interval);
 **Create** a new interval dynamically using the `SchedulerRegistry.addInterval()` method, as follows:
 
 ```typescript
-addInterval(name: string, seconds: string) {
+addInterval(name: string, milliseconds: number) {
   const callback = () => {
-    this.logger.warn(`Interval ${name} executing at time (${seconds})!`);
+    this.logger.warn(`Interval ${name} executing at time (${milliseconds})!`);
   };
 
-  const interval = setInterval(callback, seconds);
+  const interval = setInterval(callback, milliseconds);
   this.scheduler.addInterval(name, interval);
 }
 ```
@@ -335,12 +335,12 @@ clearTimeout(timeout);
 **Create** a new timeout dynamically using the `SchedulerRegistry.addTimeout()` method, as follows:
 
 ```typescript
-addTimeout(name: string, seconds: string) {
+addTimeout(name: string, milliseconds: number) {
   const callback = () => {
-    this.logger.warn(`Timeout ${name} executing after (${seconds})!`);
+    this.logger.warn(`Timeout ${name} executing after (${milliseconds})!`);
   };
 
-  const timeout = setTimeout(callback, seconds);
+  const timeout = setTimeout(callback, milliseconds);
   this.scheduler.addTimeout(name, timeout);
 }
 ```


### PR DESCRIPTION
The seconds argument of setTimeout and setInterval should be in milliseconds instead, and the type should be number instead of string.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[X] Docs
[ ] Other... Please describe:
```

## What is the current behavior?
the expected argument called 'seconds' and has the type string.


## What is the new behavior?
the argument called 'milliseconds' and has the type number


## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

## Other information
