### PR TITLE
docs: clarify solution in #2177

### DIFF
--- a/content/techniques/sql.md
+++ b/content/techniques/sql.md
@@ -527,7 +527,7 @@ export class AppModule {}
 
 > warning **Notice** If you don't set the `name` for a data source, its name is set to `default`. Please note that you shouldn't have multiple connections without a name, or with the same name, otherwise they will get overridden.
 
-> warning **Notice** If you are using `TypeOrmModule.forRootAsync`, you have to set the data source name outside `useFactory`. For example:
+> warning **Notice** If you are using `TypeOrmModule.forRootAsync`, you have to **also** set the data source name outside `useFactory`. For example:
 >
 > ```typescript
 > TypeOrmModule.forRootAsync({


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

If you only provide `name` property in `forRootAsync` options, and not in returned options from `useFactory`, module `onApplicationShutdown` will throw error like

```
 Nest could not find DataSource element (this provider does not exist in the current context)
```

This is because the `getDataSourceToken` call uses the options returned from `useFactory`, not the `forRootAsync` definition.

Issue Number: related to #2177

## What is the new behavior?

No errors on application shutdown

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Unlikely to be an issue most applications run into, but we use in-process integration tests that create and shutdown an app instance for each test suite and this was failing.