### PR TITLE
docs(logger.md): remove `.apply()` in the code example

### DIFF
--- a/content/techniques/logger.md
+++ b/content/techniques/logger.md
@@ -102,7 +102,7 @@ import { ConsoleLogger } from '@nestjs/common';
 export class MyLogger extends ConsoleLogger {
   error(message: any, stack?: string, context?: string) {
     // add your tailored logic here
-    super.error.apply(this, arguments);
+    super.error(...arguments);
   }
 }
 ```


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

In the code example, we use `super.methodName.apply(this, arguments)` to call a parent class method from a child class.


## What is the new behavior?

The `.apply()` is unnecessary when we use `super`. So, we can just call `super.methodName(...arguments)` in the child class.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
