### PR TITLE
docs(mikroorm): add a caveat about serialization

### DIFF
--- a/content/recipes/mikroorm.md
+++ b/content/recipes/mikroorm.md
@@ -192,7 +192,6 @@ Luckily, MikroORM provides a [serialization API](https://mikro-orm.io/docs/seria
 ```typescript
 @Entity()
 export class Book {
-
   @Property({ hidden: true }) // Equivalent of class-transformer's `@Exclude`
   hiddenField = Date.now();
   

--- a/content/recipes/mikroorm.md
+++ b/content/recipes/mikroorm.md
@@ -182,6 +182,13 @@ object.
 > still need CLI config with the full list of entities. On the other hand, we can
 > use globs there, as the CLI won't go thru webpack.
 
+
+#### Serialization
+
+> warning **Note** MikroORM wraps every single entity relation in a `Reference<T>` or a `Collection<T>` object, in order to provide better type-safety. This doesn't play well with class-transformer and the [serialization technique described in the NestJS docs](/techniques/serialization).
+
+In order to achieve serialization with MikroORM, the recommended way is to use the [built-in serialization API](https://mikro-orm.io/docs/serializing).
+
 #### Request scoped handlers in queues
 
 > info **info** `@UseRequestContext()` decorator was added in v4.1.0


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
The serialization technique (`ClassSerializerInterceptor`) in the docs is misleading for MikroORM users, since this ORM wraps all entity relations in reference objects, making class-transformer blind regarding wrapped entities. So it's fairly easy for a newcomer to get confused (well, I was 😅 ).

## What is the new behavior?
Add a section in the MikroORM recipe to warn about this, and suggest using the MikroORM serialization API which provide a way to hide, expose and transform properties too.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
