### PR TITLE
docs(cache): correct time unit

### DIFF
--- a/content/techniques/caching.md
+++ b/content/techniques/caching.md
@@ -51,7 +51,7 @@ await this.cacheManager.set('key', 'value');
 
 The default expiration time of the cache is 5 seconds.
 
-You can manually specify a TTL (expiration time in seconds) for this specific key, as follows:
+You can manually specify a TTL (expiration time in milliseconds) for this specific key, as follows:
 
 ```typescript
 await this.cacheManager.set('key', 'value', 1000);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [X] Docs
- [ ] Other... Please describe:


## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No


## Other information
The set method of CacheManager expects milliseconds, not seconds.