### PR TITLE
docs(): add instructions about using the global default version option

### DIFF
--- a/content/techniques/versioning.md
+++ b/content/techniques/versioning.md
@@ -230,3 +230,20 @@ export class CatsController {
   }
 }
 ```
+
+#### Global default version
+
+If you do not want to provide a version to each controller/individual routes, or if you want to have some version as the default version for every controller/individual routes that does not have defined a version, you could enable versioning like the following:
+
+```typescript
+@@filename(main)
+app.enableVersioning({
+  // ...
+  defaultVersion: '1'
+  // or
+  defaultVersion: ['1', '2']
+  // or
+  defaultVersion: VERSION_NEUTRAL
+  // and so on
+});
+```


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:

## What is the current behavior?

There's no documentation about the feature introduced in this PR: https://github.com/nestjs/nest/pull/8128

## What is the new behavior?

A new section under `techniques/versioning` page that introduces the `defaultVersion` option of `#enableVersioning` method:

![demo](https://user-images.githubusercontent.com/13461315/135653730-872f07ba-c00a-400a-a8d6-8770cff4d042.png)


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No