### PR TITLE
docs(security): typo in X-Forwarded-For header

### DIFF
--- a/content/security/rate-limiting.md
+++ b/content/security/rate-limiting.md
@@ -39,7 +39,7 @@ There is also the `@Throttle()` decorator which can be used to override the `lim
 
 #### Proxies
 
-If your application runs behind a proxy server, check the specific HTTP adapter options ([express](http://expressjs.com/en/guide/behind-proxies.html) and [fastify](https://www.fastify.io/docs/latest/Server/#trustproxy)) for the `trust proxy` option and enable it. Doing so will allow you to get the original IP address from the `X-Forwarded-For` header, and you can override the `getTracker()` method to pull the value from the header rather than from `req.ip`. The following example works with both express and fastify:
+If your application runs behind a proxy server, check the specific HTTP adapter options ([express](http://expressjs.com/en/guide/behind-proxies.html) and [fastify](https://www.fastify.io/docs/latest/Reference/Server/#trustproxy)) for the `trust proxy` option and enable it. Doing so will allow you to get the original IP address from the `X-Forwarded-For` header, and you can override the `getTracker()` method to pull the value from the header rather than from `req.ip`. The following example works with both express and fastify:
 
 ```ts
 // throttler-behind-proxy.guard.ts

--- a/content/security/rate-limiting.md
+++ b/content/security/rate-limiting.md
@@ -39,7 +39,7 @@ There is also the `@Throttle()` decorator which can be used to override the `lim
 
 #### Proxies
 
-If your application runs behind a proxy server, check the specific HTTP adapter options ([express](http://expressjs.com/en/guide/behind-proxies.html) and [fastify](https://www.fastify.io/docs/latest/Server/#trustproxy)) for the `trust proxy` option and enable it. Doing so will allow you to get the original IP address from the `X-Forward-For` header, and you can override the `getTracker()` method to pull the value from the header rather than from `req.ip`. The following example works with both express and fastify:
+If your application runs behind a proxy server, check the specific HTTP adapter options ([express](http://expressjs.com/en/guide/behind-proxies.html) and [fastify](https://www.fastify.io/docs/latest/Server/#trustproxy)) for the `trust proxy` option and enable it. Doing so will allow you to get the original IP address from the `X-Forwarded-For` header, and you can override the `getTracker()` method to pull the value from the header rather than from `req.ip`. The following example works with both express and fastify:
 
 ```ts
 // throttler-behind-proxy.guard.ts


### PR DESCRIPTION
- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md

## PR Type
<!-- Please check the one that applies to this PR using "x". -->
- [x] Docs

## What is the current behavior?
There is a typo in the XFF header

## What is the new behavior?
```diff
- X-Forward-For
+ X-Forwarded-For
```

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


## Other information
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For