### PR TITLE
`PostModel` should reference to `author` instead of `User`

### DIFF
--- a/content/recipes/prisma.md
+++ b/content/recipes/prisma.md
@@ -462,7 +462,7 @@ export class AppController {
     return this.postService.createPost({
       title,
       content,
-      User: {
+      author: {
         connect: { email: authorEmail },
       },
     });


### PR DESCRIPTION
## Description

`PostModel` should reference to `author` instead of `User`.

```js
TS2345: Argument of type '{ title: string; content: string; User: { connect: { email: string; }; }; }' is not assignable to parameter of type 'PostCreateInput'.   Object literal may only specify known properties, and 'User' does not exist in type 'PostCreateInput'.
```

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] Docs
[ ] Other... Please describe:
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
