### PR TITLE
docs(tests): added missing import for auto-mocking

### DIFF
--- a/content/fundamentals/unit-testing.md
+++ b/content/fundamentals/unit-testing.md
@@ -166,7 +166,7 @@ Nest also allows you to define a mock factory to apply to all of your missing de
 
 ```typescript
 // ...
-import { ModuleMocker } from 'jest-mock';
+import { ModuleMocker, MockFunctionMetadata } from 'jest-mock';
 
 const moduleMocker = new ModuleMocker(global);
 


### PR DESCRIPTION
Added type import for MockFunctionMetadata.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
Example with auto-mocking has no import for necessary types.
https://docs.nestjs.com/fundamentals/testing#auto-mocking

Issue Number: N/A


## What is the new behavior?
Copy-pasting of examples should work without any code changes.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
