### PR TITLE
docs(sql): Update multuple database connections docs

### DIFF
--- a/content/techniques/sql.md
+++ b/content/techniques/sql.md
@@ -589,6 +589,16 @@ At this point, you have `User` and `Album` entities registered with their own co
 })
 export class AppModule {}
 ```
+```typescript
+@@filename(album.service)
+@Injectable()
+export class AlbumService {
+    constructor(
+        @InjectRepository(Album, 'albumsConnection')
+        private readonly albumRepository: Repository<Album>
+    ) { }     
+}
+```
 
 You can also inject the `Connection` or `EntityManager` for a given connection:
 


### PR DESCRIPTION
Emphasize that it's mendatory to also mention the connection name in `@InjectRepository()` (in addition to `forFeature()`) by *adding a relevant code snippet*.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [v] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [v] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
It was not clear enough that the connection name needs to be specified not only in the `module.ts` file (in the `.forFeature()`), but also in the `service.ts` file too (in the `@InjectRepo()`).

Issue Number: N/A


## What is the new behavior?
In addition to the `module.ts` code snippet - showing you need to specify the connection name in `forFeature()` - I added a related code snippet to let devs know to add the connection name in `@InjectRepository()` too.

## Does this PR introduce a breaking change?
- [ ] Yes
- [v] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
I know it's mentioned in the paragrah above the code snippet, but I totally missed it, and it took me too long till something in stackoverflow made me realize I need to mention it in the InjectRepo too