### PR TITLE
docs ->prisma fix deprecated link

### DIFF
--- a/content/recipes/prisma.md
+++ b/content/recipes/prisma.md
@@ -549,5 +549,5 @@ If you want to learn more about using NestJS with Prisma, be sure to check out t
 
 - [NestJS & Prisma](https://www.prisma.io/nestjs)
 - [Ready-to-run example projects for REST & GraphQL](https://github.com/prisma/prisma-examples/)
-- [Production-ready starter kit](https://github.com/fivethree-team/nestjs-prisma-starter#instructions)
+- [Production-ready starter kit](https://github.com/notiz-dev/nestjs-prisma-starter#instructions)
 - [Video: Accessing Databases using NestJS with Prisma (5min)](https://www.youtube.com/watch?v=UlVJ340UEuk&ab_channel=Prisma) by [Marc Stammerjohann](https://github.com/marcjulian)


### PR DESCRIPTION
The current link targets the old repo which states in its [readme](https://github.com/fivethree-team/nestjs-prisma-starter#instructions): "This repository has moved to notiz-dev/nestjs-prisma-starter!". The PR links to the currently maintained repo.
Treat it as a typo that is fixed.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [-] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md
-> I edited the typo on github website and was not allowed to choose the correct branch name there. Sry for not exactly following your standards

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
Link to old outdated repo

Issue Number: N/A


## What is the new behavior?
Link to current repo

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
