### PR TITLE
docs: remove graphql schema file name from SDL

### DIFF
--- a/content/graphql/resolvers-map.md
+++ b/content/graphql/resolvers-map.md
@@ -120,7 +120,6 @@ export class Post {
 The `Post` object type will result in generating the following part of the GraphQL schema in SDL:
 
 ```graphql
-@@filename(schema.gql)
 type Post {
   id: Int!
   title: String!


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] Docs
[x] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

https://docs.nestjs.com/graphql/resolvers#object-types

![image](https://user-images.githubusercontent.com/48552260/107896002-84d14d00-6f78-11eb-893c-799ed7ca8b47.png)
In capture image, SDL example's file name is "schema.gql.ts". I think SDL is not ".ts" file extension. 

Additionally, in the above example, as below image doesn't have file name.
![image](https://user-images.githubusercontent.com/48552260/107896176-e7c2e400-6f78-11eb-8555-283074774e3c.png)

Also, as below image, markdown code block's language is graphql.

![image](https://user-images.githubusercontent.com/48552260/107896531-dd551a00-6f79-11eb-8e37-245676f2cb36.png)


This PR, remove graphql schema file name from SDL.



