### PR TITLE
mapped-types imports were misleading

### DIFF
--- a/content/openapi/mapped-types.md
+++ b/content/openapi/mapped-types.md
@@ -31,7 +31,7 @@ By default, all of these fields are required. To create a type with the same fie
 export class UpdateCatDto extends PartialType(CreateCatDto) {}
 ```
 
-> info **Hint** The `PartialType()` function is imported from the `@nestjs/swagger` package.
+> info **Hint** The `PartialType()` function is imported from the `@nestjs/mapped-types` package.
 
 #### Pick
 
@@ -58,7 +58,7 @@ We can pick a set of properties from this class using the `PickType()` utility f
 export class UpdateCatAgeDto extends PickType(CreateCatDto, ['age'] as const) {}
 ```
 
-> info **Hint** The `PickType()` function is imported from the `@nestjs/swagger` package.
+> info **Hint** The `PickType()` function is imported from the `@nestjs/mapped-types` package.
 
 #### Omit
 
@@ -85,7 +85,7 @@ We can generate a derived type that has every property **except** `name` as show
 export class UpdateCatDto extends OmitType(CreateCatDto, ['name'] as const) {}
 ```
 
-> info **Hint** The `OmitType()` function is imported from the `@nestjs/swagger` package.
+> info **Hint** The `OmitType()` function is imported from the `@nestjs/mapped-types` package.
 
 #### Intersection
 
@@ -117,7 +117,7 @@ export class UpdateCatDto extends IntersectionType(
 ) {}
 ```
 
-> info **Hint** The `IntersectionType()` function is imported from the `@nestjs/swagger` package.
+> info **Hint** The `IntersectionType()` function is imported from the `@nestjs/mapped-types` package.
 
 #### Composition
 


### PR DESCRIPTION
Maybe for swagger the imports are working (i dont know), but for using with validation pipe it was not:

```
export class UpdateUserDto extends PartialType(UserDto) {}
```

Or at least the documentation is kind of misleading because for me it seemed like this page is for how to write a CRUD controller.

Further the types from `@nestjs/mapped-types` should be documented within https://docs.nestjs.com/techniques/validation imo. Actually https://docs.nestjs.com/openapi/mapped-types should be copied nearly 1to1 to https://docs.nestjs.com/techniques/validation?

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[X] Docs
[ ] Other... Please describe:
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```
