### PR TITLE
docs(sse): Referenced the MessageEvent interface and fixed a typo

### DIFF
--- a/content/techniques/server-sent-events.md
+++ b/content/techniques/server-sent-events.md
@@ -13,7 +13,7 @@ sse(): Observable<MessageEvent> {
 }
 ```
 
-> info **Hint** The `@Sse()` decorator and `MessageEvent` interface are imported from the `@nestjs/common`, while `Observable`, `interval`, `and map` are imported from the `rxjs` package.
+> info **Hint** The `@Sse()` decorator and `MessageEvent` interface are imported from the `@nestjs/common`, while `Observable`, `interval`, and `map` are imported from the `rxjs` package.
 
 > warning **Warning** Server-Sent Events routes must return an `Observable` stream.
 

--- a/content/techniques/server-sent-events.md
+++ b/content/techniques/server-sent-events.md
@@ -13,7 +13,7 @@ sse(): Observable<MessageEvent> {
 }
 ```
 
-> info **Hint** The `@Sse()` decorator is imported from the `@nestjs/common`, while `Observable`, `interval`, `and map` are imported from the `rxjs` package.
+> info **Hint** The `@Sse()` decorator and `MessageEvent` interface are imported from the `@nestjs/common`, while `Observable`, `interval`, `and map` are imported from the `rxjs` package.
 
 > warning **Warning** Server-Sent Events routes must return an `Observable` stream.
 


### PR DESCRIPTION
The documentation had no reference to the MessageEvent interface being in the `@nestjs/common` package.

Also, fixed a typo where the word "and" was included in the monospace block alongside `map`.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Typo in the SSE section of the documentation, where the word "and" was contained in the monospace block next to the `map` function from RxJS, as well as a failure to mention that the MessageEvent interface is contained in the `@nestjs/common` package.

Issue Number: N/A

## What is the new behavior?

The hint box now has the proper reference to the interface being in the package, typo is also fixed.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No