### PR TITLE
Change parameters in documentation example

### DIFF
--- a/content/websockets/gateways.md
+++ b/content/websockets/gateways.md
@@ -59,12 +59,12 @@ If you would prefer not to use decorators, the following code is functionally eq
 ```typescript
 @@filename(events.gateway)
 @SubscribeMessage('events')
-handleEvent(client: Socket, data: string): string {
+handleEvent(data: string, client: Socket): string {
   return data;
 }
 @@switch
 @SubscribeMessage('events')
-handleEvent(client, data) {
+handleEvent(data, client) {
   return data;
 }
 ```


### PR DESCRIPTION
There was an error in the documention. The first parameter contains the data, the second one the WS client.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] Docs
[ ] Other... Please describe:
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


