### PR TITLE
Missing npm install command for ValidationPipe

### DIFF
--- a/content/techniques/validation.md
+++ b/content/techniques/validation.md
@@ -16,6 +16,12 @@ In the [Pipes](/pipes) chapter, we went through the process of building simple p
 
 #### Using the built-in ValidationPipe
 
+To begin using it, we first install the required dependency.
+
+```bash
+$ npm i --save class-validator class-transformer
+```
+
 > info **Hint** The `ValidationPipe` is exported from the `@nestjs/common` package.
 
 Because this pipe uses the `class-validator` and `class-transformer` libraries, there are many options available. You configure these settings via a configuration object passed to the pipe. Following are the built-in options:


### PR DESCRIPTION
In order to use the built-in `ValidationPipe` we must install `class-validator class-transformer`
otherwise, we will get errors like:
`ERROR [PackageLoader] The "class-validator" package is missing. Please, make sure to install this library ($ npm install class-validator) to take advantage of ValidationPipe.`

therefore, we should add the following to the docs:
`npm install --save class-validator class-transformer`

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?

`nest new test-app`
`nest g res cats`

(choose rest, choose crud)

add to main.ts:
`app.useGlobalPipes(new ValidationPipe());`

`nest start --watch`

we get:
`ERROR [PackageLoader] The "class-validator" package is missing.`

Issue Number: N/A


## What is the new behavior?

`npm install --save class-validator class-transformer`
no errors

## Does this PR introduce a breaking change?
- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
