### PR TITLE
docs(caching): TTL in ms as from cache-manager@^5

### DIFF
--- a/content/techniques/caching.md
+++ b/content/techniques/caching.md
@@ -51,7 +51,7 @@ await this.cacheManager.set('key', 'value');
 
 The default expiration time of the cache is 5 seconds.
 
-You can manually specify a TTL (expiration time in seconds) for this specific key, as follows:
+You can manually specify a TTL (expiration time in seconds, milliseconds as from cache-manager@^5) for this specific key, as follows:
 
 ```typescript
 await this.cacheManager.set('key', 'value', 1000);
@@ -121,7 +121,7 @@ All cached data has its own expiration time ([TTL](https://en.wikipedia.org/wiki
 
 ```typescript
 CacheModule.register({
-  ttl: 5, // seconds
+  ttl: 5, // seconds, milliseconds as from cache-manager@^5
   max: 10, // maximum number of items in cache
 });
 ```


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
In caching doc, the TTL is defined in seconds.

Issue Number: N/A


## What is the new behavior?
As from cache-manager@^5, the TTL is defined in milliseconds.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
