### PR TITLE
docs(microservices): fixed custom provider markdown link

### DIFF
--- a/content/microservices/basics.md
+++ b/content/microservices/basics.md
@@ -238,7 +238,7 @@ constructor(
 
 > info **Hint** The `ClientsModule` and `ClientProxy` classes are imported from the `@nestjs/microservices` package.
 
-At times we may need to fetch the transporter configuration from another service (say a `ConfigService`), rather than hard-coding it in our client application. To do this, we can register a [custom provider](/techniques/custom-providers) using the `ClientProxyFactory` class. This class has a static `create()` method, which accepts a transporter options object, and returns a customized `ClientProxy` instance.
+At times we may need to fetch the transporter configuration from another service (say a `ConfigService`), rather than hard-coding it in our client application. To do this, we can register a [custom provider](/fundamentals/custom-providers) using the `ClientProxyFactory` class. This class has a static `create()` method, which accepts a transporter options object, and returns a customized `ClientProxy` instance.
 
 ```typescript
 @Module({


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

```
[x] Docs
```

## What is the current behavior?
The link is invalid and redirects the user to the docs homepage.

## What is the new behavior?
Directs the user to the `Fundamentals > Custom providers` page.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```