### PR TITLE
docs(caching): fix cacheManager.set, get property

### DIFF
--- a/content/techniques/caching.md
+++ b/content/techniques/caching.md
@@ -54,13 +54,13 @@ The default expiration time of the cache is 5 seconds.
 You can manually specify a TTL (expiration time in seconds) for this specific key, as follows:
 
 ```typescript
-await this.cacheManager.set('key', 'value', { ttl: 1000 });
+await this.cacheManager.set('key', 'value', 1000);
 ```
 
 To disable expiration of the cache, set the `ttl` configuration property to `0`:
 
 ```typescript
-await this.cacheManager.set('key', 'value', { ttl: 0 });
+await this.cacheManager.set('key', 'value', 0);
 ```
 
 To remove an item from the cache, use the `del` method:


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
An error was encountered while following the example.
- VScode
- typeorm 0.3.0
- "cache-manager": "^5.1.1",
- "cache-manager-ioredis": "^2.1.0",
- "cache-manager-redis-store": "^3.0.1",


<img width="926" alt="스크린샷 2022-10-25 오전 12 44 54" src="https://user-images.githubusercontent.com/49634182/197568587-f51b1e6f-26e0-4b70-9433-9869c9239d4b.png">

error: Argument of type '{ ttl: number; }' is not assignable to parameter of type 'number'.ts(2345) 

Issue Number: N/A

## What is the new behavior?
solution: vscode suggestion
<img width="566" alt="스크린샷 2022-10-25 오전 12 47 27" src="https://user-images.githubusercontent.com/49634182/197569161-1eadea91-8571-46c0-97ea-5b4b27275b26.png">


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
I'm a Nest, Ts beginner and the bug is giving me a hard time. 🫠
