### PR TITLE
docs(faq/serverless): update `serverless.yml` example

### DIFF
--- a/content/faq/serverless.md
+++ b/content/faq/serverless.md
@@ -186,15 +186,14 @@ $ npm i -D @types/aws-lambda serverless-offline
 Once the installation process is complete, let's create the `serverless.yml` file to configure the Serverless framework:
 
 ```yaml
-service:
-  name: serverless-example
+service: serverless-example
 
 plugins:
   - serverless-offline
 
 provider:
   name: aws
-  runtime: nodejs12.x
+  runtime: nodejs14.x
 
 functions:
   main:


### PR DESCRIPTION
Updates service property to be a string representing the service's name instead of an object;
Updates runtime to the latest LTS version supported by AWS λ

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?


- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
The current example for `serverless.yml` is outdated. 

The service property as it is now throws the following error when `sls offline` is called:
```sh
Error:
Object notation for "service" property is not supported. Set "service" property directly with service name.
```

And since February 2021, [AWS λ is supporting Node.js 14.x runtime](https://aws.amazon.com/blogs/compute/node-js-14-x-runtime-now-available-in-aws-lambda/).

Issue Number: N/A


## What is the new behavior?
Accordingly to the [Serverless Deprecations](https://www.serverless.com/framework/docs/deprecations#service-property-object-notation), the service must be a string. And the runtime should be the latest supported. 

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
