### PR TITLE
docs: corrected snippet about yaml config file

### DIFF
--- a/content/techniques/configuration.md
+++ b/content/techniques/configuration.md
@@ -151,9 +151,10 @@ import { join } from 'path';
 const YAML_CONFIG_FILENAME = 'config.yml';
 
 export default () => {
-  return yaml.load(
-    fs.readFileSync(join(__dirname, YAML_CONFIG_FILENAME), 'utf8'),
-  );
+  return (<object>
+    yaml.load(
+      readFileSync(join(__dirname, YAML_CONFIG_FILENAME), 'utf8'),
+    ));
 };
 ```
 

--- a/content/techniques/configuration.md
+++ b/content/techniques/configuration.md
@@ -151,10 +151,9 @@ import { join } from 'path';
 const YAML_CONFIG_FILENAME = 'config.yml';
 
 export default () => {
-  return (<Record<string,string>>
-    yaml.load(
-      readFileSync(join(__dirname, YAML_CONFIG_FILENAME), 'utf8'),
-    ));
+  return yaml.load(
+    readFileSync(join(__dirname, YAML_CONFIG_FILENAME), 'utf8'),
+  )) as Record<string, any>;
 };
 ```
 

--- a/content/techniques/configuration.md
+++ b/content/techniques/configuration.md
@@ -151,7 +151,7 @@ import { join } from 'path';
 const YAML_CONFIG_FILENAME = 'config.yml';
 
 export default () => {
-  return (<object>
+  return (<Record<string,string>>
     yaml.load(
       readFileSync(join(__dirname, YAML_CONFIG_FILENAME), 'utf8'),
     ));


### PR DESCRIPTION
docs: corrected snippet about yaml config file

1. readFileSync is imported, not fs
2. in order to be loadable by the ConfigModule, the cast to an object was added

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[X] Docs
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The snippet for a configuration.ts is not working when used.

Issue Number: N/A


## What is the new behavior?

The new snippet works, as demonstrated [here](https://github.com/DonnerWolfBach/nestjs_fixed-yaml-config-doku-test/blob/main/working-yaml-config/config/configuration.ts)


## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

There's another error/inaccuracy in the docs directly below, but that is dealt with in another pull request.
