### PR TITLE
docs: Add ValidationPipe hint on not using `import type` for DTOs

### DIFF
--- a/content/techniques/validation.md
+++ b/content/techniques/validation.md
@@ -121,7 +121,7 @@ create(@Body() createUserDto: CreateUserDto) {
 
 > info **Hint** Since TypeScript does not store metadata about **generics or interfaces**, when you use them in your DTOs, `ValidationPipe` may not be able to properly validate incoming data.  For this reason, consider using concrete classes in your DTOs.
 
-> info **Hint** When importing your DTOs, you can't use a type-only import as that would be erased at Runtime, i.e. remember to `import { CreateUserDto }` instead of `import type { CreateUserDto }`.
+> info **Hint** When importing your DTOs, you can't use a type-only import as that would be erased at runtime, i.e. remember to `import {{ '{' }} CreateUserDto {{ '}' }}` instead of `import type {{ '{' }} CreateUserDto {{ '}' }}`.
 
 Now we can add a few validation rules in our `CreateUserDto`. We do this using decorators provided by the `class-validator` package, described in detail [here](https://github.com/typestack/class-validator#validation-decorators). In this fashion, any route that uses the `CreateUserDto` will automatically enforce these validation rules.
 

--- a/content/techniques/validation.md
+++ b/content/techniques/validation.md
@@ -121,6 +121,8 @@ create(@Body() createUserDto: CreateUserDto) {
 
 > info **Hint** Since TypeScript does not store metadata about **generics or interfaces**, when you use them in your DTOs, `ValidationPipe` may not be able to properly validate incoming data.  For this reason, consider using concrete classes in your DTOs.
 
+> info **Hint** When importing your DTOs, you can't use a type-only import as that would be erased at Runtime, i.e. remember to `import { CreateUserDto }` instead of `import type { CreateUserDto }`.
+
 Now we can add a few validation rules in our `CreateUserDto`. We do this using decorators provided by the `class-validator` package, described in detail [here](https://github.com/typestack/class-validator#validation-decorators). In this fashion, any route that uses the `CreateUserDto` will automatically enforce these validation rules.
 
 ```typescript


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[X] Docs
[ ] Other... Please describe:
```

## What is the current behavior?
Docs don't tell users that an `import type` on a DTO will result in ValidationPipe not running, since type only imports are erased at compilation time and thus can't be introspected.

Issue Number: N/A


## What is the new behavior?
Add a hint to the docs, warning users to avoid `import type` for DTOs. Developers should add tests to their controllers verifying input validation anyways, so it's OK (although not ideal) to keep the current behavior and just add a docs hint.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

## Other information
