### PR TITLE
docs(serverless): fix custom webpack example with commonjs2 from crashing cli

### DIFF
--- a/content/faq/serverless.md
+++ b/content/faq/serverless.md
@@ -271,6 +271,7 @@ return {
   ...options,
   externals: [],
   output: {
+    ...options.output,
     libraryTarget: 'commonjs2',
   },
   // ... the rest of the configuration


### PR DESCRIPTION
Following the guide https://docs.nestjs.com/faq/serverless#example-integration with commonjs2

Without ...options.output, the nestjs cli commands break

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Errors are thrown with the NestJS cli
```
Error: Cannot find module '/Users/user/Desktop/monorepo/dist/apps/app/main'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:885:15)
    at Function.Module._load (internal/modules/cjs/loader.js:730:27)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:72:12)
    at internal/main/run_main_module.js:17:47
```

Issue Number: N/A


## What is the new behavior?
The NestJS cli works with the custom config

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
