### PR TITLE
docs(security): fastify-csrf plugin registration should be awaited

### DIFF
--- a/content/security/csrf.md
+++ b/content/security/csrf.md
@@ -35,7 +35,7 @@ Once the installation is complete, register the `fastify-csrf` plugin, as follow
 import fastifyCsrf from 'fastify-csrf';
 // ...
 // somewhere in your initialization file after registering some storage plugin
-app.register(fastifyCsrf);
+await app.register(fastifyCsrf);
 ```
 
 > warning **Warning** As explained in the `fastify-csrf` docs [here](https://github.com/fastify/fastify-csrf#usage), this plugin requires a storage plugin to be initialized first. Please, see that documentation for further instructions.


### PR DESCRIPTION
Fastify plugin registration happens asynchronously and should be `await`-ed.
Inspired by #2266 😄

## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md

## PR Type
What kind of change does this PR introduce?
- [x] Docs

## Does this PR introduce a breaking change?
- [x] No
