### PR TITLE
docs(mvc): point-of-view has been deprecated

### DIFF
--- a/content/techniques/mvc.md
+++ b/content/techniques/mvc.md
@@ -129,7 +129,7 @@ A working example is available [here](https://github.com/nestjs/nest/tree/master
 As mentioned in this [chapter](/techniques/performance), we are able to use any compatible HTTP provider together with Nest. One such library is [Fastify](https://github.com/fastify/fastify). In order to create an MVC application with Fastify, we have to install the following packages:
 
 ```bash
-$ npm i --save @fastify/static point-of-view handlebars
+$ npm i --save @fastify/static @fastify/view handlebars
 ```
 
 The next steps cover almost the same process used with Express, with minor differences specific to the platform. Once the installation process is complete, open the `main.ts` file and update its contents:


### PR DESCRIPTION
https://www.npmjs.com/package/point-of-view says "point-of-view@6.3.0 has been deprecated. Please use @fastify/view@7.0.0 instead."

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
When installing point-of-view a deprecation warning is shown.

Issue Number: N/A


## What is the new behavior?
No deprecation warning.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No



## Other information
