### PR TITLE
docs(rate-limiting): fix graphql code snippet bugs

### DIFF
--- a/content/security/rate-limiting.md
+++ b/content/security/rate-limiting.md
@@ -71,8 +71,8 @@ The `ThrottlerGuard` can also be used to work with GraphQL requests. Again, the 
 export class GqlThrottlerGuard extends ThrottlerGuard {
   getRequestResponse(context: ExecutionContext) {
     const gqlCtx = GqlExecutionContext.create(context);
-    const ctx = gql.getContext();
-    return { req, ctx.req, res: ctx.res }
+    const ctx = gqlCtx.getContext();
+    return { req: ctx.req, res: ctx.res }
   }
 }
 ```


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ X ] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ X ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Docs
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Small bugs that I found at the graphql rate-limiting code snippet.
'gql' should be 'gqlCtx'  and 'req, ctx.req,' shoud be ' req: ctx.req' 

![image](https://user-images.githubusercontent.com/44275480/110294134-212ac480-7ff8-11eb-8f5e-951ea8bc0805.png)

Issue Number: N/A


## What is the new behavior?
Replace 'gql' with 'gqlCtx' and 'req, ctx.req' with 'req: ctx.req'


## Does this PR introduce a breaking change?
```
[ ] Yes
[ X ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
