### PR TITLE
docs: add hint on abort on error behavior

### DIFF
--- a/content/first-steps.md
+++ b/content/first-steps.md
@@ -72,6 +72,8 @@ To create a Nest application instance, we use the core `NestFactory` class. `Nes
 
 Note that a project scaffolded with the Nest CLI creates an initial project structure that encourages developers to follow the convention of keeping each module in its own dedicated directory.
 
+> info **Hint** By default, if any error happens while creating the application your app will exit with the code `1`. If you want to make it throw an error instead disable the option `abortOnError` (e.g., `NestFactory.create(AppModule, {{ '{' }} abortOnError: false {{ '}' }})`).
+
 <app-banner-courses></app-banner-courses>
 
 #### Platform


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?

no mention on the `abortOnError` flag. I didn't realise that this option exists and took me some time to understand why `NestFactory.create` was exiting the app instead of rejecting the promise

## What is the new behavior?

clarify that the process will abort on error by default

![image](https://user-images.githubusercontent.com/13461315/169174113-8f75e0fc-b2b9-4af5-9532-4e76f3f01d56.png)



## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No