### PR TITLE
docs(migration): Mention "HttpService" has to be imported from "@nest…

### DIFF
--- a/content/migration.md
+++ b/content/migration.md
@@ -5,7 +5,7 @@ To learn more about the new features we've added in the v8, check out this [link
 
 #### HTTP module
 
-The `HttpModule` exported from the `@nestjs/common` package has been deprecated and will be removed in the next major release.
+The `HttpModule` and `HttpService` exported from the `@nestjs/common` package have been deprecated and will be removed in the next major release.
 Instead, please use the `@nestjs/axios` package (otherwise, there are no API differences).
 
 #### gRPC strategy


### PR DESCRIPTION
The migration guide mentions `HttpModule` imports have to be moved from `@nestjs/common` to `@nestjs/axios`.
The same has to be done with `HttpService`, which is not stated in the doc.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:

