### PR TITLE
docs(faq/common-errors): fix typo in the `Common errors` block

### DIFF
--- a/content/faq/errors.md
+++ b/content/faq/errors.md
@@ -27,7 +27,7 @@ If the `<unknown_token>` above is the string `dependency`, you might have a circ
 
 If the `<unknown_token>` above is the string `Object`, it means that you're injecting using an type/interface without a proper provider's token. To fix that, make sure you're importing the class reference or use a custom token with `@Inject()` decorator. Read the [custom providers page](/fundamentals/custom-providers).
 
-Also, make sure you didn't end up injecting the provider on itself because self-injections are not allowed on NetJS. When this happens, `<unknown_token>` will likely be equal to `<provider>`.
+Also, make sure you didn't end up injecting the provider on itself because self-injections are not allowed in NestJS. When this happens, `<unknown_token>` will likely be equal to `<provider>`.
 
 If you are in a **monorepo setup**, you may face the same error as above but for core provider called `ModuleRef` as a `<unknown_token>`:
 


### PR DESCRIPTION
Fix the typo from NetJS to NestJS and use a gramatically correct preposition.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The docs in the [FAQ (common errors page)](https://docs.nestjs.com/faq/common-errors) have the following line: 

> self-injections are not allowed on NetJS.

Issue Number: N/A


## What is the new behavior?

The docs in the [FAQ (common errors page)](https://docs.nestjs.com/faq/common-errors) have the following line: 

> self-injections are not allowed in NestJS.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
