### PR TITLE
docs(fix): Updates references to deprecated class-transformer methods

### DIFF
--- a/content/pipes.md
+++ b/content/pipes.md
@@ -352,7 +352,7 @@ Now we can create a `ValidationPipe` class that uses these annotations.
 @@filename(validation.pipe)
 import { PipeTransform, Injectable, ArgumentMetadata, BadRequestException } from '@nestjs/common';
 import { validate } from 'class-validator';
-import { plainToClass } from 'class-transformer';
+import { plainToInstance } from 'class-transformer';
 
 @Injectable()
 export class ValidationPipe implements PipeTransform<any> {
@@ -360,7 +360,7 @@ export class ValidationPipe implements PipeTransform<any> {
     if (!metatype || !this.toValidate(metatype)) {
       return value;
     }
-    const object = plainToClass(metatype, value);
+    const object = plainToInstance(metatype, value);
     const errors = await validate(object);
     if (errors.length > 0) {
       throw new BadRequestException('Validation failed');
@@ -383,7 +383,7 @@ Next note that we are using destructuring to extract the metatype field (extract
 
 Next, note the helper function `toValidate()`. It's responsible for bypassing the validation step when the current argument being processed is a native JavaScript type (these can't have validation decorators attached, so there's no reason to run them through the validation step).
 
-Next, we use the class-transformer function `plainToClass()` to transform our plain JavaScript argument object into a typed object so that we can apply validation. The reason we must do this is that the incoming post body object, when deserialized from the network request, does **not have any type information** (this is the way the underlying platform, such as Express, works). Class-validator needs to use the validation decorators we defined for our DTO earlier, so we need to perform this transformation to treat the incoming body as an appropriately decorated object, not just a plain vanilla object.
+Next, we use the class-transformer function `plainToInstance()` to transform our plain JavaScript argument object into a typed object so that we can apply validation. The reason we must do this is that the incoming post body object, when deserialized from the network request, does **not have any type information** (this is the way the underlying platform, such as Express, works). Class-validator needs to use the validation decorators we defined for our DTO earlier, so we need to perform this transformation to treat the incoming body as an appropriately decorated object, not just a plain vanilla object.
 
 Finally, as noted earlier, since this is a **validation pipe** it either returns the value unchanged, or throws an exception.
 

--- a/content/techniques/configuration.md
+++ b/content/techniques/configuration.md
@@ -406,11 +406,11 @@ Alternatively, you can specify a **synchronous** `validate` function that takes 
 In this example, we'll proceed with the `class-transformer` and `class-validator` packages. First, we have to define:
 
 - a class with validation constraints,
-- a validate function that makes use of the `plainToClass` and `validateSync` functions.
+- a validate function that makes use of the `plainToInstance` and `validateSync` functions.
 
 ```typescript
 @@filename(env.validation)
-import { plainToClass } from 'class-transformer';
+import { plainToInstance } from 'class-transformer';
 import { IsEnum, IsNumber, validateSync } from 'class-validator';
 
 enum Environment {
@@ -429,7 +429,7 @@ class EnvironmentVariables {
 }
 
 export function validate(config: Record<string, unknown>) {
-  const validatedConfig = plainToClass(
+  const validatedConfig = plainToInstance(
     EnvironmentVariables,
     config,
     { enableImplicitConversion: true },

--- a/content/techniques/serialization.md
+++ b/content/techniques/serialization.md
@@ -4,7 +4,7 @@ Serialization is a process that happens before objects are returned in a network
 
 #### Overview
 
-Nest provides a built-in capability to help ensure that these operations can be performed in a straightforward way. The `ClassSerializerInterceptor` interceptor uses the powerful [class-transformer](https://github.com/typestack/class-transformer) package to provide a declarative and extensible way of transforming objects. The basic operation it performs is to take the value returned by a method handler and apply the `classToPlain()` function from [class-transformer](https://github.com/typestack/class-transformer). In doing so, it can apply rules expressed by `class-transformer` decorators on an entity/DTO class, as described below.
+Nest provides a built-in capability to help ensure that these operations can be performed in a straightforward way. The `ClassSerializerInterceptor` interceptor uses the powerful [class-transformer](https://github.com/typestack/class-transformer) package to provide a declarative and extensible way of transforming objects. The basic operation it performs is to take the value returned by a method handler and apply the `instanceToPlain()` function from [class-transformer](https://github.com/typestack/class-transformer). In doing so, it can apply rules expressed by `class-transformer` decorators on an entity/DTO class, as described below.
 
 #### Exclude properties
 
@@ -94,7 +94,7 @@ findOne(): UserEntity {
 
 > info **Hint** The `@SerializeOptions()` decorator is imported from `@nestjs/common`.
 
-Options passed via `@SerializeOptions()` are passed as the second argument of the underlying `classToPlain()` function. In this example, we are automatically excluding all properties that begin with the `_` prefix.
+Options passed via `@SerializeOptions()` are passed as the second argument of the underlying `instanceToPlain()` function. In this example, we are automatically excluding all properties that begin with the `_` prefix.
 
 #### Example
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
Currently referencing `class-transformer` methods named with `class`. They have since deprecated these methods in favor of more accurately named `instance` methods. Current example: `plainToClass`.

Issue Number: N/A


## What is the new behavior?
Post fix example: `plainToInstance`

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information
https://github.com/typestack/class-transformer/issues/235
