### PR TITLE
feat(): added dropdown for nestjs versions

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -12,6 +12,7 @@ import { AppComponent } from './app.component';
 import { SocialWrapperComponent } from './common/social-wrapper/social-wrapper.component';
 import { FooterComponent } from './homepage/footer/footer.component';
 import { HeaderComponent } from './homepage/header/header.component';
+import { VersionsComponent } from './homepage/header/versions/versions.component';
 import { HomepageComponent } from './homepage/homepage.component';
 import { MenuItemComponent } from './homepage/menu/menu-item/menu-item.component';
 import { MenuComponent } from './homepage/menu/menu.component';
@@ -77,6 +78,7 @@ const DEFAULT_PERFECT_SCROLLBAR_CONFIG: PerfectScrollbarConfigInterface = {
     EnterpriseComponent,
     SocialWrapperComponent,
     NewsletterComponent,
+    VersionsComponent
   ],
   bootstrap: [AppComponent],
   providers: [

--- a/src/app/homepage/header/header.component.html
+++ b/src/app/homepage/header/header.component.html
@@ -81,6 +81,11 @@
         >
       </li>
     </ul>
+    <ul>
+      <li>
+        <app-versions></app-versions>
+      </li>
+    </ul>
   </div>
   <!--<div class="workshop-wrapper">
     <img src="/assets/ng-camp-small.svg" alt="AngularCamp, Barcelona" />

--- a/src/app/homepage/header/versions/versions.component.html
+++ b/src/app/homepage/header/versions/versions.component.html
@@ -1,0 +1,29 @@
+<div 
+  class="dropdown dropdown-item"
+  [class.opened]="isOpen"
+>
+  <a 
+    href="#" 
+    class="drop-wrapper menu-wrapper" 
+    (click)="toggle()"
+  >
+    Versions
+    <svg
+      class="arrow-icon"
+      width="20"
+      height="20"
+      viewBox="0 0 1792 1792"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M1171 960q0 13-10 23l-466 466q-10 10-23 10t-23-10l-50-50q-10-10-10-23t10-23l393-393-393-393q-10-10-10-23t10-23l50-50q10-10 23-10t23 10l466 466q10 10 10 23z"
+      />
+    </svg>
+  </a>
+  <div class="dropdown-content"  [@openCloseAnimation]="isOpen">
+    <a href="https://docs.nestjs.com/v7/" target="_blank">7.x</a>
+    <a href="https://docs.nestjs.com/v6/" target="_blank">6.x</a>
+    <a href="https://docs.nestjs.com/v5/" target="_blank">5.x</a>
+    <a href="https://docs.nestjs.com/v4/" target="_blank">4.x</a>
+  </div>
+</div>

--- a/src/app/homepage/header/versions/versions.component.scss
+++ b/src/app/homepage/header/versions/versions.component.scss
@@ -1,0 +1,74 @@
+@import '../../../../scss/variables.scss';
+@import '../../../../scss/utils.scss';
+
+.drop-wrapper {
+  padding: 16px;
+  border: none;
+  text-transform: uppercase;
+  color: $white-color;
+  font-size: 14px;
+  font-weight: 600;
+  &:hover {
+    color: $red-color;
+  }
+}
+
+.dropdown {
+  position: relative;
+  display: inline-block;
+}
+
+.dropdown-content {
+  display: none;
+  position: absolute;
+  background-color: $silver-color;
+  min-width: 160px;
+  box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
+  z-index: 1;
+  margin-left: 8px;
+  border-bottom-left-radius: 4px;
+  border-bottom-right-radius: 4px;
+}
+
+.dropdown-content a {
+  color: $black-color;
+  padding: 12px 16px;
+  text-decoration: none;
+  display: block;
+  &:hover {
+    color: $red-color;
+  }
+}
+
+svg {
+  fill: $white-color;
+}
+
+.arrow-icon {
+  @extend .transition;
+  @include transform(rotate(90deg));
+
+  position: absolute;
+  top: 1px;
+  right: -10px;
+  font-size: 20px;
+  cursor: pointer;
+}
+
+.dropdown-item {
+  ul {
+    margin: 10px 0 15px;
+  }
+
+  &.opened {
+    .arrow-icon {
+      @include transform(rotate(-90deg));
+      fill: $red-color;
+    }
+  }
+}
+
+.dropdown:hover .dropdown-content {
+  display: block;
+}
+  

--- a/src/app/homepage/header/versions/versions.component.spec.ts
+++ b/src/app/homepage/header/versions/versions.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { VersionsComponent } from './versions.component';
+
+describe('VersionsComponent', () => {
+  let component: VersionsComponent;
+  let fixture: ComponentFixture<VersionsComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ VersionsComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(VersionsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/homepage/header/versions/versions.component.ts
+++ b/src/app/homepage/header/versions/versions.component.ts
@@ -1,0 +1,21 @@
+import { ChangeDetectionStrategy, Component, Input, OnInit } from '@angular/core';
+import { openCloseAnimation } from '../../../common';
+
+@Component({
+  selector: 'app-versions',
+  templateUrl: './versions.component.html',
+  styleUrls: ['./versions.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  animations: [
+    openCloseAnimation
+  ]
+})
+export class VersionsComponent {
+
+  @Input() isOpen = false;
+  @Input() icon: string;
+
+  toggle() {
+    this.isOpen = !this.isOpen;
+  }
+}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Docs
[x] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: takes its cue from this problem #64


## What is the new behavior?
N/A

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
This PR, added to the dropdown for nestjs versions, could be a useful addition to the documentation, to navigate between the old and new versions of NestJS, I am attaching here two screenshots both when the menu is open and when it is closed.

Also in the future as there are more versions of NestJS it could be useful.


dropdown open:
<img width="1807" alt="draft-version-nest-menu-open" src="https://user-images.githubusercontent.com/11542387/103788099-c2b88880-503e-11eb-89b7-0864ba7891e0.png">

dropdown close: 
<img width="1806" alt="draft-version-nest-menu-close" src="https://user-images.githubusercontent.com/11542387/103788160-d237d180-503e-11eb-9c47-fad152af5070.png">


