### PR TITLE
docs(sql.md) update type of parameter of findOne method

### DIFF
--- a/content/techniques/sql.md
+++ b/content/techniques/sql.md
@@ -180,7 +180,7 @@ export class UsersService {
     return this.usersRepository.find();
   }
 
-  findOne(id: string): Promise<User> {
+  findOne(id: number): Promise<User> {
     return this.usersRepository.findOneBy({ id });
   }
 


### PR DESCRIPTION
id converted to a number which is at findOne method because it shows error like 
`(property) id?: number | FindOperator<number>
Type 'string' is not assignable to type 'number | FindOperator<number>'.ts(2322)`

also, id is the number at the given example
https://github.com/nestjs/nest/blob/master/sample/05-sql-typeorm/src/users/users.service.ts#L26

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
