### PR TITLE
docs: improved section about using a config.yaml

### DIFF
--- a/content/techniques/configuration.md
+++ b/content/techniques/configuration.md
@@ -158,48 +158,7 @@ export default () => {
 ```
 
 
-> warning **Note** Nest CLI does not automatically move your "assets" (non-TS files) to the `dist` folder during the build process. To make sure that your YAML files are copied, you have to specify this in the 'nest-cli.json' file. You can find an example below:
-
-Here is an example, how your folder structure may look like:
-```bash
-.eslintrc.js
-│   .gitignore
-│   .prettierrc
-│   nest-cli.json
-│   package-lock.json
-│   package.json
-│   README.md
-│   tsconfig.build.json
-│   tsconfig.json
-│
-├───config
-│       config.yaml
-│       configuration.ts
-│
-├───dist
-├───node_modules
-└───src
-        app.controller.ts
-        app.module.ts
-        main.ts
-```
-The paths of the assets have to be relative to "sourceRoot" in 'nest-cli.json'. Because config is in the same directory as src, "include" has to go a directory up. "outDir" defines, where the assets are copied to. Your nest-cli.json file might then look like this:
-```json
-{
-  "collection": "@nestjs/schematics",
-  "sourceRoot": "src",
-  "compilerOptions": {
-    "assets": [
-      {
-        "include": "../config/*.yaml",
-        "outDir": "./dist/config"
-      }
-    ]
-  }
-}
-```
-
-Read more about "assets" [here](/cli/monorepo#assets).
+> warning **Note** Nest CLI does not automatically move your "assets" (non-TS files) to the `dist` folder during the build process. To make sure that your YAML files are copied, you have to specify this in `compilerOptions#assets` in the `nest-cli.json` file. As an example, if the `config` folder is at the same level as the `src` folder, add `compilerOptions#assets` with the value `"assets": [{"include": "../config/*.yaml","outDir": "./dist/config"}]`. Read more [here](/cli/monorepo#assets).
 
 <app-banner-enterprise></app-banner-enterprise>
 

--- a/content/techniques/configuration.md
+++ b/content/techniques/configuration.md
@@ -158,7 +158,7 @@ export default () => {
 ```
 
 
-> warning **Note** Nest CLI does not automatically move your "assets" (non-TS files) to the `dist` folder during the build process. To make sure that your YAML files are copied, you have to specify this in `compilerOptions#assets` in the `nest-cli.json` file. As an example, if the `config` folder is at the same level as the `src` folder, add `compilerOptions#assets` with the value `"assets": [{{ '{' }}"include": "../config/*.yaml","outDir": "./dist/config"{{ '}' }}]`. Read more [here](/cli/monorepo#assets).
+> warning **Note** Nest CLI does not automatically move your "assets" (non-TS files) to the `dist` folder during the build process. To make sure that your YAML files are copied, you have to specify this in the `compilerOptions#assets` object in the `nest-cli.json` file. As an example, if the `config` folder is at the same level as the `src` folder, add `compilerOptions#assets` with the value `"assets": [{{ '{' }}"include": "../config/*.yaml", "outDir": "./dist/config"{{ '}' }}]`. Read more [here](/cli/monorepo#assets).
 
 <app-banner-enterprise></app-banner-enterprise>
 

--- a/content/techniques/configuration.md
+++ b/content/techniques/configuration.md
@@ -116,7 +116,7 @@ export class AppModule {}
 
 > info **Notice** The value assigned to the `load` property is an array, allowing you to load multiple configuration files (e.g. `load: [databaseConfig, authConfig]`)
 
-With custom configuration files, we can also manage custom files such as files. Here is an example of a configuration using YAML format:
+With custom configuration files, we can also manage custom files such as YAML files. Here is an example of a configuration using YAML format:
 
 ```yaml
 http:

--- a/content/techniques/configuration.md
+++ b/content/techniques/configuration.md
@@ -157,7 +157,6 @@ export default () => {
 };
 ```
 
-
 > warning **Note** Nest CLI does not automatically move your "assets" (non-TS files) to the `dist` folder during the build process. To make sure that your YAML files are copied, you have to specify this in the `compilerOptions#assets` object in the `nest-cli.json` file. As an example, if the `config` folder is at the same level as the `src` folder, add `compilerOptions#assets` with the value `"assets": [{{ '{' }}"include": "../config/*.yaml", "outDir": "./dist/config"{{ '}' }}]`. Read more [here](/cli/monorepo#assets).
 
 <app-banner-enterprise></app-banner-enterprise>

--- a/content/techniques/configuration.md
+++ b/content/techniques/configuration.md
@@ -116,7 +116,8 @@ export class AppModule {}
 
 > info **Notice** The value assigned to the `load` property is an array, allowing you to load multiple configuration files (e.g. `load: [databaseConfig, authConfig]`)
 
-With custom configuration files, we can also manage custom files such as YAML files. Here is an example of a configuration using YAML format:
+With custom configuration files, we can also manage custom files such as 
+files. Here is an example of a configuration using YAML format:
 
 ```yaml
 http:
@@ -158,7 +159,7 @@ export default () => {
 ```
 
 
-> warning **Note** Nest CLI does not automatically move your "assets" (non-TS files) to the `dist` folder during the build process. To make sure that your YAML files are copied, you have to specify this in `compilerOptions#assets` in the `nest-cli.json` file. As an example, if the `config` folder is at the same level as the `src` folder, add `compilerOptions#assets` with the value `"assets": [{"include": "../config/*.yaml","outDir": "./dist/config"}]`. Read more [here](/cli/monorepo#assets).
+> warning **Note** Nest CLI does not automatically move your "assets" (non-TS files) to the `dist` folder during the build process. To make sure that your YAML files are copied, you have to specify this in `compilerOptions#assets` in the `nest-cli.json` file. As an example, if the `config` folder is at the same level as the `src` folder, add `compilerOptions#assets` with the value `"assets": [{{ '{' }}"include": "../config/*.yaml","outDir": "./dist/config"{{ '}' }}]`. Read more [here](/cli/monorepo#assets).
 
 <app-banner-enterprise></app-banner-enterprise>
 

--- a/content/techniques/configuration.md
+++ b/content/techniques/configuration.md
@@ -116,8 +116,7 @@ export class AppModule {}
 
 > info **Notice** The value assigned to the `load` property is an array, allowing you to load multiple configuration files (e.g. `load: [databaseConfig, authConfig]`)
 
-With custom configuration files, we can also manage custom files such as 
-files. Here is an example of a configuration using YAML format:
+With custom configuration files, we can also manage custom files such as files. Here is an example of a configuration using YAML format:
 
 ```yaml
 http:

--- a/content/techniques/configuration.md
+++ b/content/techniques/configuration.md
@@ -157,7 +157,49 @@ export default () => {
 };
 ```
 
-> warning **Note** Nest CLI does not automatically move your "assets" (non-TS files) to the `dist` folder during the build process. To make sure that your YAML files are being moved as part of the compilation, add `compilerOptions#assets` to the `nest-cli.json` configuration file (`"assets": ["**/*.yml"]`). Read more [here](/cli/monorepo#assets).
+
+> warning **Note** Nest CLI does not automatically move your "assets" (non-TS files) to the `dist` folder during the build process. To make sure that your YAML files are copied, you have to specify this in the 'nest-cli.json' file. You can find an example below:
+
+Here is an example, how your folder structure may look like:
+```bash
+.eslintrc.js
+│   .gitignore
+│   .prettierrc
+│   nest-cli.json
+│   package-lock.json
+│   package.json
+│   README.md
+│   tsconfig.build.json
+│   tsconfig.json
+│
+├───config
+│       config.yaml
+│       configuration.ts
+│
+├───dist
+├───node_modules
+└───src
+        app.controller.ts
+        app.module.ts
+        main.ts
+```
+The paths of the assets have to be relative to "sourceRoot" in 'nest-cli.json'. Because config is in the same directory as src, "include" has to go a directory up. "outDir" defines, where the assets are copied to. Your nest-cli.json file might then look like this:
+```json
+{
+  "collection": "@nestjs/schematics",
+  "sourceRoot": "src",
+  "compilerOptions": {
+    "assets": [
+      {
+        "include": "../config/*.yaml",
+        "outDir": "./dist/config"
+      }
+    ]
+  }
+}
+```
+
+Read more about "assets" [here](/cli/monorepo#assets).
 
 <app-banner-enterprise></app-banner-enterprise>
 


### PR DESCRIPTION
docs: improved section about using a config.yaml

Regarding the  [documentation about configuration](https://docs.nestjs.com/techniques/configuration#custom-configuration-files):
An instruction is given about how to use a YAML file as config file. However, the section about configuring the 'nest-cli.json' to include the config.yaml in the dist is wrong/to vague.
I included a more clear explanation of how to make the 'nest-cli.json' work (tribute to jmcdo29 to figuring it out)


## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[X] Docs
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

The instruction was unclear/wrong


## What is the new behavior?

There's a correct, more explicit instruction (I can provide a repo with a working example)


## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```


## Other information
