### PR TITLE
docs(cqrs): mention that `@Saga()` came from `@nestjs/sqrs`

### DIFF
--- a/content/recipes/cqrs.md
+++ b/content/recipes/cqrs.md
@@ -255,7 +255,7 @@ export class HeroesGameSagas {
 }
 ```
 
-> info **Hint** The `ofType` operator is exported from the `@nestjs/cqrs` package.
+> info **Hint** The `ofType` operator and the `@Saga()` decorator are exported from the `@nestjs/cqrs` package.
 
 We declared a rule - when any hero kills the dragon, the ancient item should be dropped. With this in place, `DropAncientItemCommand` will be dispatched and processed by the appropriate handler.
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Isn't clear where the `@Saga()` decorator came from

## What is the new behavior?

![image](https://user-images.githubusercontent.com/13461315/183303122-9d7d516e-e90a-41b4-8d09-f02d08a9ace9.png)


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No
