### PR TITLE
docs(terminus): replaced AppModule with the HealthModule

### DIFF
--- a/content/recipes/terminus.md
+++ b/content/recipes/terminus.md
@@ -31,13 +31,9 @@ A health check represents a summary of **health indicators**. A health indicator
 - `MemoryHealthIndicator`
 - `DiskHealthIndicator`
 
-To get started with our first health check, let's generate the `HealthModule` now using [Nest CLI](/cli/overview).
+To get started with our first health check, let's create the `HealthModule` and import the `TerminusModule` into it in its imports array.
 
-```bash
-$ nest g module health
-```
-
-Once generated, we can import the `TerminusModule` into it in its imports array.
+> info **Hint** To create the module using the [Nest CLI](cli/overview), simply execute the `$ nest g module health` command.
 
 ```typescript
 @@filename(health.module)

--- a/content/recipes/terminus.md
+++ b/content/recipes/terminus.md
@@ -22,26 +22,32 @@ $ npm install --save @nestjs/terminus
 
 A health check represents a summary of **health indicators**. A health indicator executes a check of a service, whether it is in a healthy or unhealthy state. A health check is positive if all the assigned health indicators are up and running. Because a lot of applications will need similar health indicators, [`@nestjs/terminus`](https://github.com/nestjs/terminus) provides a set of predefined indicators, such as:
 
-- `HttpHealthIndicator`
-- `TypeOrmHealthIndicator`
-- `MongooseHealthIndicator`
-- `SequelizeHealthIndicator`
-- `MicroserviceHealthIndicator`
-- `GRPCHealthIndicator`
-- `MemoryHealthIndicator`
-- `DiskHealthIndicator`
+-   `HttpHealthIndicator`
+-   `TypeOrmHealthIndicator`
+-   `MongooseHealthIndicator`
+-   `SequelizeHealthIndicator`
+-   `MicroserviceHealthIndicator`
+-   `GRPCHealthIndicator`
+-   `MemoryHealthIndicator`
+-   `DiskHealthIndicator`
 
-To get started with our first health check, we need to import the `TerminusModule` into our `AppModule`.
+To get started with our first health check, let's generate the `HealthModule` now using [Nest CLI](/cli/overview).
+
+```bash
+$ nest g module health
+```
+
+Once generated, we can import the `TerminusModule` into it in its imports array.
 
 ```typescript
-@@filename(app.module)
+@@filename(health.module)
 import { Module } from '@nestjs/common';
 import { TerminusModule } from '@nestjs/terminus';
 
 @Module({
   imports: [TerminusModule]
 })
-export class AppModule {}
+export class HealthModule {}
 ```
 
 Our healthcheck(s) can be executed using a [controller](/controllers), which can be easily set up using the [Nest CLI](cli/overview).
@@ -303,7 +309,7 @@ export class DogHealthIndicator extends HealthIndicator {
 The next thing we need to do is register the health indicator as a provider.
 
 ```typescript
-@@filename(app.module)
+@@filename(health.module)
 import { Module } from '@nestjs/common';
 import { TerminusModule } from '@nestjs/terminus';
 import { DogHealthIndicator } from './dog.health';
@@ -313,10 +319,10 @@ import { DogHealthIndicator } from './dog.health';
   imports: [TerminusModule],
   providers: [DogHealthIndicator]
 })
-export class AppModule { }
+export class HealthModule { }
 ```
 
-> info **Hint** In a real-world application the `DogHealthIndicator` should be provided in a separate module, for example, `DogModule`, which then will be imported by the `AppModule`.
+> info **Hint** In a real-world application the `DogHealthIndicator` should be provided in a separate module, for example, `DogModule`, which then will be imported by the `HealthModule`.
 
 The last required step is to add the now available health indicator in the required health check endpoint. For that, we go back to our `HealthController` and add it to our `check` function.
 

--- a/content/recipes/terminus.md
+++ b/content/recipes/terminus.md
@@ -98,6 +98,29 @@ export class HealthController {
 }
 ```
 
+```typescript
+@@filename(health.module)
+import { Module } from '@nestjs/common';
+import { TerminusModule } from '@nestjs/terminus';
+import { HealthController } from './health.controller';
+
+@Module({
+  imports: [TerminusModule],
+  controllers: [HealthController],
+})
+export class HealthModule {}
+@@switch
+import { Module } from '@nestjs/common';
+import { TerminusModule } from '@nestjs/terminus';
+import { HealthController } from './health.controller';
+
+@Module({
+  imports: [TerminusModule],
+  controllers: [HealthController],
+})
+export class HealthModule {}
+```
+
 > warning **Warning** `HttpHealthIndicator` requires the installation of the `@nestjs/axios` package and the import of `HttpModule`.
 
 Our health check will now send a _GET_-request to the `https://docs.nestjs.com` address. If

--- a/content/recipes/terminus.md
+++ b/content/recipes/terminus.md
@@ -22,14 +22,14 @@ $ npm install --save @nestjs/terminus
 
 A health check represents a summary of **health indicators**. A health indicator executes a check of a service, whether it is in a healthy or unhealthy state. A health check is positive if all the assigned health indicators are up and running. Because a lot of applications will need similar health indicators, [`@nestjs/terminus`](https://github.com/nestjs/terminus) provides a set of predefined indicators, such as:
 
--   `HttpHealthIndicator`
--   `TypeOrmHealthIndicator`
--   `MongooseHealthIndicator`
--   `SequelizeHealthIndicator`
--   `MicroserviceHealthIndicator`
--   `GRPCHealthIndicator`
--   `MemoryHealthIndicator`
--   `DiskHealthIndicator`
+- `HttpHealthIndicator`
+- `TypeOrmHealthIndicator`
+- `MongooseHealthIndicator`
+- `SequelizeHealthIndicator`
+- `MicroserviceHealthIndicator`
+- `GRPCHealthIndicator`
+- `MemoryHealthIndicator`
+- `DiskHealthIndicator`
 
 To get started with our first health check, let's generate the `HealthModule` now using [Nest CLI](/cli/overview).
 


### PR DESCRIPTION
- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md

## PR Type

- [x] Docs


## What is the current behavior?
The code block for writing the health controller exists, but there isn't a sample regarding its module.

## What is the new behavior?

I've added the code block.

## Does this PR introduce a breaking change?
- [x] No
