### PR TITLE
docs(mongodb) : remove extra type property

### DIFF
--- a/content/techniques/mongo.md
+++ b/content/techniques/mongo.md
@@ -85,7 +85,7 @@ owner: Owner;
 In case there are multiple owners, your property configuration should look as follows:
 
 ```typescript
-@Prop({ type: [{ type: mongoose.Schema.Types.ObjectId, ref: 'Owner' }] })
+@Prop({ type: [ mongoose.Schema.Types.ObjectId ], ref: 'Owner' })
 owner: Owner[];
 ```
 


### PR DESCRIPTION
remove extra type property in  @Prop decorator
the extra type in 
`@Prop({ type: [{ type: mongoose.Schema.Types.ObjectId, ref: 'Owner' }] })`
is confusing for me, I find this clearer : 
`  @Prop({ type: [mongoose.Schema.Types.ObjectId], ref: 'Owner' })`


## PR Checklist
Please check if your PR fulfills the following requirements:

- [v ] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ v] Docs
- [ ] Other... Please describe:


## What is the current behavior?
the current [here](https://docs.nestjs.com/techniques/mongodb)  works fine. but there's no need to implement nested object while we can use array syntax.

Issue Number: N/A


## What is the new behavior?
new syntax is much clearer and simpler

## Does this PR introduce a breaking change?
- [ ] Yes
- [v ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
