### PR TITLE
docs(mongo): change the way to define the mongoose document interface

### DIFF
--- a/content/techniques/mongo.md
+++ b/content/techniques/mongo.md
@@ -34,9 +34,9 @@ Let's define the `CatSchema`:
 ```typescript
 @@filename(schemas/cat.schema)
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
-import { Document } from 'mongoose';
+import { HydratedDocument } from 'mongoose';
 
-export type CatDocument = Cat & Document;
+export type CatDocument = HydratedDocument<Cat>;
 
 @Schema()
 export class Cat {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?

Currently, techniques/mongodb doc uses intersection type for defining the mongoose document interface.

```ts
import { Document } from 'mongoose';

export type CatDocument = Cat & Document;
```
it was okay before mongoose@6.3.2 but after that, they replaced the use of `this` with generics(`T`) in many `Document` methods so it infers incorrectly now.

```ts
// before
toObject(options?: ToObjectOptions): LeanDocument<this>;
toObject<T = DocType>(options?: ToObjectOptions): T;

// latest
toObject<T = LeanDocument<DocType>>(options?: ToObjectOptions): Require_id<T>;

// from: https://github.com/Automattic/mongoose/commit/659436de47d55aaa0a984b8f4cc99232c5ca8a16

```

```ts
type CatDocument = Cat & Document;

class CatsService {
  constructor(@InjectModel(Cat.name) private catModel: Model<CatDocument>) {}

  create() {
    const cat = await this.catModel.create(createCatDto);
    const catObj = cat.toObject();
    // const catObj: LeanDocument<any> & Required<{_id: unknown}>

    return catObj;
  }
}
```

## What is the new behavior?

Mongoose introduced `HydratedDocument` from 6.0.13.

```ts
import { HydratedDocument } from 'mongoose';

export type CatDocument = HydratedDocument<Cat>;
```
defining document interface as `HydratedDocument` of `Cat` so can infer the type from `Document` methods correctly.

```ts
type CatDocument = HydratedDocument<Cat>;

class CatsService {
  constructor(@InjectModel(Cat.name) private catModel: Model<CatDocument>) {}

  create() {
    const cat = await this.catModel.create(createCatDto);
    const catObj = cat.toObject();
    // const catObj: LeanDocument<Cat> & {_id: Types.ObjectId}

    return catObj;
  }
}
```

refs:
https://github.com/Automattic/mongoose/commit/8120c8f6d73f48c9a4cf5821ede8f6d96da74ec8
https://github.com/Automattic/mongoose/blob/6.7.0/docs/typescript.md#creating-your-first-document 





## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

