### PR TITLE
docs: fix broken socket options link in gateway docs

### DIFF
--- a/content/websockets/gateways.md
+++ b/content/websockets/gateways.md
@@ -29,7 +29,7 @@ In general, each gateway is listening on the same port as the **HTTP server**, u
 
 > warning **Warning** Gateways are not instantiated until they are referenced in the providers array of an existing module.
 
-You can pass any supported [option](https://socket.io/docs/server-api/) to the socket constructor with the second argument to the `@WebSocketGateway()` decorator, as shown below:
+You can pass any supported [option](https://socket.io/docs/v4/server-options/) to the socket constructor with the second argument to the `@WebSocketGateway()` decorator, as shown below:
 
 ```typescript
 @WebSocketGateway(81, { transports: ['websocket'] })


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The gateways documentation has a broken link to socket options [socket options](https://socket.io/docs/server-api/)

Issue Number: N/A


## What is the new behavior?
This PR replaces the broken link with the one at [Server.options](https://socket.io/docs/v4/server-options/)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
