### PR TITLE
docs(graphql): graphql-ws context value example

### DIFF
--- a/content/graphql/subscriptions.md
+++ b/content/graphql/subscriptions.md
@@ -334,9 +334,14 @@ If you're using the `graphql-ws` package, the signature of the `onConnect` callb
 subscriptions: {
   'graphql-ws': {
     onConnect: (context: Context<any>) => {
-      const { connectionParams } = context;
-      // the rest will remain the same as in the example above
+      const { connectionParams, extra } = context;
+      // user validation will remain the same as in the example above
+      // when using with graphql-ws, additional context value should store into extra field
+      extra.user = { user: {} };
     },
   },
+  context: ({ extra }) => {
+    // you then can access your additional context value through extra field
+  } 
 },
 ```

--- a/content/graphql/subscriptions.md
+++ b/content/graphql/subscriptions.md
@@ -341,7 +341,7 @@ subscriptions: {
     },
   },
   context: ({ extra }) => {
-    // you then can access your additional context value through extra field
+    // you can now access your additional context value through the extra field
   } 
 },
 ```

--- a/content/graphql/subscriptions.md
+++ b/content/graphql/subscriptions.md
@@ -336,7 +336,7 @@ subscriptions: {
     onConnect: (context: Context<any>) => {
       const { connectionParams, extra } = context;
       // user validation will remain the same as in the example above
-      // when using with graphql-ws, additional context value should store into extra field
+      // when using with graphql-ws, additional context value should be stored in the extra field
       extra.user = { user: {} };
     },
   },


### PR DESCRIPTION
When using subscriptions with graphql-ws package, passing additional context values are different from subscription-transport-ws package

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
When using graphql-ws, the current document on graphql  subscriptions' context passing seems to suggest that your additional  context values should directly return from `onConnect` callback and access it from the `context` callback.  but in fact in graphql-ws package, returning an object from `onConnect` callback is an optional payload that will send back to client via `ConnectionAck` message.

Issue Number: N/A


## What is the new behavior?
When using graphql-ws package, the correct way to pass additional context value is through `extra` field.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information
