### PR TITLE
docs(unit-testing): call app.close() afterEach in Fastify e2e test example

### DIFF
--- a/content/fundamentals/unit-testing.md
+++ b/content/fundamentals/unit-testing.md
@@ -288,7 +288,7 @@ describe('Cats', () => {
 >   await app.getHttpAdapter().getInstance().ready();
 > });
 > 
-> afterEach(async () => {
+> afterAll(async () => {
 >   await app.close();
 > });
 >

--- a/content/fundamentals/unit-testing.md
+++ b/content/fundamentals/unit-testing.md
@@ -287,6 +287,10 @@ describe('Cats', () => {
 >   await app.init();
 >   await app.getHttpAdapter().getInstance().ready();
 > });
+> 
+> afterEach(async () => {
+>   await app.close();
+> });
 >
 > it(`/GET cats`, () => {
 >   return app

--- a/content/fundamentals/unit-testing.md
+++ b/content/fundamentals/unit-testing.md
@@ -287,10 +287,6 @@ describe('Cats', () => {
 >   await app.init();
 >   await app.getHttpAdapter().getInstance().ready();
 > });
-> 
-> afterAll(async () => {
->   await app.close();
-> });
 >
 > it(`/GET cats`, () => {
 >   return app
@@ -302,6 +298,10 @@ describe('Cats', () => {
 >       expect(result.statusCode).toEqual(200);
 >       expect(result.payload).toEqual(/* expectedPayload */);
 >     });
+> });
+>  
+> afterAll(async () => {
+>   await app.close();
 > });
 > ```
 


### PR DESCRIPTION
Otherwise you'd get:
> Jest did not exit one second after the test run has completed.
> This usually means that there are asynchronous operations that weren't stopped in your tests. Consider running Jest with `--detectOpenHandles` to troubleshoot this issue.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Generated file (`app.e2e-spec.ts`) doesn't have the `app.close()` call. 
Issue Number: N/A


## What is the new behavior?
Has it been fixed in newer versions?


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
chill, just a docs update