### PR TITLE
docs: add notice regarding the TS version of `@nestjs/config`

### DIFF
--- a/content/techniques/configuration.md
+++ b/content/techniques/configuration.md
@@ -18,6 +18,8 @@ $ npm i --save @nestjs/config
 
 > info **Hint** The `@nestjs/config` package internally uses [dotenv](https://github.com/motdotla/dotenv).
 
+> warning **Note** `@nestjs/config` requires TypeScript 4.1 or later.
+
 #### Getting started
 
 Once the installation process is complete, we can import the `ConfigModule`. Typically, we'll import it into the root `AppModule` and control its behavior using the `.forRoot()` static method. During this step, environment variable key/value pairs are parsed and resolved. Later, we'll see several options for accessing the `ConfigService` class of the `ConfigModule` in our other feature modules.


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:

## What is the current behavior?

Sometimes people complains about typescript errors on `@nestjs/config` v1 just because they have no clue that this package requires typescript version 4.1 or higher

## What is the new behavior?

![image](https://user-images.githubusercontent.com/13461315/141374182-b94526bc-96c3-4c03-a68a-e82a8ba3d389.png)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
