### PR TITLE
doc(graphql/federation): add users resolver in posts service

### DIFF
--- a/content/graphql/federation.md
+++ b/content/graphql/federation.md
@@ -185,12 +185,30 @@ export class PostsResolvers {
 }
 ```
 
-The Posts service has virtually the same module, but is included below for the sake of completeness:
+In order to fill in the `posts` fields added to our `User` schema, we need to add a `users.resolver.ts` in our Post service.
+
+```typescript
+import { ResolveField, Resolver } from '@nestjs/graphql';
+import { PostsService } from './posts.service';
+
+@Resolver('User')
+export class UsersResolvers {
+  constructor(private postsService: PostsService) {}
+
+  @ResolveField('posts')
+  getPosts(reference: { __typename: string; id: string }) {
+    return this.postsService.findByAuthorId(reference.id);
+  }
+}
+```
+
+The Posts service needs to export both resolvers as providers in its module definition:
 
 ```typescript
 import { Module } from '@nestjs/common';
 import { GraphQLFederationModule } from '@nestjs/graphql';
 import { PostsResolvers } from './posts.resolvers';
+import { UsersResolvers } from './users.resolvers';
 
 @Module({
   imports: [
@@ -198,7 +216,7 @@ import { PostsResolvers } from './posts.resolvers';
       typePaths: ['**/*.graphql'],
     }),
   ],
-  providers: [PostsResolvers],
+  providers: [PostsResolvers, UsersResolvers],
 })
 export class AppModule {}
 ```


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] Docs
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?

In order to make the example match the *Code First* example there is a missing piece in
the *Schema First* one regarding the fetching of the `posts` authored by the `user`.
This PR adds the missing code snippet to address this in a similar fashion as the [`graphql-federation test`](https://github.com/nestjs/graphql/tree/master/tests/graphql-federation) exhibit.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
