### PR TITLE
docs: clarify on custom repository limitation in sql.md

### DIFF
--- a/content/techniques/sql.md
+++ b/content/techniques/sql.md
@@ -642,7 +642,7 @@ Now a substitute `mockRepository` will be used as the `UsersRepository`. Wheneve
 
 #### Custom repository
 
-TypeORM provides a feature called **custom repositories**. Custom repositories allow you to extend a base repository class, and enrich it with several special methods. To learn more about this feature, visit [this page](https://typeorm.io/#/custom-repository).
+TypeORM provides a feature called **custom repositories**. Custom repositories allow you to extend a base repository class, and enrich it with several special methods. To learn more about this feature, visit [this page](https://typeorm.io/#/custom-repository). Be aware that custom repositories are outside of NestJS's Dependency Injection system, thus you can't inject any values into them.
 
 In order to create your custom repository, use the `@EntityRepository()` decorator and extend the `Repository` class.
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?

I didn't find any mention on docs regarding this [custom repository](https://docs.nestjs.com/techniques/database#custom-repository) limitation: we can't use NestJS's DI on them.

## What is the new behavior?

I just bring [this comment from SO](https://stackoverflow.com/a/65227341/5290447).

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No
