### PR TITLE
refactor(styles): rename incorrect css property

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -402,7 +402,7 @@ perfect-scrollbar[fxlayout] > .ps > .ps-content {
   flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   -webkit-box-flex: 1;
-  align-item: inherit;
+  align-items: inherit;
   place-content: inherit;
   -webkit-box-pack: inherit;
   -webkit-box-align: inherit;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x ] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
A incorrect css property was causing a warning when running the documentation

![before](https://user-images.githubusercontent.com/48860569/162593998-cdd3998f-6074-4e85-a149-5f51f7d29512.png)


## What is the new behavior?

![after](https://user-images.githubusercontent.com/48860569/162594009-83035272-7091-4e25-81e9-00c01e0e2949.png)


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
