### PR TITLE
docs(graphql): Fix union name typo

### DIFF
--- a/content/graphql/unions-and-enums.md
+++ b/content/graphql/unions-and-enums.md
@@ -28,11 +28,11 @@ export class Author {
 }
 ```
 
-With this in place, register the `Result` union using the `createUnionType` function exported from the `@nestjs/graphql` package:
+With this in place, register the `ResultUnion` union using the `createUnionType` function exported from the `@nestjs/graphql` package:
 
 ```typescript
 export const ResultUnion = createUnionType({
-  name: 'Result',
+  name: 'ResultUnion',
   types: () => [Author, Book],
 });
 ```
@@ -70,7 +70,7 @@ To provide a customized `resolveType()` function, pass the `resolveType` propert
 
 ```typescript
 export const ResultUnion = createUnionType({
-  name: 'Result',
+  name: 'ResultUnion',
   types: () => [Author, Book],
   resolveType(value) {
     if (value.name) {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] Docs
[ ] Other... Please describe:
```

## What is the current behavior?

The name doesn't match the example output.

## What is the new behavior?

It does. 😄 