### PR TITLE
docs(graphql): Fix incorrect import

### DIFF
--- a/content/graphql/complexity.md
+++ b/content/graphql/complexity.md
@@ -19,7 +19,8 @@ $ npm install --save graphql-query-complexity
 Once the installation process is complete, we can define the `ComplexityPlugin` class:
 
 ```typescript
-import { GraphQLSchemaHost, Plugin } from '@nestjs/graphql';
+import { GraphQLSchemaHost } from "@nestjs/graphql";
+import { Plugin } from "@nestjs/apollo";
 import {
   ApolloServerPlugin,
   GraphQLRequestListener,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?

The example imports a module from the wrong package.

Issue Number: N/A


## What is the new behavior?

The docs example code is updated to match the working example in https://github.com/nestjs/nest/tree/master/sample/23-graphql-code-first


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

The existing example will error with the following message:

```
❯ npm start

> nest-typescript-starter@1.0.0 start
> nest start

src/common/plugins/complexity.plugin.ts:1:29 - error TS2305: Module '"@nestjs/graphql"' has no exported member 'Plugin'.

1 import { GraphQLSchemaHost, Plugin } from "@nestjs/graphql";
                              ~~~~~~

Found 1 error(s).
```

This same change was made in the samples a few months ago: https://github.com/nestjs/nest/commit/d8ba5d16e6e9abcc3c7e1dbe3951bbeee6d0044b#diff-5b158b02130ed8dc4bbebe1b6b42e0ecee7573c44e3850dd013c26765dd52b67