### PR TITLE
docs(performance): broken fastify guide link

### DIFF
--- a/content/techniques/performance.md
+++ b/content/techniques/performance.md
@@ -40,7 +40,7 @@ async function bootstrap() {
 bootstrap();
 ```
 
-By default, Fastify listens only on the `localhost 127.0.0.1` interface ([read more](https://www.fastify.io/docs/latest/Getting-Started/#your-first-server)). If you want to accept connections on other hosts, you should specify `'0.0.0.0'` in the `listen()` call:
+By default, Fastify listens only on the `localhost 127.0.0.1` interface ([read more](https://www.fastify.io/docs/latest/Guides/Getting-Started/#your-first-server)). If you want to accept connections on other hosts, you should specify `'0.0.0.0'` in the `listen()` call:
 
 ```typescript
 async function bootstrap() {


### PR DESCRIPTION
- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md

I've searched the entire project, and hopefully, this is going to be the last broken Fastify link 😄
Thanks for the patience!

## PR Type
- [x] Docs

## Does this PR introduce a breaking change?
- [x] No
