### PR TITLE
 docs: add nestjs cli change on migration guide & docs on `--strict`

### DIFF
--- a/content/cli/usages.md
+++ b/content/cli/usages.md
@@ -34,6 +34,7 @@ Creates and initializes a new Nest project. Prompts for package manager.
 | `--package-manager [package-manager]` | Specify package manager. Use `npm`, `yarn`, or `pnpm`. Package manager must be installed globally.<br/> Alias: `-p` |
 | `--language [language]`               | Specify programming language (`TS` or `JS`).<br/> Alias: `-l`                                                       |
 | `--collection [collectionName]`       | Specify schematics collection. Use package name of installed npm package containing schematic.<br/> Alias: `-c`     |
+| `--strict`                            | Start the project with the following TypeScript compiler flags enalbed: `strictNullChecks`, `noImplicitAny`, `strictBindCallApply`, `forceConsistentCasingInFileNames`, `noFallthroughCasesInSwitch` |
 
 #### nest generate
 

--- a/content/first-steps.md
+++ b/content/first-steps.md
@@ -21,6 +21,8 @@ $ npm i -g @nestjs/cli
 $ nest new project-name
 ```
 
+> info **Hint** If you want to create a new project with few flags of TypeScript's strict mode enabled, add the option `--strict` on `new` command. We highly recommend that! More on this option [here](./cli/usages).
+
 The `project-name` directory will be created, node modules and a few other boilerplate files will be installed, and a `src/` directory will be created and populated with several core files.
 
 <div class="file-tree">

--- a/content/first-steps.md
+++ b/content/first-steps.md
@@ -21,7 +21,7 @@ $ npm i -g @nestjs/cli
 $ nest new project-name
 ```
 
-> info **Hint** If you want to create a new project with few flags of TypeScript's strict mode enabled, add the option `--strict` on `new` command. We highly recommend that! More on this option [here](./cli/usages).
+> info **Hint** To create a new project with TypeScript's [strict](https://www.typescriptlang.org/tsconfig#strict) mode enabled, pass the `--strict` flag to the `nest new` command. 
 
 The `project-name` directory will be created, node modules and a few other boilerplate files will be installed, and a `src/` directory will be created and populated with several core files.
 

--- a/content/introduction.md
+++ b/content/introduction.md
@@ -23,6 +23,8 @@ $ npm i -g @nestjs/cli
 $ nest new project-name
 ```
 
+> info **Hint** If you want to create a new project with few flags of TypeScript's strict mode enabled, add the option `--strict` on `new` command. We highly recommend that! More on this option [here](./cli/usages).
+
 #### Alternatives
 
 Alternatively, to install the TypeScript starter project with **Git**:

--- a/content/introduction.md
+++ b/content/introduction.md
@@ -23,7 +23,7 @@ $ npm i -g @nestjs/cli
 $ nest new project-name
 ```
 
-> info **Hint** If you want to create a new project with few flags of TypeScript's strict mode enabled, add the option `--strict` on `new` command. We highly recommend that! More on this option [here](./cli/usages).
+> info **Hint** To create a new project with TypeScript's [strict](https://www.typescriptlang.org/tsconfig#strict) mode enabled, pass the `--strict` flag to the `nest new` command. 
 
 #### Alternatives
 

--- a/content/migration.md
+++ b/content/migration.md
@@ -94,3 +94,8 @@ All deprecated methods & modules have been removed (e.g., the deprecated `listen
 #### Node.js
 
 This release drops support for Node v10. We strongly recommend using the latest LTS version.
+
+#### NestJS CLI
+
+Due to stability issues, the command `update` was removed in the v9 of `@nestjs/cli`.  
+You can use specialized tools like [`ncu`](https://www.npmjs.com/package/npm-check-updates), `npm update`, [`yarn upgrade-interactive`](https://classic.yarnpkg.com/en/docs/cli/upgrade-interactive), Renovate Bot, etc, if you want to upgrade your dependencies.

--- a/content/migration.md
+++ b/content/migration.md
@@ -98,4 +98,4 @@ This release drops support for Node v10. We strongly recommend using the latest 
 #### NestJS CLI
 
 Due to stability issues, the command `update` was removed in the v9 of `@nestjs/cli`.  
-You can use specialized tools like [`ncu`](https://www.npmjs.com/package/npm-check-updates), `npm update`, [`yarn upgrade-interactive`](https://classic.yarnpkg.com/en/docs/cli/upgrade-interactive), Renovate Bot, etc, if you want to upgrade your dependencies.
+You can use dedicated tools like [`ncu`](https://www.npmjs.com/package/npm-check-updates), `npm update`, [`yarn upgrade-interactive`](https://classic.yarnpkg.com/en/docs/cli/upgrade-interactive), etc., if you want to upgrade your dependencies.

--- a/content/migration.md
+++ b/content/migration.md
@@ -95,7 +95,7 @@ All deprecated methods & modules have been removed (e.g., the deprecated `listen
 
 This release drops support for Node v10. We strongly recommend using the latest LTS version.
 
-#### NestJS CLI
+#### CLI
 
 Due to stability issues, the command `update` was removed in the v9 of `@nestjs/cli`.  
 You can use dedicated tools like [`ncu`](https://www.npmjs.com/package/npm-check-updates), `npm update`, [`yarn upgrade-interactive`](https://classic.yarnpkg.com/en/docs/cli/upgrade-interactive), etc., if you want to upgrade your dependencies.


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

- people complaining about not being able to use `nest update` anymore in v9
- issue: closes #2368

## What is the new behavior?

- mention in the migration guide that the command `update` was removed from `@nestjs/cli@9`

![image](https://user-images.githubusercontent.com/13461315/179237965-d73fa965-48ef-48da-b28b-5e9719a92125.png)

- add docs on `--strict` flag of `nest new` command

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

