### PR TITLE
Missing MongoDB documentation 'export' keyword

### DIFF
--- a/content/techniques/mongo.md
+++ b/content/techniques/mongo.md
@@ -491,7 +491,7 @@ The construction above instantiates `MongooseConfigService` inside `MongooseModu
 
 ```typescript
 @Injectable()
-class MongooseConfigService implements MongooseOptionsFactory {
+export class MongooseConfigService implements MongooseOptionsFactory {
   createMongooseOptions(): MongooseModuleOptions {
     return {
       uri: 'mongodb://localhost/nest',


### PR DESCRIPTION
docs: Incomplete MongoDB documentation

Missing 'export' keyword from **MongooseConfigService class** on https://docs.nestjs.com/techniques/mongodb

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No