### PR TITLE
fix(docs): change file type validator example to use MIME type

### DIFF
--- a/content/techniques/file-upload.md
+++ b/content/techniques/file-upload.md
@@ -129,7 +129,7 @@ To understand how these can be used in conjunction with the beforementioned `Fil
   new ParseFilePipe({
     validators: [
       new MaxFileSizeValidator({ maxSize: 1000 }),
-      new FileTypeValidator({ fileType: 'jpeg' }),
+      new FileTypeValidator({ fileType: 'image/jpeg' }),
     ],
   }),
 )


### PR DESCRIPTION
FileTypeValidator takes a mime type such as `image/jpeg`, but the current example uses just `jpeg`

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
