### PR TITLE
docs(file-upload): fix an inaccuracy in the Multiple files example

### DIFF
--- a/content/techniques/file-upload.md
+++ b/content/techniques/file-upload.md
@@ -85,7 +85,7 @@ When using `FileFieldsInterceptor()`, extract files from the `request` with the 
   { name: 'avatar', maxCount: 1 },
   { name: 'background', maxCount: 1 },
 ]))
-uploadFile(@UploadedFiles() files: Express.Multer.File[]) {
+uploadFile(@UploadedFiles() files: { avatar?: Express.Multer.File[], background?: Express.Multer.File[] }) {
   console.log(files);
 }
 @@switch


### PR DESCRIPTION
When the Multer fields method is used Multer returns an object with field names as keys and `File[]` as values.

In the Multiple files code example injected `files` are just `File[]`.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
no new behavior

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
