### PR TITLE
docs(who-uses): add datenlotse company

### DIFF
--- a/content/discover/who-uses.json
+++ b/content/discover/who-uses.json
@@ -239,6 +239,7 @@
     "https://halojasa.com",
     "https://hexito.com",
     "https://rivvy.app",
-    "https://padfever.com/"
+    "https://padfever.com/",
+    "https://datenlotse.org"
   ]
 }


### PR DESCRIPTION
Added datenlotse company to who uses json file

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ X ] Docs
[ ] Other... Please describe:
```

## What is the current behavior?
Datenlotse not beeing listed under who uses body

Issue Number: N/A


## What is the new behavior?
Datenlotse beeing listed under who uses body

## Does this PR introduce a breaking change?
```
[ ] Yes
[ X ] No
```


## Other information
I am the lead backend developer at datenlotse and we are using nest.js almost exclusively for our new projects