### PR TITLE
docs(typeorm): Adapt to new typorm syntax

### DIFF
--- a/content/recipes/sql-typeorm.md
+++ b/content/recipes/sql-typeorm.md
@@ -18,23 +18,27 @@ The first step we need to do is to establish the connection with our database us
 
 ```typescript
 @@filename(database.providers)
-import { createConnection } from 'typeorm';
+import { DataSource } from 'typeorm';
 
 export const databaseProviders = [
   {
-    provide: 'DATABASE_CONNECTION',
-    useFactory: async () => await createConnection({
-      type: 'mysql',
-      host: 'localhost',
-      port: 3306,
-      username: 'root',
-      password: 'root',
-      database: 'test',
-      entities: [
-          __dirname + '/../**/*.entity{.ts,.js}',
-      ],
-      synchronize: true,
-    }),
+    provide: 'DATA_SOURCE',
+    useFactory: async () => {
+      const dataSource = new DataSource({
+        type: 'mysql',
+        host: 'localhost',
+        port: 3306,
+        username: 'root',
+        password: 'root',
+        database: 'test',
+        entities: [
+            __dirname + '/../**/*.entity{.ts,.js}',
+        ],
+        synchronize: true,
+      });
+
+      return dataSource.initialize();
+    },
   },
 ];
 ```
@@ -95,14 +99,14 @@ The `Photo` entity belongs to the `photo` directory. This directory represents t
 
 ```typescript
 @@filename(photo.providers)
-import { Connection } from 'typeorm';
+import { DataSource } from 'typeorm';
 import { Photo } from './photo.entity';
 
 export const photoProviders = [
   {
     provide: 'PHOTO_REPOSITORY',
-    useFactory: (connection: Connection) => connection.getRepository(Photo),
-    inject: ['DATABASE_CONNECTION'],
+    useFactory: (dataSource: DataSource) => dataSource.getRepository(Photo),
+    inject: ['DATA_SOURCE'],
   },
 ];
 ```


### PR DESCRIPTION
Use new syntax to create database connection in typeorm introduced in [0.3.0](https://typeorm.io/changelog#030httpsgithubcomtypeormtypeormpull8616-2022-03-17)

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
Syntax used is deprecated since typeorm version 0.3.0.

Issue Number: N/A


## What is the new behavior?
Uses new syntax.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
