### PR TITLE
Update helmet.md

### DIFF
--- a/content/security/helmet.md
+++ b/content/security/helmet.md
@@ -17,7 +17,7 @@ Once the installation is complete, apply it as a global middleware.
 ```typescript
 import * as helmet from 'helmet';
 // somewhere in your initialization file
-app.use(helmet());
+await app.use(helmet());
 ```
 
 > info **Hint** If you are getting the `This expression is not callable` error while trying to import `Helmet`, you very likely have the `allowSyntheticDefaultImports` and `esModuleInterop` options set to `true` in your project's `tsconfig.json` file. If that's the case, change the import statement to: `import helmet from 'helmet'` instead.
@@ -35,12 +35,12 @@ $ npm i --save fastify-helmet
 ```typescript
 import { fastifyHelmet } from 'fastify-helmet';
 // somewhere in your initialization file
-app.register(helmet);
+await app.register(helmet);
 ```
 > warning **Warning** When using `apollo-server-fastify` and `fastify-helmet`, there may be a problem with [CSP](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) on the GraphQL playground, to solve this collision, configure the CSP as shown below:
 >
 > ```typescript
-> app.register(helmet, {
+> await app.register(helmet, {
 >   contentSecurityPolicy: {
 >     directives: {
 >       defaultSrc: [`'self'`],
@@ -53,7 +53,7 @@ app.register(helmet);
 > });
 >
 > // If you are not going to use CSP at all, you can use this:
-> app.register(helmet, {
+> await app.register(helmet, {
 >   contentSecurityPolicy: false,
 > });
 > ```

--- a/content/security/helmet.md
+++ b/content/security/helmet.md
@@ -33,7 +33,7 @@ $ npm i --save fastify-helmet
 [fastify-helmet](https://github.com/fastify/fastify-helmet) should not be used as a middleware, but as a [Fastify plugin](https://www.fastify.io/docs/latest/Plugins/), i.e., by using `app.register()`:
 
 ```typescript
-import * as helmet from 'fastify-helmet';
+import { fastifyHelmet } from 'fastify-helmet';
 // somewhere in your initialization file
 app.register(helmet);
 ```

--- a/content/security/helmet.md
+++ b/content/security/helmet.md
@@ -17,7 +17,7 @@ Once the installation is complete, apply it as a global middleware.
 ```typescript
 import * as helmet from 'helmet';
 // somewhere in your initialization file
-await app.use(helmet());
+app.use(helmet());
 ```
 
 > info **Hint** If you are getting the `This expression is not callable` error while trying to import `Helmet`, you very likely have the `allowSyntheticDefaultImports` and `esModuleInterop` options set to `true` in your project's `tsconfig.json` file. If that's the case, change the import statement to: `import helmet from 'helmet'` instead.

--- a/content/security/helmet.md
+++ b/content/security/helmet.md
@@ -35,12 +35,12 @@ $ npm i --save fastify-helmet
 ```typescript
 import { fastifyHelmet } from 'fastify-helmet';
 // somewhere in your initialization file
-await app.register(helmet);
+await app.register(fastifyHelmet);
 ```
 > warning **Warning** When using `apollo-server-fastify` and `fastify-helmet`, there may be a problem with [CSP](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) on the GraphQL playground, to solve this collision, configure the CSP as shown below:
 >
 > ```typescript
-> await app.register(helmet, {
+> await app.register(fastifyHelmet, {
 >   contentSecurityPolicy: {
 >     directives: {
 >       defaultSrc: [`'self'`],
@@ -53,7 +53,7 @@ await app.register(helmet);
 > });
 >
 > // If you are not going to use CSP at all, you can use this:
-> await app.register(helmet, {
+> await app.register(fastifyHelmet, {
 >   contentSecurityPolicy: false,
 > });
 > ```


### PR DESCRIPTION
Old import was not working anymore, error:

> Argument of type 'typeof import("/.../node_modules/fastify-helmet/index")' is not assignable to parameter of type 'FastifyPluginCallback<any, Server> | FastifyPluginAsync<any, Server> | Promise<{ default: FastifyPluginCallback<any, Server>; }> | Promise<...>'.

Also I added an `await` since `.register()` returns a promise.

fastify-helmet: 5.3.0
helmet: 4.4.1
@nestjs/platform-fastify: 7.6.14 & 8.0.0-alpha.3