### PR TITLE
docs(swagger): add fastify swagger custom options for swagger doc

### DIFF
--- a/content/openapi/introduction.md
+++ b/content/openapi/introduction.md
@@ -148,7 +148,8 @@ export interface ExpressSwaggerCustomOptions {
   urls?: Record<'url' | 'name', string>[];
 }
 ```
-If you use fastify you can use the `FastifySwaggerCustomOptions` interface exacly the same way as the express one.
+
+If you use Fastify you can use the `FastifySwaggerCustomOptions` interface exactly the same way as the Express one:
 
 ```TypeScript
 export interface FastifySwaggerCustomOptions {

--- a/content/openapi/introduction.md
+++ b/content/openapi/introduction.md
@@ -148,6 +148,44 @@ export interface ExpressSwaggerCustomOptions {
   urls?: Record<'url' | 'name', string>[];
 }
 ```
+If you use fastify you can use the `FastifySwaggerCustomOptions` interface exacly the same way as the express one.
+
+```TypeScript
+export interface FastifySwaggerCustomOptions {
+    uiConfig?: Partial<{
+        deepLinking: boolean;
+        displayOperationId: boolean;
+        defaultModelsExpandDepth: number;
+        defaultModelExpandDepth: number;
+        defaultModelRendering: string;
+        displayRequestDuration: boolean;
+        docExpansion: string;
+        filter: boolean | string;
+        layout: string;
+        maxDisplayedTags: number;
+        showExtensions: boolean;
+        showCommonExtensions: boolean;
+        useUnsafeMarkdown: boolean;
+        syntaxHighlight: {
+            activate?: boolean;
+            theme?: string;
+        } | false;
+        tryItOutEnabled: boolean;
+        validatorUrl: string | null;
+        persistAuthorization: boolean;
+        tagsSorter: string;
+        operationsSorter: string;
+        queryConfigEnabled: boolean;
+    }>;
+    initOAuth?: Record<string, any>;
+    staticCSP?: boolean | string | Record<string, string | string[]>;
+    transformStaticCSP?: (header: string) => string;
+    uiHooks?: {
+        onRequest?: Function;
+        preHandler?: Function;
+    };
+}
+```
 
 #### Example
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?

The documentation page about swagger setup option currently show the custom options available, but only for express and does not show the options or explain how to find the options for fastify.

Issue Number: N/A


## What is the new behavior?

The available options for fastify are added just after the express one.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

I presented the options like for express. Maybe in the future it would be nice to add details about what each options are used for. Like it's done with comments on the document options in the same page.

I don't know each options so I won't be able to do it for all options, but if you want I could start with the one that I know Let me know.
