### PR TITLE
docs(techniques/mongo): use `OmitType` to avoid property repitition

### DIFF
--- a/content/techniques/mongo.md
+++ b/content/techniques/mongo.md
@@ -379,10 +379,7 @@ Now, let's define the `ClickedLinkEvent` class, as follows:
 ```typescript
 @@filename(click-link-event.schema)
 @Schema()
-export class ClickedLinkEvent {
-  kind: string;
-  time: Date;
-
+export class ClickedLinkEvent extends OmitType(Event, ['kind']) {
   @Prop({ type: String, required: true })
   url: string;
 }
@@ -395,16 +392,15 @@ And `SignUpEvent` class:
 ```typescript
 @@filename(sign-up-event.schema)
 @Schema()
-export class SignUpEvent {
-  kind: string;
-  time: Date;
-
+export class SignUpEvent extends OmitType(Event, ['kind']) {
   @Prop({ type: String, required: true })
   user: string;
 }
 
 export const SignUpEventSchema = SchemaFactory.createForClass(SignUpEvent);
 ```
+
+We are using `OmitType` from `@nestjs/mapped-types` to add all properties from the `Event` class to the derived classes while also removing the discriminator key.
 
 With this in place, use the `discriminators` option to register a discriminator for a given schema. It works on both `MongooseModule.forFeature` and `MongooseModule.forFeatureAsync`:
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently, the docs suggest repeating every single property of the base class (except for the discriminator key) within the derived classes. When adding lots of properties to the base class it can be time-consuming to update all derived classes. Also, redefining the properties within the derived classes is suboptimal (SSOT / DRY principle).


## What is the new behavior?
 `@nestjs/mapped-types` provides `OmitType` which can be utilized to improve this.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
