### PR TITLE
Remove DNSHealthIndicator

### DIFF
--- a/content/recipes/terminus.md
+++ b/content/recipes/terminus.md
@@ -22,7 +22,7 @@ $ npm install --save @nestjs/terminus
 
 A health check represents a summary of **health indicators**. A health indicator executes a check of a service, whether it is in a healthy or unhealthy state. A health check is positive if all the assigned health indicators are up and running. Because a lot of applications will need similar health indicators, [@nestjs/terminus](https://github.com/nestjs/terminus) provides a set of predefined indicators, such as:
 
-- `DNSHealthIndicator`
+- `HttpHealthIndicator`
 - `TypeOrmHealthIndicator`
 - `MongooseHealthIndicator`
 - `MicroserviceHealthIndicator`
@@ -62,7 +62,7 @@ Once we have installed `@nestjs/terminus`, imported our `TerminusModule` and cre
 export class HealthController {
   constructor(
     private health: HealthCheckService,
-    private dns: DNSHealthIndicator,
+    private dns: HttpHealthIndicator,
   ) {}
 
   @Get()
@@ -75,7 +75,7 @@ export class HealthController {
 }
 @@switch
 @Controller('health')
-@Dependencies(HealthCheckService, DNSHealthIndicator)
+@Dependencies(HealthCheckService, HttpHealthIndicator)
 export class HealthController {
   constructor(
     private health,


### PR DESCRIPTION
DNSHealthIndicator is depreciated but still in the documentation.

So, following the warning message, I replace it !

```
Warning: DNSHealthIndicator has been deprecated.
Simply search and replace "DNSHealthIndicator" with "HttpHealthIndicator" in order to ugprade. DNSHealthIndicator will be removed in version 8.x.x
```