### PR TITLE
fix(microservices): update global exception filter warning for hybrid app

### DIFF
--- a/content/microservices/exception-filters.md
+++ b/content/microservices/exception-filters.md
@@ -45,7 +45,7 @@ export class ExceptionFilter {
 }
 ```
 
-> warning **Warning** You cannot set up global microservice exception filters when using a [hybrid application](/faq/hybrid-application).
+> warning **Warning** Global microservice exception filters aren't enabled by default when using a [hybrid application](/faq/hybrid-application).
 
 The following example uses a manually instantiated method-scoped filter. Just as with HTTP based applications, you can also use controller-scoped filters (i.e., prefix the controller class with a `@UseFilters()` decorator).
 


### PR DESCRIPTION
Update the warning for using global exception filters in hybrid apps. They do actually work, if you `inheritAppConfig: true` when connecting the microservice.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Docs
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```