### PR TITLE
docs(openapi): add docs about missing cli plugin options

### DIFF
--- a/content/openapi/cli-plugin.md
+++ b/content/openapi/cli-plugin.md
@@ -170,12 +170,12 @@ export interface PluginOptions {
   <tr>
     <td><code>dtoKeyOfComment</code></td>
     <td><code>'description'</code></td>
-    <td>The property key to set the comment text to on <code>ApiOperation</code>. Eg: <code>@ApiOperation({ description: 'comment' })</code></td>
+    <td>The property key to set the comment text to on <code>ApiProperty</code>.</td>
   </tr>
   <tr>
     <td><code>controllerKeyOfComment</code></td>
     <td><code>'description'</code></td>
-    <td>The property key to set the comment text to on <code>ApiOperation</code>. Eg: <code>@ApiOperation({ description: 'comment' })</code></td>
+    <td>The property key to set the comment text to on <code>ApiOperation</code>.</td>
   </tr>
   <tr>
   <td><code>introspectComments</code></td>

--- a/content/openapi/cli-plugin.md
+++ b/content/openapi/cli-plugin.md
@@ -85,6 +85,26 @@ You must duplicate both description and example values. With `introspectComments
 roles: RoleEnum[] = [];
 ```
 
+There are `dtoKeyOfComment` and `controllerKeyOfComment` plugin options that you can use to customize how the plugin will set the value for `ApiProperty` and `ApiOperation` decorators respectively. Take a look at the following example:
+
+```typescript
+export class SomeController {
+  /**
+   * Create some resource
+   */
+  @Post()
+  create() {}
+}
+```
+
+By default, these options are set to `"description"`. This means the plugin will assign `"Create some resource"` to `description` key on the `ApiOperation` operator. Like so:
+
+```ts
+@ApiOperation({ description: "Create some resource" })
+```
+
+> info **Hint** For models, the same logic applies but to `ApiProperty` decorator instead. 
+
 #### Using the CLI plugin
 
 To enable the plugin, open `nest-cli.json` (if you use [Nest CLI](/cli/overview)) and add the following `plugins` configuration:
@@ -120,6 +140,8 @@ export interface PluginOptions {
   dtoFileNameSuffix?: string[];
   controllerFileNameSuffix?: string[];
   classValidatorShim?: boolean;
+  dtoKeyOfComment?: string;
+  controllerKeyOfComment?: string;
   introspectComments?: boolean;
 }
 ```
@@ -144,6 +166,16 @@ export interface PluginOptions {
     <td><code>classValidatorShim</code></td>
     <td><code>true</code></td>
     <td>If set to true, the module will reuse <code>class-validator</code> validation decorators (e.g. <code>@Max(10)</code> will add <code>max: 10</code> to schema definition) </td>
+  </tr>
+  <tr>
+    <td><code>dtoKeyOfComment</code></td>
+    <td><code>'description'</code></td>
+    <td>The property key to set the comment text to on <code>ApiOperation</code>. Eg: <code>@ApiOperation({ description: 'comment' })</code></td>
+  </tr>
+  <tr>
+    <td><code>controllerKeyOfComment</code></td>
+    <td><code>'description'</code></td>
+    <td>The property key to set the comment text to on <code>ApiOperation</code>. Eg: <code>@ApiOperation({ description: 'comment' })</code></td>
   </tr>
   <tr>
   <td><code>introspectComments</code></td>

--- a/src/app/homepage/pages/microservices/custom-transport/custom-transport.component.html
+++ b/src/app/homepage/pages/microservices/custom-transport/custom-transport.component.html
@@ -197,8 +197,8 @@ event to dispatch:  &#123; pattern: &#39;event&#39;, data: &#39;Hello world!&#39
 <p>If you need to add some custom logic around the serialization of responses on the client side, you can use a custom class that extends the <code>ClientProxy</code> class or one of its child classes. For modifying successful requests you can override the <code>serializeResponse</code> method, and for modifying any errors that go through this client you can override the <code>serializeError</code> method. To make use of this custom class, you can pass the class itself to the <code>ClientsModule.register()</code> method using the <code>customClass</code> property. Below is an example of a custom <code>ClientProxy</code> that serializes each error into an <code>RpcException</code>.</p>
 
 <span class="filename">
-  {{ 'error-handling.proxy' | extension: appb95b5d8490d1d2e5a8dfa4408547e4314e16a15a.isJsActive }}
-<app-tabs #appb95b5d8490d1d2e5a8dfa4408547e4314e16a15a></app-tabs>
+  {{ 'error-handling.proxy' | extension: app0de82fc4a8bf2d269aeca1e7e184438efcf3e0d8.isJsActive }}
+<app-tabs #app0de82fc4a8bf2d269aeca1e7e184438efcf3e0d8></app-tabs>
 </span><pre><code class="language-typescript">
 import &#123; ClientTcp, RpcException &#125; from &#39;@nestjs/microservices&#39;;
 
@@ -210,8 +210,8 @@ class ErrorHandlingProxy extends ClientTCP &#123;
 </code></pre><p>and then use it in the <code>ClientsModule</code> like so:</p>
 
 <span class="filename">
-  {{ 'app.module' | extension: appc6380cff174d3675b3c6660600efaf7aec5d9272.isJsActive }}
-<app-tabs #appc6380cff174d3675b3c6660600efaf7aec5d9272></app-tabs>
+  {{ 'app.module' | extension: app2750dd81614c4ebfea443f3fdb1c35cf2c1bdc85.isJsActive }}
+<app-tabs #app2750dd81614c4ebfea443f3fdb1c35cf2c1bdc85></app-tabs>
 </span><pre><code class="language-typescript">
 @Module(&#123;
   imports: [


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
There are no information relating to `dtoKeyOfComment` and `controllerKeyOfComment` CLI plugin options. 

## What is the new behavior?
This PR adds the information for `dtoKeyOfComment` and `controllerKeyOfComment`

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Ref https://github.com/nestjs/swagger/issues/1515