### PR TITLE
docs(authentication): fix curl response payload

### DIFF
--- a/content/security/authentication.md
+++ b/content/security/authentication.md
@@ -761,7 +761,7 @@ Ensure the app is running, and test the routes using `cURL`.
 ```bash
 $ # GET /profile
 $ curl http://localhost:3000/profile
-$ # result -> {"statusCode":401,"error":"Unauthorized"}
+$ # result -> {"statusCode":401,"message":"Unauthorized"}
 
 $ # POST /auth/login
 $ curl -X POST http://localhost:3000/auth/login -d '{"username": "john", "password": "changeme"}' -H "Content-Type: application/json"


### PR DESCRIPTION
slight error in the payload.
it returns a "message" field and not an "error" field

<img width="442" alt="Screen Shot 2022-01-21 at 4 01 05 PM" src="https://user-images.githubusercontent.com/42227095/150599619-cdd93ae8-4b7b-4ba0-bf48-fa7190a77d18.png">


## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A
Curl response payload has incorrect key of "error".

## What is the new behavior?
Fix the curl response payload to correct key of "message"

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information