### PR TITLE
docs(swagger): added missing ApiExcludeController decorator

### DIFF
--- a/content/openapi/decorators.md
+++ b/content/openapi/decorators.md
@@ -17,7 +17,7 @@ All of the available OpenAPI decorators have an `Api` prefix to distinguish them
 | `@ApiParam()`             | Method              |
 | `@ApiQuery()`             | Method              |
 | `@ApiHeader()`            | Method / Controller |
-| `@ApiExcludeController()` | Method / Controller |
+| `@ApiExcludeController()` | Controller          |
 | `@ApiExcludeEndpoint()`   | Method              |
 | `@ApiTags()`              | Method / Controller |
 | `@ApiProperty()`          | Model               |

--- a/content/openapi/decorators.md
+++ b/content/openapi/decorators.md
@@ -8,6 +8,7 @@ All of the available OpenAPI decorators have an `Api` prefix to distinguish them
 | `@ApiResponse()`          | Method / Controller |
 | `@ApiProduces()`          | Method / Controller |
 | `@ApiConsumes()`          | Method / Controller |
+| `@ApiCookieAuth()`        | Method / Controller |
 | `@ApiBearerAuth()`        | Method / Controller |
 | `@ApiOAuth2()`            | Method / Controller |
 | `@ApiBasicAuth()`         | Method / Controller |

--- a/content/openapi/decorators.md
+++ b/content/openapi/decorators.md
@@ -2,24 +2,25 @@
 
 All of the available OpenAPI decorators have an `Api` prefix to distinguish them from the core decorators. Below is a full list of the exported decorators along with a designation of the level at which the decorator may be applied.
 
-|                          |                     |
-| ------------------------ | ------------------- |
-| `@ApiOperation()`        | Method              |
-| `@ApiResponse()`         | Method / Controller |
-| `@ApiProduces()`         | Method / Controller |
-| `@ApiConsumes()`         | Method / Controller |
-| `@ApiBearerAuth()`       | Method / Controller |
-| `@ApiOAuth2()`           | Method / Controller |
-| `@ApiBasicAuth()`        | Method / Controller |
-| `@ApiSecurity()`         | Method / Controller |
-| `@ApiExtraModels()`      | Method / Controller |
-| `@ApiBody()`             | Method              |
-| `@ApiParam()`            | Method              |
-| `@ApiQuery()`            | Method              |
-| `@ApiHeader()`           | Method / Controller |
-| `@ApiExcludeEndpoint()`  | Method              |
-| `@ApiTags()`             | Method / Controller |
-| `@ApiProperty()`         | Model               |
-| `@ApiPropertyOptional()` | Model               |
-| `@ApiHideProperty()`     | Model               |
-| `@ApiExtension()`        | Method              |
+|                           |                     |
+| ------------------------- | ------------------- |
+| `@ApiOperation()`         | Method              |
+| `@ApiResponse()`          | Method / Controller |
+| `@ApiProduces()`          | Method / Controller |
+| `@ApiConsumes()`          | Method / Controller |
+| `@ApiBearerAuth()`        | Method / Controller |
+| `@ApiOAuth2()`            | Method / Controller |
+| `@ApiBasicAuth()`         | Method / Controller |
+| `@ApiSecurity()`          | Method / Controller |
+| `@ApiExtraModels()`       | Method / Controller |
+| `@ApiBody()`              | Method              |
+| `@ApiParam()`             | Method              |
+| `@ApiQuery()`             | Method              |
+| `@ApiHeader()`            | Method / Controller |
+| `@ApiExcludeController()` | Method / Controller |
+| `@ApiExcludeEndpoint()`   | Method              |
+| `@ApiTags()`              | Method / Controller |
+| `@ApiProperty()`          | Model               |
+| `@ApiPropertyOptional()`  | Model               |
+| `@ApiHideProperty()`      | Model               |
+| `@ApiExtension()`         | Method              |

--- a/content/openapi/decorators.md
+++ b/content/openapi/decorators.md
@@ -4,24 +4,24 @@ All of the available OpenAPI decorators have an `Api` prefix to distinguish them
 
 |                           |                     |
 | ------------------------- | ------------------- |
-| `@ApiOperation()`         | Method              |
-| `@ApiResponse()`          | Method / Controller |
-| `@ApiProduces()`          | Method / Controller |
+| `@ApiBasicAuth()`         | Method / Controller |
+| `@ApiBearerAuth()`        | Method / Controller |
+| `@ApiBody()`              | Method              |
 | `@ApiConsumes()`          | Method / Controller |
 | `@ApiCookieAuth()`        | Method / Controller |
-| `@ApiBearerAuth()`        | Method / Controller |
-| `@ApiOAuth2()`            | Method / Controller |
-| `@ApiBasicAuth()`         | Method / Controller |
-| `@ApiSecurity()`          | Method / Controller |
-| `@ApiExtraModels()`       | Method / Controller |
-| `@ApiBody()`              | Method              |
-| `@ApiParam()`             | Method              |
-| `@ApiQuery()`             | Method              |
-| `@ApiHeader()`            | Method / Controller |
 | `@ApiExcludeController()` | Controller          |
 | `@ApiExcludeEndpoint()`   | Method              |
-| `@ApiTags()`              | Method / Controller |
+| `@ApiExtension()`         | Method              |
+| `@ApiExtraModels()`       | Method / Controller |
+| `@ApiHeader()`            | Method / Controller |
+| `@ApiHideProperty()`      | Model               |
+| `@ApiOAuth2()`            | Method / Controller |
+| `@ApiOperation()`         | Method              |
+| `@ApiParam()`             | Method              |
+| `@ApiProduces()`          | Method / Controller |
 | `@ApiProperty()`          | Model               |
 | `@ApiPropertyOptional()`  | Model               |
-| `@ApiHideProperty()`      | Model               |
-| `@ApiExtension()`         | Method              |
+| `@ApiQuery()`             | Method              |
+| `@ApiResponse()`          | Method / Controller |
+| `@ApiSecurity()`          | Method / Controller |
+| `@ApiTags()`              | Method / Controller |


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
- [x] Docs

## What is the current behavior?
`@nestjs/swagger` version [5.0.0](https://github.com/nestjs/swagger/releases/tag/5.0.0) added a new decorator to exclude controllers.
But the documentation doesn't have that on the list.

## What is the new behavior?
I've added it to the list.

I also had to format the markdown table cause the decorator had an extra character!
Sorry if it's a bit confusing while reviewing 😄 (it's on the line 20)

## Does this PR introduce a breaking change?
- [x] No
