### PR TITLE
docs(sql):  update required dependency mysql to mysql2

### DIFF
--- a/content/recipes/sql-typeorm.md
+++ b/content/recipes/sql-typeorm.md
@@ -11,7 +11,7 @@
 To start the adventure with this library we have to install all required dependencies:
 
 ```bash
-$ npm install --save typeorm mysql
+npm install --save typeorm mysql2
 ```
 
 The first step we need to do is to establish the connection with our database using `createConnection()` function imported from the `typeorm` package. The `createConnection()` function returns a `Promise`, and therefore we have to create an [async provider](/fundamentals/async-components).


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [X] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

The [SQL (TypeORM)](https://docs.nestjs.com/recipes/sql-typeorm#sql-typeorm) documentation requires user to install `mysql`.

In this manner, users may get errors during DB configuration, because of inproper dependency installation.

## What is the new behavior?
Now the documentation requires `mysql2` instead of `mysql` 


## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
[Database](https://docs.nestjs.com/techniques/database) documentation correctly requires `mysql2`.
Therefore, outdated **SQL (TypeORM)** section sould be updated.
