### PR TITLE
docs(sql): adding hint of injection token with typeorm async Connection options

### DIFF
--- a/content/techniques/sql.md
+++ b/content/techniques/sql.md
@@ -744,25 +744,7 @@ TypeOrmModule.forRootAsync({
 This construction works the same as `useClass` with one critical difference - `TypeOrmModule` will lookup imported modules to reuse an existing `ConfigService` instead of instantiating a new one.
 
 If you don't use ConnectionName as 'default', you need to specify ConnectionName so that nestjs can recognize it.
-
-```typescript
-TypeOrmModule.forRootAsync({
-  useFactory: () => {
-    return {
-      type: 'mysql',
-      host: 'localhost',
-      port: 3306,
-      username: 'root',
-      password: 'root',
-      database: 'test',
-      entities:[],
-      synchronize: true,
-      name:"typeorm_user_connection"
-    }
-  },
-  name: 'USER',
-}),
-```
+> **Hint**: make sure the `name` property is on the same level as the `useFactory`, `useClass`, or `useValue` property. This will allow Nest to properly create the injection token
 
 
 #### Example

--- a/content/techniques/sql.md
+++ b/content/techniques/sql.md
@@ -567,7 +567,7 @@ export class AppModule {}
 
 > warning **Notice** If you don't set the `name` for a connection, its name is set to `default`. Please note that you shouldn't have multiple connections without a name, or with the same name, otherwise they will get overridden.
 
-If you using multiple connections with asynchronously, set Connection Name like this.
+If you need to use multiple connections with asynchronous module registration, you can set the name for the connection like this:
 
 ```typescript
 const defaultOptions = {

--- a/content/techniques/sql.md
+++ b/content/techniques/sql.md
@@ -743,10 +743,7 @@ TypeOrmModule.forRootAsync({
 
 This construction works the same as `useClass` with one critical difference - `TypeOrmModule` will lookup imported modules to reuse an existing `ConfigService` instead of instantiating a new one.
 
-If you don't use ConnectionName as 'default', you need to specify ConnectionName so that nestjs can recognize it.
-
-> info **Hint**: make sure the `name` property is on the same level as the `useFactory`, `useClass`, or `useValue` property. This will allow Nest to properly create the injection token
-
+> info **Hint** Make sure that the `name` property is defined on the same level as the `useFactory`, `useClass`, or `useValue` property. This will allow Nest to properly register the connection under the appropriate injection token.
 
 #### Example
 

--- a/content/techniques/sql.md
+++ b/content/techniques/sql.md
@@ -743,7 +743,7 @@ TypeOrmModule.forRootAsync({
 
 This construction works the same as `useClass` with one critical difference - `TypeOrmModule` will lookup imported modules to reuse an existing `ConfigService` instead of instantiating a new one.
 
-> info **Hint** Make sure that the `name` property is defined on the same level as the `useFactory`, `useClass`, or `useValue` property. This will allow Nest to properly register the connection under the appropriate injection token.
+> info **Hint** Make sure that the `name` property is defined at the same level as the `useFactory`, `useClass`, or `useValue` property. This will allow Nest to properly register the connection under the appropriate injection token.
 
 #### Example
 

--- a/content/techniques/sql.md
+++ b/content/techniques/sql.md
@@ -567,6 +567,42 @@ export class AppModule {}
 
 > warning **Notice** If you don't set the `name` for a connection, its name is set to `default`. Please note that you shouldn't have multiple connections without a name, or with the same name, otherwise they will get overridden.
 
+If you using multiple connections with asynchronously, set Connection Name like this.
+
+```typescript
+const defaultOptions = {
+  type: 'postgres',
+  port: 5432,
+  username: 'user',
+  password: 'password',
+  database: 'db',
+  synchronize: true,
+};
+
+@Module({
+  imports: [
+    TypeOrmModule.forRootAsync({
+      useFactory: () => ({
+        ...defaultOptions
+        host: 'user_db_host',
+        entities: [User],
+      }),
+    }),
+    TypeOrmModule.forRootAsync({
+      useFactory: () => ({
+        ...defaultOptions,
+        name: 'albums_typeorm_connection',
+        host: 'album_db_host',
+        entities: [Album],
+      }),
+      name: 'albumsConnection'
+    }),
+  ],
+})
+
+export class AppModule {}
+```
+
 At this point, you have `User` and `Album` entities registered with their own connection. With this setup, you have to tell the `TypeOrmModule.forFeature()` method and the `@InjectRepository()` decorator which connection should be used. If you do not pass any connection name, the `default` connection is used.
 
 ```typescript

--- a/content/techniques/sql.md
+++ b/content/techniques/sql.md
@@ -567,42 +567,6 @@ export class AppModule {}
 
 > warning **Notice** If you don't set the `name` for a connection, its name is set to `default`. Please note that you shouldn't have multiple connections without a name, or with the same name, otherwise they will get overridden.
 
-If you need to use multiple connections with asynchronous module registration, you can set the name for the connection like this:
-
-```typescript
-const defaultOptions = {
-  type: 'postgres',
-  port: 5432,
-  username: 'user',
-  password: 'password',
-  database: 'db',
-  synchronize: true,
-};
-
-@Module({
-  imports: [
-    TypeOrmModule.forRootAsync({
-      useFactory: () => ({
-        ...defaultOptions
-        host: 'user_db_host',
-        entities: [User],
-      }),
-    }),
-    TypeOrmModule.forRootAsync({
-      useFactory: () => ({
-        ...defaultOptions,
-        name: 'albums_typeorm_connection',
-        host: 'album_db_host',
-        entities: [Album],
-      }),
-      name: 'albumsConnection'
-    }),
-  ],
-})
-
-export class AppModule {}
-```
-
 At this point, you have `User` and `Album` entities registered with their own connection. With this setup, you have to tell the `TypeOrmModule.forFeature()` method and the `@InjectRepository()` decorator which connection should be used. If you do not pass any connection name, the `default` connection is used.
 
 ```typescript
@@ -778,6 +742,28 @@ TypeOrmModule.forRootAsync({
 ```
 
 This construction works the same as `useClass` with one critical difference - `TypeOrmModule` will lookup imported modules to reuse an existing `ConfigService` instead of instantiating a new one.
+
+If you don't use ConnectionName as 'default', you need to specify ConnectionName so that nestjs can recognize it.
+
+```typescript
+TypeOrmModule.forRootAsync({
+  useFactory: () => {
+    return {
+      type: 'mysql',
+      host: 'localhost',
+      port: 3306,
+      username: 'root',
+      password: 'root',
+      database: 'test',
+      entities:[],
+      synchronize: true,
+      name:"typeorm_user_connection"
+    }
+  },
+  name: 'USER',
+}),
+```
+
 
 #### Example
 

--- a/content/techniques/sql.md
+++ b/content/techniques/sql.md
@@ -744,7 +744,8 @@ TypeOrmModule.forRootAsync({
 This construction works the same as `useClass` with one critical difference - `TypeOrmModule` will lookup imported modules to reuse an existing `ConfigService` instead of instantiating a new one.
 
 If you don't use ConnectionName as 'default', you need to specify ConnectionName so that nestjs can recognize it.
-> **Hint**: make sure the `name` property is on the same level as the `useFactory`, `useClass`, or `useValue` property. This will allow Nest to properly create the injection token
+
+> info **Hint**: make sure the `name` property is on the same level as the `useFactory`, `useClass`, or `useValue` property. This will allow Nest to properly create the injection token
 
 
 #### Example


### PR DESCRIPTION
In the case of forRoot connection, the'name' item in forRoot becomes the connection name of nestjs.
However, in the case of forRootAsync connection, apart from the'name' item that exists inside forRoot, the'name' item of forRootAsync exists.
You must specify the conneciton name in the'name' item of forRootAsync to use the code described in the document.

Here is my example:

```typescript

@Module({
	imports: [
		TypeOrmModule.forRootAsync({
			imports: [MyConfigModule],
			useExisting: ASPDBConfig,
			name: 'ASP',
		}),
		TypeOrmModule.forRootAsync({
			imports: [MyConfigModule],
			useExisting: InCompanyDBConfig,
			name: 'InCompany',
		}),
		ApplicationModule,
	],
	providers: [],
})
export class EntryModule {}


@Module({
	imports: [TypeOrmModule.forFeature([Document, Unit], 'ASP')],
	providers: [NTSSendService],
	controllers: [NTSSendController],
	exports: [],
})
export class NTSSendModule {}


@Injectable()
export class NTSSendService {
	constructor(
		@InjectRepository(Document, 'ASP') protected readonly docRepo: Repository<Document>,
		@InjectRepository(Unit, 'ASP') protected readonly unitRepo: Repository<Unit>,
    ) {}
}

```

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] Docs
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

related Issue : https://github.com/nestjs/typeorm/issues/48#issuecomment-423111925
