### PR TITLE
Improper example codes.

### DIFF
--- a/content/application-context.md
+++ b/content/application-context.md
@@ -19,7 +19,7 @@ The standalone application object allows you to obtain a reference to any instan
 
 ```typescript
 @@filename()
-const app = await NestFactory.create(AppModule);
+const app = await NestFactory.createApplicationContext(AppModule);
 const tasksService = app.get(TasksService);
 ```
 
@@ -27,7 +27,7 @@ To access the `TasksService` instance we use the `get()` method. The `get()` met
 
 ```typescript
 @@filename()
-const app = await NestFactory.create(AppModule);
+const app = await NestFactory.createApplicationContext(AppModule);
 const tasksService = app.select(TasksModule).get(TasksService, { strict: true });
 ```
 


### PR DESCRIPTION
Since the doc is about *Standalone applications*, it's more accurate to use `createApplicationContext()` method.


## PR Type

[x] Docs

## Does this PR introduce a breaking change?

[x] No
