### PR TITLE
docs(openapi): replace swaggerOptions type with SwaggerUiOptions

### DIFF
--- a/content/openapi/introduction.md
+++ b/content/openapi/introduction.md
@@ -136,7 +136,7 @@ You can configure Swagger UI by passing the options object which fulfills the `E
 ```TypeScript
 export interface ExpressSwaggerCustomOptions {
   explorer?: boolean;
-  swaggerOptions?: Record<string, any>;
+  swaggerOptions?: SwaggerUiOptions;
   customCss?: string;
   customCssUrl?: string;
   customJs?: string;


### PR DESCRIPTION
based on https://github.com/nestjs/swagger/pull/2138 swaggerOptions type changed into SwaggerUiOptions

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Issue Number: N/A

## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
