### PR TITLE
docs(security): fix req type of login example

### DIFF
--- a/content/security/authentication.md
+++ b/content/security/authentication.md
@@ -313,14 +313,15 @@ Open the `app.controller.ts` file and replace its contents with the following:
 
 ```typescript
 @@filename(app.controller)
-import { Controller, Request, Post, UseGuards } from '@nestjs/common';
+import { Controller, Req, Post, UseGuards } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
+import { Request } from 'express';
 
 @Controller()
 export class AppController {
   @UseGuards(AuthGuard('local'))
   @Post('auth/login')
-  async login(@Request() req) {
+  async login(@Req() req: Request) {
     return req.user;
   }
 }
@@ -367,7 +368,7 @@ Now, we can update the `/auth/login` route handler and use the `LocalAuthGuard` 
 ```typescript
 @UseGuards(LocalAuthGuard)
 @Post('auth/login')
-async login(@Request() req) {
+async login(@Req() req: Request) {
   return req.user;
 }
 ```


### PR DESCRIPTION
This fixes the following error: Parameter 'req' implicitly has an 'any' type.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
![nestjs-requestdecorator-error2](https://user-images.githubusercontent.com/1633192/150364331-6c9e3895-b00c-4bcc-87f6-24b047a9c6f2.png)


Issue Number: N/A


## What is the new behavior?

No typing error.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

