### PR TITLE
docs(events): added warning for event subscribers 

### DIFF
--- a/content/techniques/events.md
+++ b/content/techniques/events.md
@@ -83,7 +83,7 @@ handleOrderCreatedEvent(payload: OrderCreatedEvent) {
 }
 ```
 
-> warning **Warning** Event subscribers cannot be subject to the scope of the request.
+> warning **Warning** Event subscribers cannot be request-scoped.
 
 The first argument can be a `string` or `symbol` for a simple event emitter and a `string | symbol | Array<string | symbol>` in a case of a wildcard emitter. The second argument (optional) is a listener options object ([read more](https://github.com/EventEmitter2/EventEmitter2#emitteronevent-listener-options-objectboolean)).
 

--- a/content/techniques/events.md
+++ b/content/techniques/events.md
@@ -83,6 +83,8 @@ handleOrderCreatedEvent(payload: OrderCreatedEvent) {
 }
 ```
 
+> warning **Warning** Event subscribers cannot be subject to the scope of the request.
+
 The first argument can be a `string` or `symbol` for a simple event emitter and a `string | symbol | Array<string | symbol>` in a case of a wildcard emitter. The second argument (optional) is a listener options object ([read more](https://github.com/EventEmitter2/EventEmitter2#emitteronevent-listener-options-objectboolean)).
 
 ```typescript


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Docs
[x] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1576 


## What is the new behavior?
N/A

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
This PR, added warning for event subscribers which cannot be subject to the scope of the request