### PR TITLE
docs(websockets): Add socket io version warning

### DIFF
--- a/content/websockets/gateways.md
+++ b/content/websockets/gateways.md
@@ -20,6 +20,8 @@ $ npm i --save-dev @types/socket.io
 $ npm i --save @nestjs/websockets @nestjs/platform-socket.io
 ```
 
+> warning **Warning** `@nestjs/platform-socket.io` currently depends on socket.io v2.3 and socket.io v3.0 client and server are not backwards compatible. However, can implement a custom adapter to use socket.io v3.0. Please refer to [this issue](https://github.com/nestjs/nest/issues/5676) for further information.
+
 #### Overview
 
 In general, each gateway is listening on the same port as the **HTTP server**, unless your app is not a web application, or you have changed the port manually. This default behavior can be modified by passing an argument to the `@WebSocketGateway(80)` decorator where `80` is a chosen port number. You can also set a [namespace](https://socket.io/docs/rooms-and-namespaces/) used by the gateway using the following construction:

--- a/content/websockets/gateways.md
+++ b/content/websockets/gateways.md
@@ -20,7 +20,7 @@ $ npm i --save-dev @types/socket.io
 $ npm i --save @nestjs/websockets @nestjs/platform-socket.io
 ```
 
-> warning **Warning** `@nestjs/platform-socket.io` currently depends on socket.io v2.3 and socket.io v3.0 client and server are not backwards compatible. However, can implement a custom adapter to use socket.io v3.0. Please refer to [this issue](https://github.com/nestjs/nest/issues/5676) for further information.
+> warning **Warning** `@nestjs/platform-socket.io` currently depends on socket.io v2.3 and socket.io v3.0 client and server are not backward compatible. However, you can still implement a custom adapter to use socket.io v3.0. Please refer to [this issue](https://github.com/nestjs/nest/issues/5676) for further information.
 
 #### Overview
 


### PR DESCRIPTION
Added warning about @nestjs/platform-socket.io depending on socket.io v2.3

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[X] Docs
[ ] Other... Please describe:
```

## What is the current behavior?
Issue Number: nestjs/nest/issues/5676


## What is the new behavior?
N/A

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

## Other information
