### PR TITLE
docs(prisma): remove preview feature notice about prisma migrate

### DIFF
--- a/content/recipes/prisma.md
+++ b/content/recipes/prisma.md
@@ -180,10 +180,8 @@ model Post {
 With your Prisma models in place, you can generate your SQL migration files and run them against the database. Run the following commands in your terminal:
 
 ```bash
-$ npx prisma migrate dev --name init --preview-feature
+$ npx prisma migrate dev --name init
 ```
-
-> info **Note** The `prisma migrate` commands currently requires the `--preview-feature` option as it's in [Preview](https://www.prisma.io/docs/about/releases#preview).
 
 This `prisma migrate dev` command generates SQL files and directly runs them against the database. In this case, the following migration files was created in the existing `prisma` directory:
 


### PR DESCRIPTION
[Prisma Migrate is no longer a preview feature](https://www.prisma.io/blog/prisma-migrate-ga-b5eno5g08d0b#prisma-migrate-is-ready-for-use-in-production)