### PR TITLE
docs(openapi): Removed trailing ";"

### DIFF
--- a/content/openapi/introduction.md
+++ b/content/openapi/introduction.md
@@ -128,7 +128,7 @@ const document = SwaggerModule.createDocument(app, options, {
   operationIdFactory: (
     controllerKey: string,
     methodKey: string
-  ) => methodKey;
+  ) => methodKey
 });
 ```
 


### PR DESCRIPTION
Removed trailing semi colon as this causes compiler issues when a user copy and pastes the sample.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X ] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[X ] Docs
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
If a user copy and pastes the example from the OpenAPI Swagger docs they will get compiler issues as the current code is :

```
  const document = SwaggerModule.createDocument(app, options, {
    operationIdFactory: (
      controllerKey: string,
      methodKey: string
    ) => methodKey;
  });  
```

Issue Number: N/A


## What is the new behavior?
My change simply removed the semicolon trailing behind "methodKey".
Eg:
```
  const document = SwaggerModule.createDocument(app, options, {
    operationIdFactory: (
      controllerKey: string,
      methodKey: string
    ) => methodKey
  });  
```

Since the compiler expects nothing trailing or a "," (comma) trailing methodKey

```  const document = SwaggerModule.createDocument(app, options, {
    operationIdFactory: (
      controllerKey: string,
      methodKey: string
    ) => methodKey,
  });  
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[ X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
