### PR TITLE
docs: Prisma 2 CLI renamed from `@prisma/cli` to `prisma`

### DIFF
--- a/content/recipes/prisma.md
+++ b/content/recipes/prisma.md
@@ -32,7 +32,7 @@ Start by installing the Prisma CLI as a development dependency in your project:
 
 ```bash
 $ cd hello-prisma
-$ npm install @prisma/cli --save-dev
+$ npm install prisma --save-dev
 ```
 
 In the following steps, we'll be utilizing the [Prisma CLI](https://www.prisma.io/docs/reference/tools-and-interfaces/prisma-cli). As a best practice, it's recommended to invoke the CLI locally by prefixing it with `npx`:
@@ -46,7 +46,7 @@ $ npx prisma
 If you're using Yarn, then you can install the Prisma CLI as follows:
 
 ```bash
-$ yarn add @prisma/cli --dev
+$ yarn add prisma --dev
 ```
 
 Once installed, you can invoke it by prefixing it with `yarn`:


### PR DESCRIPTION
## Description

Prisma 2 CLI renamed from `@prisma/cli` to `prisma`

Ref: https://www.prisma.io/docs/guides/upgrade-guides/upgrade-from-prisma-1/upgrading-the-prisma-layer-mysql

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] Docs
[ ] Other... Please describe:
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
