### PR TITLE
docs(caching): fix github link to point to the moved repo location

### DIFF
--- a/content/techniques/caching.md
+++ b/content/techniques/caching.md
@@ -4,11 +4,10 @@ Caching is a great and simple **technique** that helps improve your app's perfor
 
 #### Installation
 
-First install [required packages](https://github.com/node-cache-manager/node-cache-manager) (and its types for TypeScript users):
+First install [required packages](https://github.com/node-cache-manager/node-cache-manager):
 
 ```bash
 $ npm install cache-manager
-$ npm install -D @types/cache-manager
 ```
 
 #### In-memory cache

--- a/content/techniques/caching.md
+++ b/content/techniques/caching.md
@@ -4,7 +4,7 @@ Caching is a great and simple **technique** that helps improve your app's perfor
 
 #### Installation
 
-First install [required packages](https://github.com/BryanDonovan/node-cache-manager) (and its types for TypeScript users):
+First install [required packages](https://github.com/node-cache-manager/node-cache-manager) (and its types for TypeScript users):
 
 ```bash
 $ npm install cache-manager


### PR DESCRIPTION
The `node-cache-manager` repo was moved to a new parent account on GitHub.