### PR TITLE
docs(graphql): context not in subscription object

### DIFF
--- a/content/graphql/subscriptions.md
+++ b/content/graphql/subscriptions.md
@@ -334,19 +334,22 @@ All subscriptions made with this connection will have the same `authToken`, and 
 If you're using the `graphql-ws` package, the signature of the `onConnect` callback will be slightly different:
 
 ```typescript
-subscriptions: {
-  'graphql-ws': {
-    onConnect: (context: Context<any>) => {
-      const { connectionParams, extra } = context;
-      // user validation will remain the same as in the example above
-      // when using with graphql-ws, additional context value should be stored in the extra field
-      extra.user = { user: {} };
+GraphQLModule.forRoot<ApolloDriverConfig>({
+  driver: ApolloDriver,
+  subscriptions: {
+    'graphql-ws': {
+      onConnect: (context: Context<any>) => {
+        const { connectionParams, extra } = context;
+        // user validation will remain the same as in the example above
+        // when using with graphql-ws, additional context value should be stored in the extra field
+        extra.user = { user: {} };
+      },
     },
   },
   context: ({ extra }) => {
     // you can now access your additional context value through the extra field
-  }
-},
+  },
+});
 ```
 
 #### Enable subscriptions with Mercurius driver


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?

The `context` object isn't part of the `subscriptions` object.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
