### PR TITLE
Clarify that lifecycle doesn't apply to lazy loaded modules

### DIFF
--- a/content/fundamentals/lazy-loading-modules.md
+++ b/content/fundamentals/lazy-loading-modules.md
@@ -6,6 +6,8 @@ Lazy loading can help decrease bootstrap time by loading only modules required b
 
 > info **Hint** If you're familiar with the **Angular** framework, you might have seen the "lazy-loading modules" term before. Be aware that this technique is **functionally different** in Nest and so think about this as an entirely different feature that shares similar naming conventions.
 
+> warning **Warning** Do note that [lifecycle hooks methods](https://docs.nestjs.com/fundamentals/lifecycle-events) are not invoked in lazy loaded modules and services.
+
 #### Getting started
 
 To load modules on-demand, Nest provides the `LazyModuleLoader` class that can be injected into a class in the normal way:


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?

I tried to use all the lifecycle hooks methods in a module (and its service) that was lazy loaded but none of them was called. But I didn't find any mention on the docs site regarding that behavior.

<details><summary>demo</summary>

![image](https://user-images.githubusercontent.com/13461315/162590264-f5938230-57f8-4c37-935e-338088632138.png)

```ts
// app.service.ts
@Injectable()
export class AppService {
  constructor(private readonly lazyModuleLoader: LazyModuleLoader) {}
  async getHello(): Promise<string> {
    const { LazyModule } = await import('./lazy.module');
    const moduleRef = await this.lazyModuleLoader.load(() => LazyModule);
    const lazyService = moduleRef.get(LazyService);
    return lazyService.getHello();
  }
}
```

```ts
// app.module.ts
@Module({
  imports: [],
  controllers: [AppController],
  providers: [AppService],
})
export class AppModule {
  onModuleInit() {
    console.log('[nestjs] AppModule initialized')
  }
}
```

```ts
// lazy.service.ts
@Injectable()
export class LazyService {
  onModuleInit() {
    console.log('A')
  }
  onApplicatoinBootstrap() {
    console.log('B')
  }
  onModuleDestroy() {
    console.log('C')
  }
  beforeApplicationShutdown() {
    console.log('D')
  }
  onApplicationShutdown() {
    console.log('E')
  }

  getHello(): string {
    return 'Hello World From lazy service!';
  }
}
```

```ts
// lazy.module.ts
console.log('[nodejs] lazy.module.ts loaded')
@Module({
  providers: [LazyService],
})
export class LazyModule {
  onModuleInit() {
    console.log('A')
  }
  onApplicatoinBootstrap() {
    console.log('B')
  }
  onModuleDestroy() {
    console.log('C')
  }
  beforeApplicationShutdown() {
    console.log('D')
  }
  onApplicationShutdown() {
    console.log('E')
  }
}
```

</details>

## What is the new behavior?

I'm not sure what's the best way to document that, but we should mention that those lifecycle hooks methods are not called on lazy loaded modules. 


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

