### PR TITLE
Make it clear that the cache TTL is in seconds.

### DIFF
--- a/content/techniques/caching.md
+++ b/content/techniques/caching.md
@@ -52,7 +52,7 @@ await this.cacheManager.set('key', 'value');
 
 The default expiration time of the cache is 5 seconds.
 
-You can manually specify a TTL (expiration time) for this specific key, as follows:
+You can manually specify a TTL (expiration time in seconds) for this specific key, as follows:
 
 ```typescript
 await this.cacheManager.set('key', 'value', { ttl: 1000 });


### PR DESCRIPTION
I was a bit confused when I first read these docs what units the cache TTL is in. I expected milliseconds, and had to read the cache-manager docs to confirm.

Reference: https://www.npmjs.com/package/cache-manager

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ x] Docs
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[x ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
