### PR TITLE
Update task-scheduling.md

### DIFF
--- a/content/techniques/task-scheduling.md
+++ b/content/techniques/task-scheduling.md
@@ -66,11 +66,11 @@ In the example above, we passed `45 * * * * *` to the decorator. The following k
 * * * * * *
 | | | | | |
 | | | | | day of week
-| | | | month
+| | | | months
 | | | day of month
-| | hour
-| minute
-second (optional)
+| | hours
+| minutes
+seconds (optional)
 </code></pre>
 
 Some sample cron patterns are:


### PR DESCRIPTION
When I was reading the documentation of https://github.com/kelektiv/node-cron#cron-ranges I find that `cron values` are defined as plural inflection. Hence I thought to make it consistent.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
