### PR TITLE
Fix 404 link for passportjs strategies

### DIFF
--- a/content/techniques/authentication.md
+++ b/content/techniques/authentication.md
@@ -8,7 +8,7 @@ Authentication is an **essential** part of most applications. There are many dif
 - Manage authenticated state (by issuing a portable token, such as a JWT, or creating an [Express session](https://github.com/expressjs/session))
 - Attach information about the authenticated user to the `Request` object for further use in route handlers
 
-Passport has a rich ecosystem of [strategies](http://www.passportjs.org/packages/) that implement various authentication mechanisms. While simple in concept, the set of Passport strategies you can choose from is large and presents a lot of variety. Passport abstracts these varied steps into a standard pattern, and the `@nestjs/passport` module wraps and standardizes this pattern into familiar Nest constructs.
+Passport has a rich ecosystem of [strategies](http://www.passportjs.org/) that implement various authentication mechanisms. While simple in concept, the set of Passport strategies you can choose from is large and presents a lot of variety. Passport abstracts these varied steps into a standard pattern, and the `@nestjs/passport` module wraps and standardizes this pattern into familiar Nest constructs.
 
 In this chapter, we'll implement a complete end-to-end authentication solution for a RESTful API server using these powerful and flexible modules. You can use the concepts described here to implement any Passport strategy to customize your authentication scheme. You can follow the steps in this chapter to build this complete example. You can find a repository with a completed sample app [here](https://github.com/nestjs/nest/tree/master/sample/19-auth-jwt).
 


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

Direct link to the http://www.passportjs.org/packages/ raises `404 Not Found`.
There isn't any direct non-404 link to passportjs strategies page from what I see.
So the goal of this PR is to just fix that 404 issue. Strategies list is pretty trivial to find from the landing page.


<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] Docs
[ ] Other... Please describe:
```


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information

Referenced page
https://docs.nestjs.com/techniques/authentication