### PR TITLE
docs: replace 'class-validator' and 'class-transformer' by their nestjs's forks

### DIFF
--- a/content/graphql/resolvers-map.md
+++ b/content/graphql/resolvers-map.md
@@ -282,7 +282,7 @@ Create the `GetAuthorArgs` class using `@ArgsType()` as shown below:
 
 ```typescript
 @@filename(authors/dto/get-author.args)
-import { MinLength } from 'class-validator';
+import { MinLength } from '@nestjs/class-validator';
 import { Field, ArgsType } from '@nestjs/graphql';
 
 @ArgsType()
@@ -600,10 +600,10 @@ export abstract class IQuery {
 }
 ```
 
-By generating classes (instead of the default technique of generating interfaces), you can use declarative validation **decorators** in combination with the schema first approach, which is an extremely useful technique (read [more](/techniques/validation)). For example, you could add `class-validator` decorators to the generated `CreatePostInput` class as shown below to enforce minimum and maximum string lengths on the `title` field:
+By generating classes (instead of the default technique of generating interfaces), you can use declarative validation **decorators** in combination with the schema first approach, which is an extremely useful technique (read [more](/techniques/validation)). For example, you could add `@nestjs/class-validator` decorators to the generated `CreatePostInput` class as shown below to enforce minimum and maximum string lengths on the `title` field:
 
 ```typescript
-import { MinLength, MaxLength } from 'class-validator';
+import { MinLength, MaxLength } from '@nestjs/class-validator';
 
 export class CreatePostInput {
   @MinLength(3)
@@ -617,7 +617,7 @@ export class CreatePostInput {
 However, if you add decorators directly to the automatically generated file, they will be **overwritten** each time the file is generated. Instead, create a separate file and simply extend the generated class.
 
 ```typescript
-import { MinLength, MaxLength } from 'class-validator';
+import { MinLength, MaxLength } from '@nestjs/class-validator';
 import { Post } from '../../graphql.ts';
 
 export class CreatePostInput extends Post {

--- a/content/openapi/cli-plugin.md
+++ b/content/openapi/cli-plugin.md
@@ -12,7 +12,7 @@ The Swagger plugin will automatically:
 - set the `required` property depending on the question mark (e.g. `name?: string` will set `required: false`)
 - set the `type` or `enum` property depending on the type (supports arrays as well)
 - set the `default` property based on the assigned default value
-- set several validation rules based on `class-validator` decorators (if `classValidatorShim` set to `true`)
+- set several validation rules based on `@nestjs/class-validator` decorators (if `classValidatorShim` set to `true`)
 - add a response decorator to every endpoint with a proper status and `type` (response model)
 - generate descriptions for properties and endpoints based on comments (if `introspectComments` set to `true`)
 - generate example values for properties based on comments (if `introspectComments` set to `true`)
@@ -165,7 +165,7 @@ export interface PluginOptions {
   <tr>
     <td><code>classValidatorShim</code></td>
     <td><code>true</code></td>
-    <td>If set to true, the module will reuse <code>class-validator</code> validation decorators (e.g. <code>@Max(10)</code> will add <code>max: 10</code> to schema definition) </td>
+    <td>If set to true, the module will reuse <code>@nestjs/class-validator</code> validation decorators (e.g. <code>@Max(10)</code> will add <code>max: 10</code> to schema definition) </td>
   </tr>
   <tr>
     <td><code>dtoKeyOfComment</code></td>

--- a/content/techniques/configuration.md
+++ b/content/techniques/configuration.md
@@ -389,15 +389,15 @@ Note that once you decide to pass a `validationOptions` object, any settings you
 
 Alternatively, you can specify a **synchronous** `validate` function that takes an object containing the environment variables (from env file and process) and returns an object containing validated environment variables so that you can convert/mutate them if needed. If the function throws an error, it will prevent the application from bootstrapping.
 
-In this example, we'll proceed with the `class-transformer` and `class-validator` packages. First, we have to define:
+In this example, we'll proceed with the `@nestjs/class-transformer` and `@nestjs/class-validator` packages. First, we have to define:
 
 - a class with validation constraints,
 - a validate function that makes use of the `plainToClass` and `validateSync` functions.
 
 ```typescript
 @@filename(env.validation)
-import { plainToClass } from 'class-transformer';
-import { IsEnum, IsNumber, validateSync } from 'class-validator';
+import { plainToClass } from '@nestjs/class-transformer';
+import { IsEnum, IsNumber, validateSync } from '@nestjs/class-validator';
 
 enum Environment {
   Development = "development",

--- a/content/techniques/serialization.md
+++ b/content/techniques/serialization.md
@@ -4,14 +4,14 @@ Serialization is a process that happens before objects are returned in a network
 
 #### Overview
 
-Nest provides a built-in capability to help ensure that these operations can be performed in a straightforward way. The `ClassSerializerInterceptor` interceptor uses the powerful [class-transformer](https://github.com/typestack/class-transformer) package to provide a declarative and extensible way of transforming objects. The basic operation it performs is to take the value returned by a method handler and apply the `classToPlain()` function from [class-transformer](https://github.com/typestack/class-transformer). In doing so, it can apply rules expressed by `class-transformer` decorators on an entity/DTO class, as described below.
+Nest provides a built-in capability to help ensure that these operations can be performed in a straightforward way. The `ClassSerializerInterceptor` interceptor uses the powerful [@nestjs/class-transformer](https://github.com/nestjs/class-transformer) package to provide a declarative and extensible way of transforming objects. The basic operation it performs is to take the value returned by a method handler and apply the `classToPlain()` function from [@nestjs/class-transformer](https://github.com/nestjs/class-transformer). In doing so, it can apply rules expressed by `@nestjs/class-transformer` decorators on an entity/DTO class, as described below.
 
 #### Exclude properties
 
 Let's assume that we want to automatically exclude a `password` property from a user entity. We annotate the entity as follows:
 
 ```typescript
-import { Exclude } from 'class-transformer';
+import { Exclude } from '@nestjs/class-transformer';
 
 export class UserEntity {
   id: number;
@@ -106,4 +106,4 @@ While this chapter shows examples using HTTP style applications (e.g., Express o
 
 #### Learn more
 
-Read more about available decorators and options as provided by the `class-transformer` package [here](https://github.com/typestack/class-transformer).
+Read more about available decorators and options as provided by the `@nestjs/class-transformer` package [here](https://github.com/nestjs/class-transformer).

--- a/content/techniques/validation.md
+++ b/content/techniques/validation.md
@@ -8,7 +8,7 @@ It is best practice to validate the correctness of any data sent into a web appl
 - `ParseArrayPipe`
 - `ParseUUIDPipe`
 
-The `ValidationPipe` makes use of the powerful [class-validator](https://github.com/typestack/class-validator) package and its declarative validation decorators. The `ValidationPipe` provides a convenient approach to enforce validation rules for all incoming client payloads, where the specific rules are declared with simple annotations in local class/DTO declarations in each module.
+The `ValidationPipe` makes use of the powerful [@nestjs/class-validator](https://github.com/nestjs/class-validator) package and its declarative validation decorators. The `ValidationPipe` provides a convenient approach to enforce validation rules for all incoming client payloads, where the specific rules are declared with simple annotations in local class/DTO declarations in each module.
 
 #### Overview
 
@@ -19,12 +19,12 @@ In the [Pipes](/pipes) chapter, we went through the process of building simple p
 To begin using it, we first install the required dependency.
 
 ```bash
-$ npm i --save class-validator class-transformer
+$ npm i --save @nestjs/class-validator @nestjs/class-transformer
 ```
 
 > info **Hint** The `ValidationPipe` is exported from the `@nestjs/common` package.
 
-Because this pipe uses the `class-validator` and `class-transformer` libraries, there are many options available. You configure these settings via a configuration object passed to the pipe. Following are the built-in options:
+Because this pipe uses the `@nestjs/class-validator` and `@nestjs/class-transformer` libraries, there are many options available. You configure these settings via a configuration object passed to the pipe. Following are the built-in options:
 
 ```typescript
 export interface ValidationPipeOptions extends ValidatorOptions {
@@ -34,7 +34,7 @@ export interface ValidationPipeOptions extends ValidatorOptions {
 }
 ```
 
-In addition to these, all `class-validator` options (inherited from the `ValidatorOptions` interface) are available:
+In addition to these, all `@nestjs/class-validator` options (inherited from the `ValidatorOptions` interface) are available:
 
 <table>
   <tr>
@@ -131,7 +131,7 @@ In addition to these, all `class-validator` options (inherited from the `Validat
   </tr>
 </table>
 
-> info **Notice** Find more information about the `class-validator` package in its [repository](https://github.com/typestack/class-validator).
+> info **Notice** Find more information about the `@nestjs/class-validator` package in its [repository](https://github.com/nestjs/class-validator).
 
 #### Auto-validation
 
@@ -159,10 +159,10 @@ create(@Body() createUserDto: CreateUserDto) {
 
 > info **Hint** When importing your DTOs, you can't use a type-only import as that would be erased at runtime, i.e. remember to `import {{ '{' }} CreateUserDto {{ '}' }}` instead of `import type {{ '{' }} CreateUserDto {{ '}' }}`.
 
-Now we can add a few validation rules in our `CreateUserDto`. We do this using decorators provided by the `class-validator` package, described in detail [here](https://github.com/typestack/class-validator#validation-decorators). In this fashion, any route that uses the `CreateUserDto` will automatically enforce these validation rules.
+Now we can add a few validation rules in our `CreateUserDto`. We do this using decorators provided by the `@nestjs/class-validator` package, described in detail [here](https://github.com/nestjs/class-validator#validation-decorators). In this fashion, any route that uses the `CreateUserDto` will automatically enforce these validation rules.
 
 ```typescript
-import { IsEmail, IsNotEmpty } from 'class-validator';
+import { IsEmail, IsNotEmpty } from '@nestjs/class-validator';
 
 export class CreateUserDto {
   @IsEmail()
@@ -192,10 +192,10 @@ findOne(@Param() params: FindOneParams) {
 }
 ```
 
-`FindOneParams`, like a DTO, is simply a class that defines validation rules using `class-validator`. It would look like this:
+`FindOneParams`, like a DTO, is simply a class that defines validation rules using `@nestjs/class-validator`. It would look like this:
 
 ```typescript
-import { IsNumberString } from 'class-validator';
+import { IsNumberString } from '@nestjs/class-validator';
 
 export class FindOneParams {
   @IsNumberString()
@@ -433,4 +433,4 @@ While this chapter shows examples using HTTP style applications (e.g., Express o
 
 #### Learn more
 
-Read more about custom validators, error messages, and available decorators as provided by the `class-validator` package [here](https://github.com/typestack/class-validator).
+Read more about custom validators, error messages, and available decorators as provided by the `@nestjs/class-validator` package [here](https://github.com/nestjs/class-validator).


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #2104

## What is the new behavior?

- replace every occurrence of `@nestjs/class-validator` with `class-validator`
- replace every occurrence of `@nestjs/class-transformer` with `class-transformer`

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Let me know if we should keep occurrences like the following

![image](https://user-images.githubusercontent.com/13461315/141315682-12bdcef8-4c41-4c8c-8269-2acc146f11af.png)
