### PR TITLE
docs(recipes/router-module): add missing 'versioning' hyperlink

### DIFF
--- a/content/recipes/router-module.md
+++ b/content/recipes/router-module.md
@@ -4,7 +4,7 @@
 
 In an HTTP application (for example, REST API), the route path for a handler is determined by concatenating the (optional) prefix declared for the controller (inside the `@Controller` decorator),
 and any path specified in the method's decorator (e.g, `@Get('users')`). You can learn more about that in [this section](/controllers#routing). Additionally,
-you can define a [global prefix](/faq/global-prefix) for all routes registered in your application, or enable [versioning]().
+you can define a [global prefix](/faq/global-prefix) for all routes registered in your application, or enable [versioning](/techniques/versioning).
 
 Also, there are edge-cases when defining a prefix at a module-level (and so for all controllers registered inside that module) may come in handy.
 For example, imagine a REST application that exposes several different endpoints being used by a specific portion of your application called "Dashboard".


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
Currently, document `/recipes/router-module` doesn't have URL to `Versioning` page.


## What is the new behavior?
I added missing URL to `Versioning` Docs page.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
