### PR TITLE
docs(fastify,helmet,apollo): add warnings

### DIFF
--- a/content/security/helmet.md
+++ b/content/security/helmet.md
@@ -37,3 +37,23 @@ import * as helmet from 'fastify-helmet';
 // somewhere in your initialization file
 app.register(helmet);
 ```
+> warning **Warning** When using `apollo-server-fastify` and `fastify-helmet`, there may be a problem with [CSP](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) on the graphql playground, to solve this collision, configure the CSP as shown below:
+>
+> ```typescript
+> app.register(helmet, {
+>   contentSecurityPolicy: {
+>     directives: {
+>       defaultSrc: [`'self'`],
+>       styleSrc: [`'self'`, `'unsafe-inline'`, 'cdn.jsdelivr.net', 'fonts.googleapis.com'],
+>       fontSrc: [`'self'`, 'fonts.gstatic.com'],
+>       imgSrc: [`'self'`, 'data:', 'cdn.jsdelivr.net'],
+>       scriptSrc: [`'self'`, `https: 'unsafe-inline'`, `cdn.jsdelivr.net`],
+>     },
+>   },
+> });
+>
+> // If you are not going to use CSP at all, you can use this:
+> app.register(helmet, {
+>   contentSecurityPolicy: false,
+> });
+> ```

--- a/content/security/helmet.md
+++ b/content/security/helmet.md
@@ -37,7 +37,7 @@ import * as helmet from 'fastify-helmet';
 // somewhere in your initialization file
 app.register(helmet);
 ```
-> warning **Warning** When using `apollo-server-fastify` and `fastify-helmet`, there may be a problem with [CSP](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) on the graphql playground, to solve this collision, configure the CSP as shown below:
+> warning **Warning** When using `apollo-server-fastify` and `fastify-helmet`, there may be a problem with [CSP](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) on the GraphQL playground, to solve this collision, configure the CSP as shown below:
 >
 > ```typescript
 > app.register(helmet, {

--- a/content/techniques/performance.md
+++ b/content/techniques/performance.md
@@ -15,7 +15,7 @@ First, we need to install the required package:
 ```bash
 $ npm i --save @nestjs/platform-fastify
 ```
-> warning **Warning** When using `@nestjs/platform-fastify` version `<=3.0.0` and `apollo-server-fastify`, graphql playground may not work due to incompatibility with `fastify` version `^3.0.0`. You may want to use the unstable `apollo-server-fastify` version `^3.0.0-alpha.3` or choose express.
+> warning **Warning** When using `@nestjs/platform-fastify` version `>=7.5.0` and `apollo-server-fastify`, GraphQL playground may not work due to incompatibility with `fastify` version `^3.0.0`. You may want to use the unstable `apollo-server-fastify` version `^3.0.0-alpha.3` or temporarily choose express instead.
 
 #### Adapter
 

--- a/content/techniques/performance.md
+++ b/content/techniques/performance.md
@@ -15,6 +15,7 @@ First, we need to install the required package:
 ```bash
 $ npm i --save @nestjs/platform-fastify
 ```
+> warning **Warning** When using `@nestjs/platform-fastify` version `<=3.0.0` and `apollo-server-fastify`, graphql playground may not work due to incompatibility with `fastify` version `^3.0.0`. You may want want to use the unstable `apollo-server-fastify` version `^3.0.0-alpha.3` or choose express.
 
 #### Adapter
 

--- a/content/techniques/performance.md
+++ b/content/techniques/performance.md
@@ -15,7 +15,7 @@ First, we need to install the required package:
 ```bash
 $ npm i --save @nestjs/platform-fastify
 ```
-> warning **Warning** When using `@nestjs/platform-fastify` version `<=3.0.0` and `apollo-server-fastify`, graphql playground may not work due to incompatibility with `fastify` version `^3.0.0`. You may want want to use the unstable `apollo-server-fastify` version `^3.0.0-alpha.3` or choose express.
+> warning **Warning** When using `@nestjs/platform-fastify` version `<=3.0.0` and `apollo-server-fastify`, graphql playground may not work due to incompatibility with `fastify` version `^3.0.0`. You may want to use the unstable `apollo-server-fastify` version `^3.0.0-alpha.3` or choose express.
 
 #### Adapter
 


### PR DESCRIPTION
add warnings

apollo-server-fastify does not have full support for fastify v3 which
results in the playground not loading. Added a warning to either use
unstable apollo-server-fastify version that supports v3 or express.
Playground also uses CDN which requires a change to CSP if using helmet.
Added a warning containing required policy additions.

https://github.com/nestjs/nest/issues/6180

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] Docs
[ ] Other... Please describe:
```

## What is the current behavior?

Issue Number: [Nest#6180](https://github.com/nestjs/nest/issues/6180)


## What is the new behavior?

Add warning advising of changes required to fix above issue.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
