### PR TITLE
docs(prisma): Prisma Migrate entered GA and preview-feature flag is no longer needed

### DIFF
--- a/content/recipes/prisma.md
+++ b/content/recipes/prisma.md
@@ -180,10 +180,8 @@ model Post {
 With your Prisma models in place, you can generate your SQL migration files and run them against the database. Run the following commands in your terminal:
 
 ```bash
-$ npx prisma migrate dev --name init --preview-feature
+$ npx prisma migrate dev --name init
 ```
-
-> info **Note** The `prisma migrate` commands currently requires the `--preview-feature` option as it's in [Preview](https://www.prisma.io/docs/about/releases#preview).
 
 This `prisma migrate dev` command generates SQL files and directly runs them against the database. In this case, the following migration files was created in the existing `prisma` directory:
 


### PR DESCRIPTION
Prisma Migrate entered General Availability as of version 2.19.0. 

That means you no longer need to add `--preview-feature` flag when running `prisma migrate` commands.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] Docs
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

- [Prisma 2.19.0 Release](https://github.com/prisma/prisma/releases/tag/2.19.0)
- [Blog post about Prisma Migrate enters GA](https://www.prisma.io/blog/prisma-migrate-ga-b5eno5g08d0b)