### PR TITLE
docs(swagger): change options to config so it matches types

### DIFF
--- a/content/openapi/introduction.md
+++ b/content/openapi/introduction.md
@@ -28,13 +28,13 @@ import { AppModule } from './app.module';
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
 
-  const options = new DocumentBuilder()
+  const config = new DocumentBuilder()
     .setTitle('Cats example')
     .setDescription('The cats API description')
     .setVersion('1.0')
     .addTag('cats')
     .build();
-  const document = SwaggerModule.createDocument(app, options);
+  const document = SwaggerModule.createDocument(app, config);
   SwaggerModule.setup('api', app, document);
 
   await app.listen(3000);
@@ -124,12 +124,13 @@ export interface SwaggerDocumentOptions {
 For example, if you want to make sure that the library generates operation names like `createUser` instead of `UserController_createUser`, you can set the following:
 
 ```TypeScript
-const document = SwaggerModule.createDocument(app, options, {
+const options:SwaggerDocumentOptions =  {
   operationIdFactory: (
     controllerKey: string,
     methodKey: string
   ) => methodKey
 });
+const document = SwaggerModule.createDocument(app, config, options);
 ```
 
 #### Example

--- a/content/openapi/introduction.md
+++ b/content/openapi/introduction.md
@@ -124,7 +124,7 @@ export interface SwaggerDocumentOptions {
 For example, if you want to make sure that the library generates operation names like `createUser` instead of `UserController_createUser`, you can set the following:
 
 ```TypeScript
-const options:SwaggerDocumentOptions =  {
+const options: SwaggerDocumentOptions =  {
   operationIdFactory: (
     controllerKey: string,
     methodKey: string


### PR DESCRIPTION
Change options on second argument to config, and further exemplify the options assignin it to a separated variable for added clarity

Closes [1652](https://github.com/nestjs/docs.nestjs.com/issues/1652)

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[X] Docs
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

We describe how to use swagger like this, which can lead to confusion when later on the docs we present [options](https://docs.nestjs.com/openapi/introduction#document-options). SwaggerModule.createDocument second argument is [called config](https://github.com/nestjs/swagger/blob/61adb725788af64938d6bdd28fdaaf116bcd24f7/lib/swagger-module.ts#L14)

```typescript
  const options = new DocumentBuilder()
    .setTitle('Cats example')
    .setDescription('The cats API description')
    .setVersion('1.0')
    .addTag('cats')
    .build();
  const document = SwaggerModule.createDocument(app, options);
```

Issue Number: [1652](https://github.com/nestjs/docs.nestjs.com/issues/1652)


## What is the new behavior?
Simply change the name options to config

```typescript
  const config = new DocumentBuilder()
    .setTitle('Cats example')
    .setDescription('The cats API description')
    .setVersion('1.0')
    .addTag('cats')
    .build();
  const document = SwaggerModule.createDocument(app, config);
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
