### PR TITLE
Correction on exceptions filter for httpAdapterHost

### DIFF
--- a/content/exception-filters.md
+++ b/content/exception-filters.md
@@ -364,8 +364,8 @@ The first method is to inject the `HttpAdapter` reference when instantiating the
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
 
-  const { httpAdapter } = app.get(HttpAdapterHost);
-  app.useGlobalFilters(new AllExceptionsFilter(httpAdapter));
+  const httpAdapterHost = app.get(HttpAdapterHost);
+  app.useGlobalFilters(new AllExceptionsFilter(httpAdapterHost));
 
   await app.listen(3000);
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [x] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Docs
- [ ] Other... Please describe:


## What is the current behavior?
At present the docs states that the variable to be passed into the AllExceptionsFilter should be an httpAdapter, but the constructor requests for an HttpAdapterHost and this breaks the typescript.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
It compiles successfully after the change to an httpAdapterHost variable.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
