### PR TITLE
docs: cover `CacheModule#register` (and so on) optional type argument

### DIFF
--- a/content/techniques/caching.md
+++ b/content/techniques/caching.md
@@ -217,17 +217,19 @@ class HttpCacheInterceptor extends CacheInterceptor {
 
 #### Different stores
 
-This service takes advantage of [cache-manager](https://github.com/BryanDonovan/node-cache-manager) under the hood. The `cache-manager` package supports a wide-range of useful stores, for example, [Redis](https://github.com/dabroek/node-cache-manager-redis-store) store. A full list of supported stores is available [here](https://github.com/BryanDonovan/node-cache-manager#store-engines). To set up the Redis store, simply pass the package together with corresponding options to the `register()` method.
+This service takes advantage of [cache-manager](https://github.com/BryanDonovan/node-cache-manager) under the hood. The `cache-manager` package supports a wide-range of useful stores, for example, [Redis store](https://github.com/dabroek/node-cache-manager-redis-store). A full list of supported stores is available [here](https://github.com/BryanDonovan/node-cache-manager#store-engines). To set up the Redis store, simply pass the package together with corresponding options to the `register()` method.
 
 ```typescript
+import type { ClientOpts as RedisClientOpts } from 'redis'
 import * as redisStore from 'cache-manager-redis-store';
 import { CacheModule, Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 
 @Module({
   imports: [
-    CacheModule.register({
+    CacheModule.register<RedisClientOpts>({
       store: redisStore,
+      // Store-specify configuration:
       host: 'localhost',
       port: 6379,
     }),
@@ -294,6 +296,8 @@ CacheModule.registerAsync({
 ```
 
 This works the same as `useClass` with one critical difference - `CacheModule` will lookup imported modules to reuse any already-created `ConfigService`, instead of instantiating its own.
+
+> info **Hint** `CacheModule#register` and `CacheModule#registerAsync` and `CacheOptionsFactory` has an optional generic (type argument) to narrow down store-specific configuration options, making it type safe.
 
 #### Example
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
No documentation regarding the feature added in https://github.com/nestjs/nest/pull/8592


## What is the new behavior?

![image](https://user-images.githubusercontent.com/13461315/141788914-d041d781-9504-4f99-bcfa-7143fdbb2fd9.png)

![image](https://user-images.githubusercontent.com/13461315/141788957-2956a322-5a1f-405a-bab8-0b7e4fa81c57.png)


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

I didn't put any hint on how users can find the valid store configuration type because I think there's no standard way besides looking into store's source like I've done for `cache-manager-redis-store` (looking at `@types/cache-manager-redis-store`'s source)
