### PR TITLE
docs(testing): fix wrong documentation for fastify e2e tests

### DIFF
--- a/content/fundamentals/unit-testing.md
+++ b/content/fundamentals/unit-testing.md
@@ -239,7 +239,7 @@ describe('Cats', () => {
 });
 ```
 
-> info **Hint** If you're using [Fastify](/techniques/performance) as your HTTP adapter, it requires slightly different configuration, and has build-in testing capabilities:
+> info **Hint** If you're using [Fastify](/techniques/performance) as your HTTP adapter, it requires a slightly different configuration, and has built-in testing capabilities:
 >
 > ```ts
 > let app: NestFastifyApplication;

--- a/content/fundamentals/unit-testing.md
+++ b/content/fundamentals/unit-testing.md
@@ -260,7 +260,7 @@ describe('Cats', () => {
 >       url: '/cats'
 >     }).then(result => {
 >       expect(result.statusCode).to.be.eql(200)
->       expect(result.payload).to.be.eql('up')
+>       expect(result.payload).to.be.eql(/* expectedPayload */)
 >     });
 > })
 > ```

--- a/content/fundamentals/unit-testing.md
+++ b/content/fundamentals/unit-testing.md
@@ -260,7 +260,7 @@ describe('Cats', () => {
 >       url: '/cats'
 >     }).then(result => {
 >       expect(result.statusCode).toEqual(200)
->       expect(result.payload).to.be.eql(/* expectedPayload */)
+>       expect(result.payload).toEqual(/* expectedPayload */)
 >     });
 > })
 > ```

--- a/content/fundamentals/unit-testing.md
+++ b/content/fundamentals/unit-testing.md
@@ -239,15 +239,30 @@ describe('Cats', () => {
 });
 ```
 
-> info **Hint** If you're using [Fastify](/techniques/performance) as your HTTP adapter, it requires slightly different configuration:
+> info **Hint** If you're using [Fastify](/techniques/performance) as your HTTP adapter, it requires slightly different configuration, and has build-in testing capabilities:
 >
 > ```ts
-> app = moduleRef.createNestApplication<NestFastifyApplication>(
->   new FastifyAdapter(),
-> );
+> let app: NestFastifyApplication;
+> 
+> beforeAll(async () => {
+>   app = moduleRef.createNestApplication<NestFastifyApplication>(
+>     new FastifyAdapter(),
+>   );
 >
-> await app.init();
-> await app.getHttpAdapter().getInstance().ready();
+>   await app.init();
+>   await app.getHttpAdapter().getInstance().ready();
+> })
+> 
+> it(`/GET cats`, () => {
+>   return app
+>     .inject({
+>       method: 'GET',
+>       url: '/cats'
+>     }).then(result => {
+>       expect(result.statusCode).to.be.eql(200)
+>       expect(result.payload).to.be.eql('up')
+>     });
+> })
 > ```
 
 In this example, we build on some of the concepts described earlier. In addition to the `compile()` method we used earlier, we now use the `createNestApplication()` method to instantiate a full Nest runtime environment. We save a reference to the running app in our `app` variable so we can use it to simulate HTTP requests.

--- a/content/fundamentals/unit-testing.md
+++ b/content/fundamentals/unit-testing.md
@@ -259,7 +259,7 @@ describe('Cats', () => {
 >       method: 'GET',
 >       url: '/cats'
 >     }).then(result => {
->       expect(result.statusCode).to.be.eql(200)
+>       expect(result.statusCode).toEqual(200)
 >       expect(result.payload).to.be.eql(/* expectedPayload */)
 >     });
 > })


### PR DESCRIPTION
Demonstrate using Fastify's .inject method, instead of supertest, which only works for Express.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] Docs
[ ] Other... Please describe:
```

## What is the current behavior?
e2e test code in the docs does not work when using fastify

## What is the new behavior?
the correct way to write e2e tests for fastify is documented

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
