### PR TITLE
docs: change wording of datasource injection scope

### DIFF
--- a/content/techniques/sql.md
+++ b/content/techniques/sql.md
@@ -61,7 +61,7 @@ The `forRoot()` method supports all the configuration properties exposed by the 
 
 > info **Hint** Learn more about the data source options [here](https://typeorm.io/data-source-options).
 
-Once this is done, the TypeORM `DataSource` and `EntityManager` objects will be available to inject across the entire project (without needing to import any modules), for example:
+Once this is done, the TypeORM `DataSource` and `EntityManager` objects will be available to inject across the entire Nest application's dependency tree (without needing to import any modules), for example:
 
 ```typescript
 @@filename(app.module)


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


## Other information
The current wording is a bit confusing. A `project` to me means all the files in the repo. If you think about it, it's obvious that this behavior can't apply to any random file. But by changing the wording a bit I hope it gets clearer as to where the line is actually drawn.