### PR TITLE
Add a section for overriding APP_* token providers

### DIFF
--- a/content/fundamentals/unit-testing.md
+++ b/content/fundamentals/unit-testing.md
@@ -314,7 +314,7 @@ The compiled module has several useful methods, as described in the following ta
 
 #### Overriding globally registered providers
 
-If you have a [globally registered guard](/security/authentication#enable-authentication-globally) (or pipe, interceptor, or filter), you need to take a few more steps to override that enhancer. To re-cap the original registration looks like this:
+If you have a [globally registered guard](/security/authentication#enable-authentication-globally) (or pipe, interceptor, or filter), you need to take a few more steps to override that enhancer. To recap the original registration looks like this:
 
 ```typescript
 providers: [
@@ -339,7 +339,7 @@ providers: [
 
 > info **Hint** Change the `useClass` to `useExisting` to reference a registered provider instead of having Nest instantiate it behind the token.
 
-Now the `JwtAuthGuard` is visible to nest as a regular provider that can be overridden when creating the test module:
+Now the `JwtAuthGuard` is visible to nestjs as a regular provider that can be overridden when creating the `TestingModule`:
 
 ```typescript
 const moduleRef = await Test.createTestingModule({

--- a/content/fundamentals/unit-testing.md
+++ b/content/fundamentals/unit-testing.md
@@ -312,7 +312,7 @@ The compiled module has several useful methods, as described in the following ta
 
 > info **Hint** Keep your e2e test files inside the `e2e` directory. The testing files should have a `.e2e-spec` or `.e2e-test` suffix.
 
-#### Overriding globally registered providers
+#### Overriding globally registered enhancers
 
 If you have a [globally registered guard](/security/authentication#enable-authentication-globally) (or pipe, interceptor, or filter), you need to take a few more steps to override that enhancer. To recap the original registration looks like this:
 
@@ -325,7 +325,7 @@ providers: [
 ],
 ```
 
-This is registering the guard as a "multi"-provider through the `APP_*` token. To be able to replace the JwtAuthGuard here, the registration needs to use an existing provider in this slot:
+This is registering the guard as a "multi"-provider through the `APP_*` token. To be able to replace the `JwtAuthGuard` here, the registration needs to use an existing provider in this slot:
 
 ```typescript
 providers: [
@@ -339,7 +339,7 @@ providers: [
 
 > info **Hint** Change the `useClass` to `useExisting` to reference a registered provider instead of having Nest instantiate it behind the token.
 
-Now the `JwtAuthGuard` is visible to nestjs as a regular provider that can be overridden when creating the `TestingModule`:
+Now the `JwtAuthGuard` is visible to nest as a regular provider that can be overridden when creating the `TestingModule`:
 
 ```typescript
 const moduleRef = await Test.createTestingModule({

--- a/content/fundamentals/unit-testing.md
+++ b/content/fundamentals/unit-testing.md
@@ -339,7 +339,7 @@ providers: [
 
 > info **Hint** Change the `useClass` to `useExisting` to reference a registered provider instead of having Nest instantiate it behind the token.
 
-Now the `JwtAuthGuard` is visible to nest as a regular provider that can be overridden when creating the `TestingModule`:
+Now the `JwtAuthGuard` is visible to Nest as a regular provider that can be overridden when creating the `TestingModule`:
 
 ```typescript
 const moduleRef = await Test.createTestingModule({

--- a/content/fundamentals/unit-testing.md
+++ b/content/fundamentals/unit-testing.md
@@ -314,7 +314,7 @@ The compiled module has several useful methods, as described in the following ta
 
 #### Overriding globally registered enhancers
 
-If you have a [globally registered guard](/security/authentication#enable-authentication-globally) (or pipe, interceptor, or filter), you need to take a few more steps to override that enhancer. To recap the original registration looks like this:
+If you have a globally registered guard (or pipe, interceptor, or filter), you need to take a few more steps to override that enhancer. To recap the original registration looks like this:
 
 ```typescript
 providers: [


### PR DESCRIPTION
This adds a section on how to replace `APP_*` token providers in testing. This follows the description by @kamilmysliwiec in https://github.com/nestjs/nest/issues/4053 . I've used the solution in my project and it worked great.

Thanks to @jmcdo29 who pointed me to that issue when I was struggling with this.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] Docs
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/nestjs/nest/issues/5821


## What is the new behavior?

more docs

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
