### PR TITLE
docs(testing): including configuration service

### DIFF
--- a/content/fundamentals/unit-testing.md
+++ b/content/fundamentals/unit-testing.md
@@ -156,35 +156,7 @@ catsService = await moduleRef.resolve(CatsService);
 
 > info **Hint** Learn more about the module reference features [here](/fundamentals/module-ref).
 
-Instead of using the production version of any provider, you can override it with a [custom provider](/fundamentals/custom-providers) for testing purposes. For example, you can mock a database service instead of connecting to a live database. We'll cover overrides in the [End-to-end testing](#end-to-end-testing) section, but they're available for unit tests as well.
-
-##### Configuration Service
-
-Similar to utilizing production versions of the `CatsController` and `CatsService` above, it is also possible to utilize the production version of the [Configuration Module](https://docs.nestjs.com/techniques/configuration#configuration) if it is installed, rather than overriding it with a custom provider. In the following example we import it into our module and then retrieve the static instance, assigning it to a `configService` variable that can be used in our tests.
-
-```typescript
-@@filename(cats.controller.spec)
-import { Test } from '@nestjs/testing';
-import { ConfigModule, ConfigService } from '@nestjs/config';
-import { CatsController } from './cats.controller';
-import { CatsService } from './cats.service';
-
-describe('CatsController', () => {
-    let controller: CatsController;
-    let configService: ConfigService;
-
-    beforeEach(async () => {
-        const moduleRef = await Test.createTestingModule({
-            imports: [ConfigModule.forRoot()],
-            controllers: [CatsController],
-            providers: [CatsService],
-        }).compile();
-
-        controller = moduleRef.get<CatsController>(CatsController);
-        configService = moduleRef.get<ConfigService>(ConfigService);
-    });
-});
-```
+Instead of using the production version of any provider, you can override it with a [custom provider](/fundamentals/custom-providers) for testing purposes. For example, you can mock a database service instead of connecting to a live database. We'll cover overrides in the next section, but they're available for unit tests as well.
 
 <app-banner-courses></app-banner-courses>
 

--- a/content/fundamentals/unit-testing.md
+++ b/content/fundamentals/unit-testing.md
@@ -156,7 +156,35 @@ catsService = await moduleRef.resolve(CatsService);
 
 > info **Hint** Learn more about the module reference features [here](/fundamentals/module-ref).
 
-Instead of using the production version of any provider, you can override it with a [custom provider](/fundamentals/custom-providers) for testing purposes. For example, you can mock a database service instead of connecting to a live database. We'll cover overrides in the next section, but they're available for unit tests as well.
+Instead of using the production version of any provider, you can override it with a [custom provider](/fundamentals/custom-providers) for testing purposes. For example, you can mock a database service instead of connecting to a live database. We'll cover overrides in the [End-to-end testing](#end-to-end-testing) section, but they're available for unit tests as well.
+
+##### Configuration Service
+
+Similar to utilizing production versions of the `CatsController` and `CatsService` above, it is also possible to utilize the production version of the [Configuration Module](https://docs.nestjs.com/techniques/configuration#configuration) if it is installed, rather than overriding it with a custom provider. In the following example we import it into our module and then retrieve the static instance, assigning it to a `configService` variable that can be used in our tests.
+
+```typescript
+@@filename(cats.controller.spec)
+import { Test } from '@nestjs/testing';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { CatsController } from './cats.controller';
+import { CatsService } from './cats.service';
+
+describe('CatsController', () => {
+    let controller: CatsController;
+    let configService: ConfigService;
+
+    beforeEach(async () => {
+        const moduleRef = await Test.createTestingModule({
+            imports: [ConfigModule.forRoot()],
+            controllers: [CatsController],
+            providers: [CatsService],
+        }).compile();
+
+        controller = moduleRef.get<CatsController>(CatsController);
+        configService = moduleRef.get<ConfigService>(ConfigService);
+    });
+});
+```
 
 <app-banner-courses></app-banner-courses>
 

--- a/content/techniques/configuration.md
+++ b/content/techniques/configuration.md
@@ -535,3 +535,31 @@ You can then use it as usual, by calling the `get` method with the configuration
 ```typescript
 const port = configService.get('PORT');
 ```
+
+### Using in testing
+
+It is also possible to utilize the Configuration Service in testing. In the following example we import it into our module and then retrieve the static instance, assigning it to a `configService` variable that can be used in our tests.
+
+```typescript
+@@filename(cats.controller.spec)
+import { Test } from '@nestjs/testing';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { CatsController } from './cats.controller';
+import { CatsService } from './cats.service';
+
+describe('CatsController', () => {
+    let controller: CatsController;
+    let configService: ConfigService;
+
+    beforeEach(async () => {
+        const moduleRef = await Test.createTestingModule({
+            imports: [ConfigModule.forRoot()],
+            controllers: [CatsController],
+            providers: [CatsService],
+        }).compile();
+
+        controller = moduleRef.get<CatsController>(CatsController);
+        configService = moduleRef.get<ConfigService>(ConfigService);
+    });
+});
+```

--- a/content/techniques/configuration.md
+++ b/content/techniques/configuration.md
@@ -536,7 +536,7 @@ You can then use it as usual, by calling the `get` method with the configuration
 const port = configService.get('PORT');
 ```
 
-### Using in testing
+### Using in e2e/integration tests
 
 It is also possible to utilize the Configuration Service in testing. In the following example we import it into our module and then retrieve the static instance, assigning it to a `configService` variable that can be used in our tests.
 


### PR DESCRIPTION
Update testing documentation to contain instructions for using the config service

Resolves #1640

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] Docs
[ ] Other... Please describe:
```

## What is the current behavior?
There currently aren't any instructions for utilising the Configuration Service during testing. 

Issue Number: 1640


## What is the new behavior?
I updated the Testing documentation to contain instructions on how to access the Configuration Service within a test. 

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
