### PR TITLE
Update nats.md

### DIFF
--- a/content/microservices/nats.md
+++ b/content/microservices/nats.md
@@ -7,7 +7,7 @@
 To start building NATS-based microservices, first install the required package:
 
 ```bash
-$ npm i --save nats
+$ npm i --save nats@^1.4.12
 ```
 
 #### Overview


### PR DESCRIPTION
nats.js 2.0 has been released and is not compatible with pervious version. To use NATS with Nest.js nats.js 1.x needs to be installed.
