### PR TITLE
fix(build): replace --prod (deprecated) with --configuration production in npm script

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build": "ng build --deleteOutputPath=false",
     "build:watch": "concurrently \"nodemon --config nodemon.json\" \"npm run start:watch\"",
     "prebuild:prod": "npm run docs",
-    "build:prod": "ng build --prod --aot --deleteOutputPath=false",
+    "build:prod": "ng build --configuration production --aot --deleteOutputPath=false",
     "test": "ng test",
     "lint": "ng lint",
     "e2e": "ng e2e",


### PR DESCRIPTION


## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Building docs with production env with `--prod` flag in `ng build` command

## What is the new behavior?
Using the `--configuration production` flag in `ng build` command.

This is done because `--prod` flag is deprecated:

> Deprecated: Use --configuration production instead.
>
> Shorthand for "--configuration=production". Set the build configuration to the production target. By default, the production target is set up in the workspace configuration such that all builds make use of bundling, limited tree-shaking, and also limited dead code elimination.
>
> From [Angular Docs - `ng build` options](https://angular.io/cli/build#options)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
