### PR TITLE
Update apollo-server-express version to nest8

### DIFF
--- a/content/graphql/quick-start.md
+++ b/content/graphql/quick-start.md
@@ -9,7 +9,7 @@ In this chapter, we assume a basic understanding of GraphQL, and focus on how to
 Start by installing the required packages:
 
 ```bash
-$ npm i @nestjs/graphql graphql-tools graphql apollo-server-express
+$ npm i @nestjs/graphql graphql-tools graphql apollo-server-express@2.x.x
 ```
 > info **Hint** If using Fastify, instead of installing `apollo-server-express`, you should install `apollo-server-fastify`.
 


### PR DESCRIPTION
Nest 8 is not intended to run with apollo-server-express@3.x.x but this open version command will install apollo-server-express@3 and break the startup [1]
as @kamilmysliwiec suggested it should use version 2


[1] https://github.com/nestjs/graphql/pull/1627

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
