### PR TITLE
docs(authorization): change authorId type from string to number

### DIFF
--- a/content/security/authorization.md
+++ b/content/security/authorization.md
@@ -193,7 +193,7 @@ class User {
 class Article {
   id: number;
   isPublished: boolean;
-  authorId: string;
+  authorId: number;
 }
 ```
 


### PR DESCRIPTION
change authorId type from string to number

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ x ] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] Docs
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Casl factory sample code doesn't work due ti Author.authorId and Iser.id type mismatch

Issue Number: N/A


## What is the new behavior?

Casl factory sample code works after change

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
