### PR TITLE
docs: corrected snippet for options by removing the extra round brace at the end

### DIFF
--- a/content/openapi/introduction.md
+++ b/content/openapi/introduction.md
@@ -129,7 +129,7 @@ const options: SwaggerDocumentOptions =  {
     controllerKey: string,
     methodKey: string
   ) => methodKey
-});
+};
 const document = SwaggerModule.createDocument(app, config, options);
 ```
 


### PR DESCRIPTION
docs: corrected snippet for the options constant in the openapi introduction.md file.

- **contains an extra round bracket '**)**'.**

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] Docs
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The snippet for generating operation names like `createUser` instead of `UserController_createUser` does not work.

![image](https://user-images.githubusercontent.com/31963345/106186205-f3b55480-61c9-11eb-899f-d395e3af8235.png)

![image](https://user-images.githubusercontent.com/31963345/106187090-290e7200-61cb-11eb-8d30-cd62b47881f2.png)


Issue Number: N/A


## What is the new behavior?

![image](https://user-images.githubusercontent.com/31963345/106186242-0596f780-61ca-11eb-8d0d-ff4f9739a179.png)

removing the round bracket solved the syntax error  

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
