### PR TITLE
fix: specify max cache-manager version

### DIFF
--- a/content/techniques/caching.md
+++ b/content/techniques/caching.md
@@ -7,7 +7,7 @@ Caching is a great and simple **technique** that helps improve your app's perfor
 First install [required packages](https://github.com/BryanDonovan/node-cache-manager) (and its types for TypeScript users):
 
 ```bash
-$ npm install cache-manager
+$ npm install cache-manager@^4
 $ npm install -D @types/cache-manager
 ```
 


### PR DESCRIPTION
I have refactored cache manager and in version 5 it is not compatible with the current implementation in NestJS. 
https://github.com/node-cache-manager/node-cache-manager/pull/203