### PR TITLE
docs(microservices): drop deprecated `toPromise` from snippets

### DIFF
--- a/content/microservices/basics.md
+++ b/content/microservices/basics.md
@@ -355,21 +355,19 @@ The `data` property is the message payload sent by the message producer. The `pa
 
 #### Handling timeouts
 
-In distributed systems, sometimes microservices might be down or not available. To avoid infinitely long waiting, you can use Timeouts. A timeout is an incredibly useful pattern when communicating with other services. To apply timeouts to your microservice calls, you can use the `RxJS` timeout operator. If the microservice does not respond to the request within a certain time, an exception is thrown, which can be caught and handled appropriately.
+In distributed systems, sometimes microservices might be down or not available. To avoid infinitely long waiting, you can use Timeouts. A timeout is an incredibly useful pattern when communicating with other services. To apply timeouts to your microservice calls, you can use the [RxJS](https://rxjs.dev) `timeout` operator. If the microservice does not respond to the request within a certain time, an exception is thrown, which can be caught and handled appropriately.
 
-To solve this problem you have to use [rxjs](https://github.com/ReactiveX/rxjs) package. Just use the `timeout` operator in the pipe:
+To solve this problem you have to use [`rxjs`](https://github.com/ReactiveX/rxjs) package. Just use the `timeout` operator in the pipe:
 
 ```typescript
 @@filename()
 this.client
       .send<TResult, TInput>(pattern, data)
-      .pipe(timeout(5000))
-      .toPromise();
+      .pipe(timeout(5000));
 @@switch
 this.client
       .send(pattern, data)
-      .pipe(timeout(5000))
-      .toPromise();
+      .pipe(timeout(5000));
 ```
 
 > info **Hint** The `timeout` operator is imported from the `rxjs/operators` package.


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information

I don't see any good reason to transform the returned observable to promise as all the other examples of `this.client.send` are using Observables, so I just remove the deprecated `toPromise` call