### PR TITLE
docs : added the missing import for CatsModule in other-features.md of the openapi

### DIFF
--- a/content/openapi/other-features.md
+++ b/content/openapi/other-features.md
@@ -22,6 +22,7 @@ You can setup multiple specifications support as shown below:
 import { NestFactory } from '@nestjs/core';
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 import { AppModule } from './app.module';
+import { CatsModule } from './cats/cats.module';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);


### PR DESCRIPTION
docs: corrected snippet for openapi other-features.md file.
- The current snippet is missing the import for the CatsModule

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] Docs
[ ] Other... Please describe:
```

## What is the current behavior?
![image](https://user-images.githubusercontent.com/31963345/106276605-d8942480-625d-11eb-94e9-b697501ac06c.png)
the above line I missing. This would lead to the following error
![image](https://user-images.githubusercontent.com/31963345/106276839-2872eb80-625e-11eb-880c-830966c69f46.png)
 ```
   Cannot find name 'CatsModule'.ts(2304)
 ```

Issue Number: N/A


## What is the new behavior?
Added the import for CatsModule

![image](https://user-images.githubusercontent.com/31963345/106276605-d8942480-625d-11eb-94e9-b697501ac06c.png)
solving the error 

 ```
    Cannot find name 'CatsModule'.ts(2304)
 ```

![image](https://user-images.githubusercontent.com/31963345/106277184-ac2cd800-625e-11eb-9157-9a0ccc466017.png)


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
