### PR TITLE
docs(recipes): fixes webpack hmr config

### DIFF
--- a/content/recipes/hot-reload.md
+++ b/content/recipes/hot-reload.md
@@ -24,9 +24,8 @@ Once the installation is complete, create a `webpack-hmr.config.js` file in the 
 
 ```typescript
 const nodeExternals = require('webpack-node-externals');
-const { RunScriptWebpackPlugin } = require('run-script-webpack-plugin');
 
-module.exports = function (options, webpack) {
+module.exports = function(options, webpack) {
   return {
     ...options,
     entry: ['webpack/hot/poll?100', options.entry],
@@ -37,11 +36,10 @@ module.exports = function (options, webpack) {
     ],
     plugins: [
       ...options.plugins,
-      new webpack.HotModuleReplacementPlugin(),
       new webpack.WatchIgnorePlugin({
         paths: [/\.js$/, /\.d\.ts$/],
       }),
-      new RunScriptWebpackPlugin({ name: options.output.filename }),
+      new webpack.HotModuleReplacementPlugin(),
     ],
   };
 };


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The Webpack HMR config is outdated. The guide within our docs won't work when using `nest-cli`.

Issue Number: [nestjs#9748](https://github.com/nestjs/nest/issues/9748)


## What is the new behavior?

I've updated with a config that enables HMR properly.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
