### PR TITLE
docs(caching): update redis custom host and port

### DIFF
--- a/content/techniques/caching.md
+++ b/content/techniques/caching.md
@@ -220,27 +220,28 @@ class HttpCacheInterceptor extends CacheInterceptor {
 This service takes advantage of [cache-manager](https://github.com/BryanDonovan/node-cache-manager) under the hood. The `cache-manager` package supports a wide-range of useful stores, for example, [Redis store](https://github.com/dabroek/node-cache-manager-redis-store). A full list of supported stores is available [here](https://github.com/BryanDonovan/node-cache-manager#store-engines). To set up the Redis store, simply pass the package together with corresponding options to the `register()` method.
 
 ```typescript
-import type { RedisClientOptions } from 'redis';
+import type { ClientOpts } from 'redis';
 import * as redisStore from 'cache-manager-redis-store';
 import { CacheModule, Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 
 @Module({
   imports: [
-    CacheModule.register<RedisClientOptions>({
+    CacheModule.register<ClientOpts>({
       store: redisStore,
 
       // Store-specific configuration:
-      socket: {
-        host: 'localhost',
-        port: 6379,
-      },
+      host: 'localhost',
+      port: 6379,
     }),
   ],
   controllers: [AppController],
 })
 export class AppModule {}
 ```
+
+> warning**Warning** `cache-manager-redis-store` does not support redis v4. In order for the `ClientOpts` interface to exist and work correctly you need to install the
+> latest `redis` 3.x.x major release. See this [issue](https://github.com/dabroek/node-cache-manager-redis-store/issues/40) to track the progress of this upgrade.
 
 #### Async configuration
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [X] Docs
- [ ] Other... Please describe:


## What is the current behavior?
The documentation takes into account that cache-manager-redis-store supports redis v4, thus leading the reader to believe that they are setting the host and port when this is not read.

Issue Number: #2324


## What is the new behavior?
It informs the actual parameters that are taken into account and explains to the reader why he should download redis major 3 version.

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
