### PR TITLE
Update cli-plugin.md

### DIFF
--- a/content/openapi/cli-plugin.md
+++ b/content/openapi/cli-plugin.md
@@ -42,7 +42,7 @@ export class CreateUserDto {
 
 While not a significant issue with medium-sized projects, it becomes verbose & hard to maintain once you have a large set of classes.
 
-By enabling the Swagger plugin, the above class definition can be declared simply:
+By [enabling the Swagger plugin](#using-the-cli-plugin), the above class definition can be declared simply:
 
 ```typescript
 export class CreateUserDto {


### PR DESCRIPTION
"enabling the Swagger plugin" appears too similar to installing and configuring the Swagger module (at first glace) - adding link to "enabling the CLI plugin" will reduce questions and confusion on StackOverflow (see examples: https://stackoverflow.com/questions/59368042/how-to-enable-nestjs-swagger-4-x-plugin)

