### PR TITLE
docs(openapi): Add docs to throw different exceptions under the same …

### DIFF
--- a/content/openapi/types-and-parameters.md
+++ b/content/openapi/types-and-parameters.md
@@ -298,3 +298,24 @@ pets: Pet[];
 > info **Hint** The `getSchemaPath()` function is imported from `@nestjs/swagger`.
 
 Both `Cat` and `Dog` must be defined as extra models using the `@ApiExtraModels()` decorator (at the class-level).
+
+#### Multiple responses in controller
+
+In case your app returns different exceptions with under the same HTTP status code, you might use `@ApiExtraModels()` in this way:
+
+```typescript
+@Injectable()
+export class CatController {
+  @ApiExtraModels(BadAppCodeException, BadEmailException)
+  @ApiBadRequestResponse({
+    schema: {
+      oneOf: refs(BadAppCodeException, BadEmailException),
+    },
+  })
+  multipleErrorsResponse() { ... }
+}
+```
+
+First, you tell swagger that `BadAppCodeException` and `BadEmailException` are models it needs to look at. After that, you use `oneOf` and `refs` to set the different exceptions your API might throw.
+
+> info **Hint** The `refs()` function is imported from `@nestjs/swagger`.


### PR DESCRIPTION
…http code

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
I think it's worthy to add this part to the docs because the decorator `@ApiExtraModels()` doesn't have an concrete example of its implementation.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
