### PR TITLE
docs(graphql): SchemaDirectiveVisitor requires @graphql-tools/utils@^7

### DIFF
--- a/content/graphql/directives.md
+++ b/content/graphql/directives.md
@@ -10,7 +10,7 @@ A directive is an identifier preceded by a `@` character, optionally followed by
 
 #### Custom directives
 
-To create a custom schema directive, declare a class which extends the `SchemaDirectiveVisitor` class exported from the `apollo-server` package.
+To create a custom schema directive, declare a class which extends the `SchemaDirectiveVisitor` class exported from the `@graphql-tools/utils` package.
 
 ```typescript
 import { SchemaDirectiveVisitor } from '@graphql-tools/utils';
@@ -32,7 +32,8 @@ export class UpperCaseDirective extends SchemaDirectiveVisitor {
 
 > info **Hint** Note that directives cannot be decorated with the `@Injectable()` decorator. Thus, they are not able to inject dependencies.
 > 
-> warning **Warning** `SchemaDirectiveVisitor` is exported from the `@graphql-tools/utils` package so make sure to install it in your project.
+> warning **Warning** `SchemaDirectiveVisitor` is exported from the `@graphql-tools/utils` package. Note that the 8.x release of this package removes this export
+> and uses a different and incompatible approach to directives, so make sure to install `@graphql-tools/utils@^7` in your project.
 
 Now, register the `UpperCaseDirective` in the `GraphQLModule.forRoot()` method:
 

--- a/content/graphql/directives.md
+++ b/content/graphql/directives.md
@@ -31,8 +31,8 @@ export class UpperCaseDirective extends SchemaDirectiveVisitor {
 ```
 
 > info **Hint** Note that directives cannot be decorated with the `@Injectable()` decorator. Thus, they are not able to inject dependencies.
-> 
-> warning **Warning** `SchemaDirectiveVisitor` is exported from the `@graphql-tools/utils` package. Note that the 8.x release of this package removes this export
+
+> warning **Warning** `SchemaDirectiveVisitor` is exported from the `@graphql-tools/utils` package. Note that the 8.x release of graphql-tools removes this export
 > and uses a different and incompatible approach to directives, so make sure to install `@graphql-tools/utils@^7` in your project.
 
 Now, register the `UpperCaseDirective` in the `GraphQLModule.forRoot()` method:

--- a/content/graphql/directives.md
+++ b/content/graphql/directives.md
@@ -32,8 +32,7 @@ export class UpperCaseDirective extends SchemaDirectiveVisitor {
 
 > info **Hint** Note that directives cannot be decorated with the `@Injectable()` decorator. Thus, they are not able to inject dependencies.
 
-> warning **Warning** `SchemaDirectiveVisitor` is exported from the `@graphql-tools/utils` package. Note that the 8.x release of graphql-tools removes this export
-> and uses a different and incompatible approach to directives, so make sure to install `@graphql-tools/utils@^7` in your project.
+> warning **Warning** `SchemaDirectiveVisitor` is exported from the `@graphql-tools/utils` package. Note that the 8.x release of `graphql-tools` removes this export and provides a different and incompatible approach to directives, so make sure to install `@graphql-tools/utils@^7` in your project.
 
 Now, register the `UpperCaseDirective` in the `GraphQLModule.forRoot()` method:
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #2021


## What is the new behavior?
Adds note to GraphQL Directives documentation to the effect that `@graphql-tools/utils@^8` is not compatible.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No
