### PR TITLE
docs(sql): drop mention on typeorm transaction decorators

### DIFF
--- a/content/techniques/sql.md
+++ b/content/techniques/sql.md
@@ -379,7 +379,7 @@ import { UsersService } from './users.service';
 export class UsersModule {}
 ```
 
-#### Transactions
+#### TypeORM Transactions
 
 A database transaction symbolizes a unit of work performed within a database management system against a database, and treated in a coherent and reliable way independent of other transactions. A transaction generally represents any change in a database ([learn more](https://en.wikipedia.org/wiki/Database_transaction)).
 
@@ -431,8 +431,6 @@ async createMany(users: User[]) {
   });
 }
 ```
-
-Using decorators to control the transaction (`@Transaction()` and `@TransactionManager()`) is not recommended.
 
 <app-banner-shop></app-banner-shop>
 
@@ -1044,7 +1042,7 @@ With that option specified, every model registered through the `forFeature()` me
 
 > warning **Warning** Note that models that aren't registered through the `forFeature()` method, but are only referenced from the model (via an association), won't be included.
 
-#### Transactions
+#### Sequelize Transactions
 
 A database transaction symbolizes a unit of work performed within a database management system against a database, and treated in a coherent and reliable way independent of other transactions. A transaction generally represents any change in a database ([learn more](https://en.wikipedia.org/wiki/Database_transaction)).
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the new behavior?

`typeorm@0.3` [no longer](https://github.com/typeorm/typeorm/releases/tag/0.3.0) has `@TransactionRepository()`, `@TransactionManager()`, `@Transaction()` decorators, so there's no reason to mention them here

I've also renamed the _transactions_ sections because before we got the same name in the summary list, which I found confusing

![image](https://user-images.githubusercontent.com/13461315/198858651-53a1dcce-8b84-4854-9fc5-45e39ea8c09b.png)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No
