### PR TITLE
docs(openapi): add more docs for swagger setup method

### DIFF
--- a/content/openapi/introduction.md
+++ b/content/openapi/introduction.md
@@ -139,17 +139,17 @@ You can configure Swagger UI by passing the options object which fulfills the `S
 
 ```TypeScript
 export interface SwaggerCustomOptions {
-    explorer?: boolean;
-    swaggerOptions?: Record<string, any>;
-    customCss?: string;
-    customCssUrl?: string;
-    customJs?: string;
-    customfavIcon?: string;
-    swaggerUrl?: string;
-    customSiteTitle?: string;
-    validatorUrl?: string;
-    url?: string;
-    urls?: Record<'url' | 'name', string>[];
+  explorer?: boolean;
+  swaggerOptions?: Record<string, any>;
+  customCss?: string;
+  customCssUrl?: string;
+  customJs?: string;
+  customfavIcon?: string;
+  swaggerUrl?: string;
+  customSiteTitle?: string;
+  validatorUrl?: string;
+  url?: string;
+  urls?: Record<'url' | 'name', string>[];
 }
 ```
 

--- a/content/openapi/introduction.md
+++ b/content/openapi/introduction.md
@@ -48,10 +48,10 @@ The `DocumentBuilder` helps to structure a base document that conforms to the Op
 
 Once we create a document, we can call the `setup()` method. It accepts:
 
-1. the path to mount the Swagger UI
-2. an application instance
-3. the document object instantiated above
-4. optional configuration parameter. More on this in the [Setup options section](/openapi/introduction#document-options).
+1. The path to mount the Swagger UI
+2. An application instance
+3. The document object instantiated above
+4. Optional configuration parameter (read more [here](/openapi/introduction#document-options))
 
 Now you can run the following command to start the HTTP server:
 

--- a/content/openapi/introduction.md
+++ b/content/openapi/introduction.md
@@ -35,12 +35,7 @@ async function bootstrap() {
     .addTag('cats')
     .build();
   const document = SwaggerModule.createDocument(app, options);
-  SwaggerModule.setup('api', app, document, {
-    swaggerOptions: {
-      persistAuthorization: true,
-    },
-    customSiteTitle: 'My website browser title.',
-  });
+  SwaggerModule.setup('api', app, document);
 
   await app.listen(3000);
 }

--- a/content/openapi/introduction.md
+++ b/content/openapi/introduction.md
@@ -163,3 +163,8 @@ const customOptions: SwaggerCustomOptions = {
   customSiteTitle: 'My API Docs',
 };
 SwaggerModule.setup('docs', app, document, customOptions);
+```
+
+#### Example
+
+A working example is available [here](https://github.com/nestjs/nest/tree/master/sample/11-swagger).

--- a/content/openapi/introduction.md
+++ b/content/openapi/introduction.md
@@ -35,7 +35,12 @@ async function bootstrap() {
     .addTag('cats')
     .build();
   const document = SwaggerModule.createDocument(app, options);
-  SwaggerModule.setup('api', app, document);
+  SwaggerModule.setup('api', app, document, {
+    swaggerOptions: {
+      persistAuthorization: true,
+    },
+    customSiteTitle: 'My website browser title.',
+  });
 
   await app.listen(3000);
 }
@@ -51,6 +56,7 @@ Once we create a document, we can call the `setup()` method. It accepts:
 1. the path to mount the Swagger UI
 2. an application instance
 3. the document object instantiated above
+4. optional configuration parameter
 
 Now you can run the following command to start the HTTP server:
 

--- a/content/openapi/introduction.md
+++ b/content/openapi/introduction.md
@@ -153,7 +153,7 @@ export interface SwaggerCustomOptions {
 }
 ```
 
-For example, if you want to make sure that the auth token in the docs persists after refreshing page or change the browser title you can set the following:
+For example, if you want to make sure that the authentication token persists after refreshing the page, or change the page title (that shows up in the browser), you can use the following settings:
 
 ```TypeScript
 const customOptions: SwaggerCustomOptions = {
@@ -163,9 +163,5 @@ const customOptions: SwaggerCustomOptions = {
   customSiteTitle: 'My API Docs',
 };
 SwaggerModule.setup('docs', app, document, customOptions);
-```
-
-
-#### Example
 
 A working example is available [here](https://github.com/nestjs/nest/tree/master/sample/11-swagger).

--- a/content/openapi/introduction.md
+++ b/content/openapi/introduction.md
@@ -163,5 +163,3 @@ const customOptions: SwaggerCustomOptions = {
   customSiteTitle: 'My API Docs',
 };
 SwaggerModule.setup('docs', app, document, customOptions);
-
-A working example is available [here](https://github.com/nestjs/nest/tree/master/sample/11-swagger).

--- a/content/openapi/introduction.md
+++ b/content/openapi/introduction.md
@@ -135,7 +135,7 @@ const document = SwaggerModule.createDocument(app, options, {
 
 ### Setup options
 
-While calling setup method, it is possible to have some extra options. These options should be of type `SwaggerCustomOptions`, which can be the following:
+While calling the setup method, it is possible to pass extra options. These options should be of type `SwaggerCustomOptions`, which can be the following:
 
 ```TypeScript
 export interface SwaggerCustomOptions {

--- a/content/openapi/introduction.md
+++ b/content/openapi/introduction.md
@@ -140,7 +140,7 @@ While calling the setup method, it is possible to pass extra options. These opti
 ```TypeScript
 export interface SwaggerCustomOptions {
     explorer?: boolean;
-    swaggerOptions?: any;
+    swaggerOptions?: Record<string, any>;
     customCss?: string;
     customCssUrl?: string;
     customJs?: string;

--- a/content/openapi/introduction.md
+++ b/content/openapi/introduction.md
@@ -133,7 +133,7 @@ const document = SwaggerModule.createDocument(app, options, {
 });
 ```
 
-### Setup options
+#### Setup options
 
 While calling the setup method, it is possible to pass extra options. These options should be of type `SwaggerCustomOptions`, which can be the following:
 

--- a/content/openapi/introduction.md
+++ b/content/openapi/introduction.md
@@ -56,7 +56,7 @@ Once we create a document, we can call the `setup()` method. It accepts:
 1. the path to mount the Swagger UI
 2. an application instance
 3. the document object instantiated above
-4. optional configuration parameter
+4. optional configuration parameter. More on this in the [Setup options section](/openapi/introduction#document-options).
 
 Now you can run the following command to start the HTTP server:
 
@@ -137,6 +137,39 @@ const document = SwaggerModule.createDocument(app, options, {
   ) => methodKey
 });
 ```
+
+### Setup options
+
+While calling setup method, it is possible to have some extra options. These options should be of type `SwaggerCustomOptions`, which can be the following:
+
+```TypeScript
+export interface SwaggerCustomOptions {
+    explorer?: boolean;
+    swaggerOptions?: any;
+    customCss?: string;
+    customCssUrl?: string;
+    customJs?: string;
+    customfavIcon?: string;
+    swaggerUrl?: string;
+    customSiteTitle?: string;
+    validatorUrl?: string;
+    url?: string;
+    urls?: Record<'url' | 'name', string>[];
+}
+```
+
+For example, if you want to make sure that the auth token in the docs persists after refreshing page or change the browser title you can set the following:
+
+```TypeScript
+const customOptions: SwaggerCustomOptions = {
+  swaggerOptions: {
+    persistAuthorization: true,
+  },
+  customSiteTitle: 'My API Docs',
+};
+SwaggerModule.setup('docs', app, document, customOptions);
+```
+
 
 #### Example
 

--- a/content/openapi/introduction.md
+++ b/content/openapi/introduction.md
@@ -135,7 +135,7 @@ const document = SwaggerModule.createDocument(app, options, {
 
 #### Setup options
 
-While calling the setup method, it is possible to pass extra options. These options should be of type `SwaggerCustomOptions`, which can be the following:
+You can configure Swagger UI by passing the options object which fulfills the `SwaggerCustomOptions` interface as a fourth argument of the `SwaggerModule#setup` method.
 
 ```TypeScript
 export interface SwaggerCustomOptions {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] Docs
[ ] Other... Please describe:
```

## What is the current behavior?
When using `addBearerAuth`, 

Issue Number: N/A


## What is the new behavior?
`persistAuthorization` option is so important when using `addBearerAuth`. On each refresh, it removes authorization keys. It's better to have this option (and others) in documentations.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
