### PR TITLE
docs(caching): update docs for disabling cache expiration

### DIFF
--- a/content/techniques/caching.md
+++ b/content/techniques/caching.md
@@ -58,10 +58,10 @@ You can manually specify a TTL (expiration time) for this specific key, as follo
 await this.cacheManager.set('key', 'value', { ttl: 1000 });
 ```
 
-To disable expiration of the cache, set the `ttl` configuration property to `null`:
+To disable expiration of the cache, set the `ttl` configuration property to `0`:
 
 ```typescript
-await this.cacheManager.set('key', 'value', { ttl: null });
+await this.cacheManager.set('key', 'value', { ttl: 0 });
 ```
 
 To remove an item from the cache, use the `del` method:


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] Docs
[ ] Other... Please describe:
```

## What is the current behavior?
The documentation says to set the `ttl` to `null` should disable the cache. The TS types do not allow it to be null, and I found that actually setting it to null does not disable the cache expiration.

Issue Number: N/A


## What is the new behavior?
Setting the ttl to `0` works to disable the cache expiration.

https://github.com/BryanDonovan/node-cache-manager/issues/107

https://github.com/BryanDonovan/node-cache-manager/issues/147


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
