### PR TITLE
docs: add a warning for FileTypeValidator

### DIFF
--- a/content/techniques/file-upload.md
+++ b/content/techniques/file-upload.md
@@ -120,6 +120,8 @@ export abstract class FileValidator<TValidationOptions = Record<string, any>> {
 - `MaxFileSizeValidator` - Checks if a given file's size is less than the provided value (measured in `bytes`)
 - `FileTypeValidator` - Checks if a given file's mime-type matches the given value. 
 
+> warning **Warning** The [FileTypeValidator](https://github.com/nestjs/nest/blob/master/packages/common/pipes/file/file-type.validator.ts) class uses a naive implementation to verify the incoming file's type. Consider using a custom implementation (like checking the file's [magic number](https://www.ibm.com/support/pages/what-magic-number)) if your app requires a safer solution.
+
 To understand how these can be used in conjunction with the beforementioned `FileParsePipe`, we'll use an altered snippet of the last presented example:
 
 ```typescript


### PR DESCRIPTION
add a warning for FileTypeValidator to be clear about its unsuitability for safer file type validation.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?

Issue Number: #2497 


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No
