### PR TITLE
docs(modules): clarify about `exports` array of `@Module()` options

### DIFF
--- a/content/modules.md
+++ b/content/modules.md
@@ -8,24 +8,12 @@ Each application has at least one module, a **root module**. The root module is 
 
 The `@Module()` decorator takes a single object whose properties describe the module:
 
-<table>
-  <tr>
-    <td><code>providers</code></td>
-    <td>the providers that will be instantiated by the Nest injector and that may be shared at least across this module</td>
-  </tr>
-  <tr>
-    <td><code>controllers</code></td>
-    <td>the set of controllers defined in this module which have to be instantiated</td>
-  </tr>
-  <tr>
-    <td><code>imports</code></td>
-    <td>the list of imported modules that export the providers which are required in this module</td>
-  </tr>
-  <tr>
-    <td><code>exports</code></td>
-    <td>the subset of <code>providers</code> that are provided by this module and should be available in other modules which import this module</td>
-  </tr>
-</table>
+|               |                                                                                                                              |
+|---------------|------------------------------------------------------------------------------------------------------------------------------|
+| `providers`   | the providers that will be instantiated by the Nest injector and that may be shared at least across this module              |
+| `controllers` | the set of controllers defined in this module which have to be instantiated                                                  |
+| `imports`     | the list of imported modules that export the providers which are required in this module                                     |
+| `exports`     | the subset of `providers` that are provided by this module and should be available in other modules which import this module |
 
 The module **encapsulates** providers by default. This means that it's impossible to inject providers that are neither directly part of the current module nor exported from the imported modules. Thus, you may consider the exported providers from a module as the module's public interface, or API.
 

--- a/content/modules.md
+++ b/content/modules.md
@@ -8,12 +8,12 @@ Each application has at least one module, a **root module**. The root module is 
 
 The `@Module()` decorator takes a single object whose properties describe the module:
 
-|               |                                                                                                                              |
-|---------------|------------------------------------------------------------------------------------------------------------------------------|
-| `providers`   | the providers that will be instantiated by the Nest injector and that may be shared at least across this module              |
-| `controllers` | the set of controllers defined in this module which have to be instantiated                                                  |
-| `imports`     | the list of imported modules that export the providers which are required in this module                                     |
-| `exports`     | the subset of `providers` that are provided by this module and should be available in other modules which import this module |
+| | |
+|-|-|
+| `providers`   | the providers that will be instantiated by the Nest injector and that may be shared at least across this module |
+| `controllers` | the set of controllers defined in this module which have to be instantiated  |
+| `imports`     | the list of imported modules that export the providers which are required in this module |
+| `exports`     | the subset of `providers` that are provided by this module and should be available in other modules which import this module. You can use either the provider itself or just its token (`provide` value) |
 
 The module **encapsulates** providers by default. This means that it's impossible to inject providers that are neither directly part of the current module nor exported from the imported modules. Thus, you may consider the exported providers from a module as the module's public interface, or API.
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:

## What is the current behavior?

![image](https://user-images.githubusercontent.com/13461315/140970718-7f466bed-e148-4349-90f6-70ac2ff429e6.png)

Isn't clear that we can use the `provide` value of providers on `exports` list of `@Module()`. We can figure out this by looking on types definitions tho 

## What is the new behavior?

![image](https://user-images.githubusercontent.com/13461315/140971185-b4be7767-788c-4798-a376-ae693683bb4b.png)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Also, I changed the HTML table to markdown
