### PR TITLE
docs(file-upload): Fix typo Multiple Fields.

### DIFF
--- a/content/techniques/file-upload.md
+++ b/content/techniques/file-upload.md
@@ -181,7 +181,7 @@ uploadFile(files) {
 
 > info **Hint** The `FilesInterceptor()` decorator is exported from the `@nestjs/platform-express` package. The `@UploadedFiles()` decorator is exported from `@nestjs/common`.
 
-#### Multiple files
+#### Multiple fields
 
 To upload multiple fields (all with different field name keys), use the `FileFieldsInterceptor()` decorator. This decorator takes two arguments:
 

--- a/content/techniques/file-upload.md
+++ b/content/techniques/file-upload.md
@@ -181,7 +181,7 @@ uploadFile(files) {
 
 > info **Hint** The `FilesInterceptor()` decorator is exported from the `@nestjs/platform-express` package. The `@UploadedFiles()` decorator is exported from `@nestjs/common`.
 
-#### Multiple fields
+#### Multiple files
 
 To upload multiple fields (all with different field name keys), use the `FileFieldsInterceptor()` decorator. This decorator takes two arguments:
 

--- a/content/techniques/file-upload.md
+++ b/content/techniques/file-upload.md
@@ -183,7 +183,7 @@ uploadFile(files) {
 
 #### Multiple files
 
-To upload multiple fields (all with different field name keys), use the `FileFieldsInterceptor()` decorator. This decorator takes two arguments:
+To upload multiple files (all with different field name keys), use the `FileFieldsInterceptor()` decorator. This decorator takes two arguments:
 
 - `uploadedFields`: an array of objects, where each object specifies a required `name` property with a string value specifying a field name, as described above, and an optional `maxCount` property, as described above
 - `options`: optional `MulterOptions` object, as described above


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
Typo in header, I believe `Multiple files` should be `Multiple fields`.
Multiple files topic is already handled before this section.


## What is the new behavior?
- Header now displays `Multiple fields`.

## Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

Header change so existing hyperlinks might break.
Referees should update their references.

## Other information
