### PR TITLE
docs(queue): update bull connection option

### DIFF
--- a/content/techniques/queues.md
+++ b/content/techniques/queues.md
@@ -411,7 +411,7 @@ One approach is to use a factory function:
 ```typescript
 BullModule.forRootAsync({
   useFactory: () => ({
-    redis: {
+    connection: {
       host: 'localhost',
       port: 6379,
     },
@@ -425,7 +425,7 @@ Our factory behaves like any other [asynchronous provider](https://docs.nestjs.c
 BullModule.forRootAsync({
   imports: [ConfigModule],
   useFactory: async (configService: ConfigService) => ({
-    redis: {
+    connection: {
       host: configService.get('QUEUE_HOST'),
       port: +configService.get('QUEUE_PORT'),
     },
@@ -449,7 +449,7 @@ The construction above will instantiate `BullConfigService` inside `BullModule` 
 class BullConfigService implements SharedBullConfigurationFactory {
   createSharedConfiguration(): BullModuleOptions {
     return {
-      redis: {
+      connection: {
         host: 'localhost',
         port: 6379,
       },


### PR DESCRIPTION
Fixed BullModule.forRootAsync `redis` parameter to `connection` as per implementation

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
