### PR TITLE
Add http-module use example

### DIFF
--- a/content/techniques/http-module.md
+++ b/content/techniques/http-module.md
@@ -148,7 +148,7 @@ export class CatsService {
 }
 ```
 
-#### Full Example
+#### Full example
 
 Since the return of `HttpService` is an Observable, we can use `rxjs` `firstValueFrom` or `lastValueFrom` to retrieve the data of the request in the form of a promise.
 

--- a/content/techniques/http-module.md
+++ b/content/techniques/http-module.md
@@ -150,7 +150,7 @@ export class CatsService {
 
 #### Full example
 
-Since the return of `HttpService` is an Observable, we can use `rxjs` `firstValueFrom` or `lastValueFrom` to retrieve the data of the request in the form of a promise.
+Since the return value of the `HttpService` methods is an Observable, we can use `rxjs` - `firstValueFrom` or `lastValueFrom` to retrieve the data of the request in the form of a promise.
 
 ```typescript
 import { catchError, firstValueFrom } from 'rxjs';

--- a/content/techniques/http-module.md
+++ b/content/techniques/http-module.md
@@ -147,3 +147,31 @@ export class CatsService {
   }
 }
 ```
+
+#### Full Example
+
+Since the return of `HttpService` is an Observable, we can use `rxjs` `firstValueFrom` or `lastValueFrom` to retrieve the data of the request in the form of a promise.
+
+```typescript
+import { catchError, firstValueFrom } from 'rxjs';
+
+@Injectable()
+export class CatsService {
+  private readonly logger = new Logger(CatsService.name);
+  constructor(private readonly httpService: HttpService) {}
+
+  findAll(): Promise<Cat[]> {
+    const { data } = await firstValueFrom(
+      this.httpService.get<Cat[]>('http://localhost:3000/cats').pipe(
+        catchError((error: AxiosError) => {
+          this.logger.error(error.response.data);
+          throw 'An error happened!';
+        }),
+      ),
+    );
+    return data;
+  }
+}
+```
+
+> info **Hint** Visit RxJS's documentation on [`firstValueFrom`](https://rxjs.dev/api/index/function/firstValueFrom) and [`lastValueFrom`](https://rxjs.dev/api/index/function/lastValueFrom) for differences between them.


### PR DESCRIPTION
## PR Checklist

I'm submitting this PR on behalf of `hacktoberfest`. (Could the maintainers add the Hacktoberfest label at this repo?)

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
The docs explain how to use the HttpModule, but it lacks examples of using HttpService with rxjs features. So with this PR I propose to add an full example on how to proper use HttpService, with a plus of error handling.

I'm proposing this because the stack overflow/google answers weren't good enough and I was only able to finish my work after I asked for help in the discord channel. 

Issue Number: N/A


## What is the new behavior?
The docs will have a full example on how to use HttpService


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
