### PR TITLE
docs: replace interfaces with type aliases on configuration page

### DIFF
--- a/content/techniques/configuration.md
+++ b/content/techniques/configuration.md
@@ -219,10 +219,10 @@ const dbHost = this.configService.get<string>('database.host', 'localhost');
 `ConfigService` has two optional generics (type arguments). The first one is to help prevent accessing a config property that does not exist. Use it as shown below:
 
 ```typescript
-interface EnvironmentVariables {
+type EnvironmentVariables = {
   PORT: number;
   TIMEOUT: string;
-}
+};
 
 // somewhere in the code
 constructor(private configService: ConfigService<EnvironmentVariables>) {
@@ -233,7 +233,7 @@ constructor(private configService: ConfigService<EnvironmentVariables>) {
 }
 ```
 
-With the `infer` property set to `true`, the `ConfigService#get` method will automatically infer the property type based on the interface, so for example, `typeof port === "number"` (if you're not using `strictNullChecks` flag from TypeScript) since `PORT` has a `number` type in the `EnvironmentVariables` interface.
+With the `infer` property set to `true`, the `ConfigService#get` method will automatically infer the property type based on the interface, so for example, `typeof port === "number"` (if you're not using `strictNullChecks` flag from TypeScript) since `PORT` has a `number` type in the `EnvironmentVariables` type alias.
 
 Also, with the `infer` feature, you can infer the type of a nested custom configuration object's property, even when using dot notation, as follows:
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?

Examples on https://docs.nestjs.com/techniques/configuration are taking in count `@nestjs/config@1.1.0`

## What is the new behavior?

After this change on `@nestjs/config`: https://github.com/nestjs/config/commit/b85f73497f8a088495e5303a1cc7e58163416097 we can no longer use TypeScript interfaces on `ConfigService` type arg due to TSC constraint errors (see https://github.com/microsoft/TypeScript/issues/42825#issuecomment-780160383)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information

I chose to update only the interface that will be passed to `ConfigService`, not the ones used by `ConfigService#get`, let me know if this is fine