### PR TITLE
docs(exceptions-filters): minor improvements

### DIFF
--- a/content/exception-filters.md
+++ b/content/exception-filters.md
@@ -238,7 +238,7 @@ In the example above, the `HttpExceptionFilter` is applied only to the single `c
 
 ```typescript
 @@filename(cats.controller)
-@UseFilters(new HttpExceptionFilter())
+@UseFilters(HttpExceptionFilter)
 export class CatsController {}
 ```
 
@@ -358,14 +358,14 @@ The above implementation is just a shell demonstrating the approach. Your implem
 
 Global filters **can** extend the base filter. This can be done in either of two ways.
 
-The first method is to inject the `HttpServer` reference when instantiating the custom global filter:
+The first method is to inject the `HttpAdapterHost` reference when instantiating the custom global filter:
 
 ```typescript
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
 
-  const { httpAdapter } = app.get(HttpAdapterHost);
-  app.useGlobalFilters(new AllExceptionsFilter(httpAdapter));
+  const httpAdapterHost = app.get(HttpAdapterHost);
+  app.useGlobalFilters(new AllExceptionsFilter(httpAdapterHost));
 
   await app.listen(3000);
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

- Doc uses `new` once again even after the class technique was introduced and encouraged
- Doc references old HttpServer and passes wrong argument to exception filter constructor

## What is the new behavior?

Doc uses class reference and passes HttpAdapterHost to exception filter constructor.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
