### PR TITLE
docs(graphql): updates generic Paginated GraphQL type to be fully typed instead of typed as any

### DIFF
--- a/content/graphql/resolvers-map.md
+++ b/content/graphql/resolvers-map.md
@@ -410,7 +410,19 @@ We saw one use of generics above. This powerful TypeScript feature can be used t
 import { Field, ObjectType, Int } from '@nestjs/graphql';
 import { Type } from '@nestjs/common';
 
-export function Paginated<T>(classRef: Type<T>): any {
+interface IEdgeType<T> {
+  cursor: string;
+  node: T;
+}
+
+export interface IPaginatedType<T> {
+  edges: IEdgeType<T>[];
+  nodes: T[];
+  totalCount: number;
+  hasNextPage: boolean;
+}
+
+export function Paginated<T>(classRef: Type<T>): Type<IPaginatedType<T>> {
   @ObjectType(`${classRef.name}Edge`)
   abstract class EdgeType {
     @Field((type) => String)
@@ -421,7 +433,7 @@ export function Paginated<T>(classRef: Type<T>): any {
   }
 
   @ObjectType({ isAbstract: true })
-  abstract class PaginatedType {
+  abstract class PaginatedType implements IPaginatedType<T> {
     @Field((type) => [EdgeType], { nullable: true })
     edges: EdgeType[];
 
@@ -434,7 +446,7 @@ export function Paginated<T>(classRef: Type<T>): any {
     @Field()
     hasNextPage: boolean;
   }
-  return PaginatedType;
+  return PaginatedType as Type<IPaginatedType<T>>;
 }
 ```
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?

The current generic Paginated GraphQL type is typed as `any`.

## What is the new behavior?

The updated generic Paginated GraphQL type is fully typed, check this CodeSandbox for an example, note how TypeScript knows the edges and nodes are of the `PostModel` type.
https://codesandbox.io/s/modest-brook-pl3fq?file=/src/graphql/post.ts

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
