### PR TITLE
Update connectionFactory constant to connectionProvider

### DIFF
--- a/content/fundamentals/dependency-injection.md
+++ b/content/fundamentals/dependency-injection.md
@@ -240,7 +240,7 @@ The `useFactory` syntax allows for creating providers **dynamically**. The actua
 
 ```typescript
 @@filename()
-const connectionFactory = {
+const connectionProvider = {
   provide: 'CONNECTION',
   useFactory: (optionsProvider: OptionsProvider, optionalProvider?: string) => {
     const options = optionsProvider.get();
@@ -254,14 +254,14 @@ const connectionFactory = {
 
 @Module({
   providers: [
-    connectionFactory,
+    connectionProvider,
     OptionsProvider,
     // { provide: 'SomeOptionalProvider', useValue: 'anything' },
   ],
 })
 export class AppModule {}
 @@switch
-const connectionFactory = {
+const connectionProvider = {
   provide: 'CONNECTION',
   useFactory: (optionsProvider, optionalProvider) => {
     const options = optionsProvider.get();
@@ -275,7 +275,7 @@ const connectionFactory = {
 
 @Module({
   providers: [
-    connectionFactory,
+    connectionProvider,
     OptionsProvider,
     // { provide: 'SomeOptionalProvider', useValue: 'anything' },
   ],


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
the constant in the documentation is named as `connectionFactory`. but the object which is provided is a provider not a factory. the factory is in the provider after the `useFactory` key

## What is the new behavior?
renamed constant name to `connectionProvider`

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

