### PR TITLE
docs(bull): change return type in async config service

### DIFF
--- a/content/techniques/queues.md
+++ b/content/techniques/queues.md
@@ -447,7 +447,7 @@ The construction above will instantiate `BullConfigService` inside `BullModule` 
 ```typescript
 @Injectable()
 class BullConfigService implements SharedBullConfigurationFactory {
-  createSharedConfiguration(): SharedBullConfigurationFactory {
+  createSharedConfiguration(): BullModuleOptions {
     return {
       redis: {
         host: 'localhost',


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?

The return type of `createSharedConfiguration` is `SharedBullConfigurationFactory `, which is incorrect.

Issue Number: N/A


## What is the new behavior?

The return type of `createSharedConfiguration` is now `BullModuleOptions`.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
