### PR TITLE
docs(file-upload): added warning for cloud providers

### DIFF
--- a/content/techniques/file-upload.md
+++ b/content/techniques/file-upload.md
@@ -31,7 +31,7 @@ The `FileInterceptor()` decorator takes two arguments:
 - `fieldName`: string that supplies the name of the field from the HTML form that holds a file
 - `options`: optional object of type `MulterOptions`. This is the same object used by the multer constructor (more details [here](https://github.com/expressjs/multer#multeropts)).
 
-> warning **Warning** `FileInterceptor()` is not compatible with third party cloud providers type Firebase (and other cloud providers)
+> warning **Warning** `FileInterceptor()` may not be compatible with third party cloud providers like Google Firebase or others.
 
 #### Array of files
 

--- a/content/techniques/file-upload.md
+++ b/content/techniques/file-upload.md
@@ -31,6 +31,8 @@ The `FileInterceptor()` decorator takes two arguments:
 - `fieldName`: string that supplies the name of the field from the HTML form that holds a file
 - `options`: optional object of type `MulterOptions`. This is the same object used by the multer constructor (more details [here](https://github.com/expressjs/multer#multeropts)).
 
+> warning **Warning** `FileInterceptor()` is not compatible with third party cloud providers type Firebase (and other cloud providers)
+
 #### Array of files
 
 To upload an array of files (identified with a single field name), use the `FilesInterceptor()` decorator (note the plural **Files** in the decorator name). This decorator takes three arguments:


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Docs
[x] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
N/A

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
This PR, added warning which specifies that "FileInterceptor()" is not compatible with third party cloud providers