### PR TITLE
docs(caching): fixed invalid redis typings

### DIFF
--- a/content/techniques/caching.md
+++ b/content/techniques/caching.md
@@ -235,8 +235,6 @@ import { AppController } from './app.controller';
         host: 'localhost',
         port: 6379,
       },
-      // username: '',
-      // password: '',
     }),
   ],
   controllers: [AppController],

--- a/content/techniques/caching.md
+++ b/content/techniques/caching.md
@@ -220,18 +220,23 @@ class HttpCacheInterceptor extends CacheInterceptor {
 This service takes advantage of [cache-manager](https://github.com/BryanDonovan/node-cache-manager) under the hood. The `cache-manager` package supports a wide-range of useful stores, for example, [Redis store](https://github.com/dabroek/node-cache-manager-redis-store). A full list of supported stores is available [here](https://github.com/BryanDonovan/node-cache-manager#store-engines). To set up the Redis store, simply pass the package together with corresponding options to the `register()` method.
 
 ```typescript
-import type { ClientOpts as RedisClientOpts } from 'redis'
+import type { RedisClientOptions } from 'redis';
 import * as redisStore from 'cache-manager-redis-store';
 import { CacheModule, Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 
 @Module({
   imports: [
-    CacheModule.register<RedisClientOpts>({
+    CacheModule.register<RedisClientOptions>({
       store: redisStore,
+      
       // Store-specific configuration:
-      host: 'localhost',
-      port: 6379,
+      socket: {
+        host: 'localhost',
+        port: 6379,
+      },
+      // username: '',
+      // password: '',
     }),
   ],
   controllers: [AppController],


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md

## PR Type
- [x] Docs

## What is the current behavior?
The latest `redis` NPM package does not have the `ClientOpts` type.

![image](https://user-images.githubusercontent.com/37535505/152553615-61fa020e-45a6-4c33-98a4-f1fd9fac3f5e.png)


## What is the new behavior?
I've replaced the `ClientOpts` with `RedisClientOptions` type which is exported here:
https://github.com/redis/node-redis/blob/46b831c92282d16d5b224effa20cf8dc6002fd8c/packages/client/lib/client/index.ts#L18

![image](https://user-images.githubusercontent.com/37535505/152554054-77726f5d-820a-4164-b83f-d5dbaf09d4c5.png)

## Does this PR introduce a breaking change?
- [x] No
