### PR TITLE
docs(hot-reload): Changing a lib not compatible with webpack 5

### DIFF
--- a/content/recipes/hot-reload.md
+++ b/content/recipes/hot-reload.md
@@ -13,7 +13,7 @@ If you are using the [Nest CLI](https://docs.nestjs.com/cli/overview), the confi
 First install the required packages:
 
 ```bash
-$ npm i --save-dev webpack-node-externals start-server-webpack-plugin
+$ npm i --save-dev webpack-node-externals start-server-nestjs-webpack-plugin
 ```
 
 #### Configuration
@@ -23,9 +23,9 @@ Once the installation is complete, create a `webpack-hmr.config.js` file in the 
 ```typescript
 const webpack = require('webpack');
 const nodeExternals = require('webpack-node-externals');
-const StartServerPlugin = require('start-server-webpack-plugin');
+const StartServerPlugin = require('start-server-nestjs-webpack-plugin');
 
-module.exports = function(options) {
+module.exports = function (options) {
   return {
     ...options,
     entry: ['webpack/hot/poll?100', options.entry],
@@ -87,7 +87,7 @@ If you are not using the [Nest CLI](https://docs.nestjs.com/cli/overview), the c
 First install the required packages:
 
 ```bash
-$ npm i --save-dev webpack webpack-cli webpack-node-externals ts-loader start-server-webpack-plugin
+$ npm i --save-dev webpack webpack-cli webpack-node-externals ts-loader start-server-nestjs-webpack-plugin
 ```
 
 #### Configuration
@@ -98,7 +98,7 @@ Once the installation is complete, create a `webpack.config.js` file in the root
 const webpack = require('webpack');
 const path = require('path');
 const nodeExternals = require('webpack-node-externals');
-const StartServerPlugin = require('start-server-webpack-plugin');
+const StartServerPlugin = require('start-server-nestjs-webpack-plugin');
 
 module.exports = {
   entry: ['webpack/hot/poll?100', './src/main.ts'],


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] Docs
[x] Other... Please describe: Changing a lib that was breaking in webpack 5
```

## What is the current behavior?
Hot Reload breaking due to a lib not compatible with webpack 5.
https://github.com/ericclemmons/start-server-webpack-plugin/issues/40
An issue has already been opened and remained unanswered for 29 days.

Issue Number: #5667


## What is the new behavior?

Due to the lack of updating of the current library, I created a new NPM package that solves the problem.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
