### PR TITLE
Corrected response decorator @Res

### DIFF
--- a/content/techniques/streaming-files.md
+++ b/content/techniques/streaming-files.md
@@ -49,14 +49,14 @@ export class FileController {
 The default content type is `application/octet-stream`, if you need to customize the response you can use the `res.set` method.
 
 ```ts
-import { Controller, Get, StreamableFile, Response } from '@nestjs/common';
+import { Controller, Get, StreamableFile, Res } from '@nestjs/common';
 import { createReadStream } from 'fs';
 import { join } from 'path';
 
 @Controller('file')
 export class FileController {
   @Get()
-  getFile(@Response({ passthrough: true }) res): StreamableFile {
+  getFile(@Res({ passthrough: true }) res): StreamableFile {
     const file = createReadStream(join(process.cwd(), 'package.json'));
     res.set({
       'Content-Type': 'application/json',


### PR DESCRIPTION
Seems to be older `@Response` instead of `@Res`

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
