### PR TITLE
Update scalars.md: GraphQLTimestamp is integer

### DIFF
--- a/content/graphql/scalars.md
+++ b/content/graphql/scalars.md
@@ -10,7 +10,7 @@ The code-first approach ships with five scalars in which three of them are simpl
 - `Int` (alias for `GraphQLInt`) - a signed 32‐bit integer
 - `Float` (alias for `GraphQLFloat`) - a signed double-precision floating-point value
 - `GraphQLISODateTime` - a date-time string at UTC (used by default to represent `Date` type)
-- `GraphQLTimestamp` - a numeric string which represents time and date as number of milliseconds from start of UNIX epoch
+- `GraphQLTimestamp` - a signed integer which represents date and time as number of milliseconds from start of UNIX epoch
 
 The `GraphQLISODateTime` (e.g. `2019-12-03T09:54:33Z`) is used by default to represent the `Date` type. To use the `GraphQLTimestamp` instead, set the `dateScalarMode` of the `buildSchemaOptions` object to `'timestamp'` as follows:
 


### PR DESCRIPTION
`GraphQLTimestamp` is an integer in the current version implementation, not a string. The doc should reflect the current version. The wording is taken from the scalar's description property.

The range of values is limited by [`Number.MIN_SAFE_INTEGER`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MIN_SAFE_INTEGER) (`-(2^53 - 1)`) and [`Number.MAX_SAFE_INTEGER`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER) (`2^53 - 1`).
Thus the current implementation has a bigger range than a 32-bit integer.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The current doc version states that `GraphQLTimestamp` is a string.


## What is the new behavior?

The new doc version states that `GraphQLTimestamp` is a number.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
