### PR TITLE
docs(@nestjs/mongoose): rm anonymous functions in .pre hooks

### DIFF
--- a/content/techniques/mongo.md
+++ b/content/techniques/mongo.md
@@ -265,7 +265,7 @@ Middleware (also called pre and post hooks) are functions which are passed contr
         name: Cat.name,
         useFactory: () => {
           const schema = CatsSchema;
-          schema.pre('save', () => console.log('Hello from pre save'));
+          schema.pre('save', function() { console.log('Hello from pre save') });
           return schema;
         },
       },
@@ -286,11 +286,11 @@ Like other [factory providers](https://docs.nestjs.com/fundamentals/custom-provi
         imports: [ConfigModule],
         useFactory: (configService: ConfigService) => {
           const schema = CatsSchema;
-          schema.pre('save', () =>
+          schema.pre('save', function() {
             console.log(
               `${configService.get('APP_NAME')}: Hello from pre save`,
             ),
-          );
+          });
           return schema;
         },
         inject: [ConfigService],


### PR DESCRIPTION


## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] Docs
[ ] Other... Please describe:
```

## What is the current behavior?

https://github.com/nestjs/docs.nestjs.com/blob/master/content/techniques/mongo.md#hooks-middleware

In most cases users wants to access the document which located in `this` of the function. If we pass there anonymous function like in this example it will lose context and can confuse users.

Issue Number: N/A


## What is the new behavior?
In official mongoose examples used `function()` instead of `() => {}`
https://mongoosejs.com/docs/middleware.html#pre

Now
Function wouldn't lose context and mongoose document will be accassable throught `this`

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
