### PR TITLE
docs(cache): added warning for cache manager compatibility

### DIFF
--- a/content/techniques/caching.md
+++ b/content/techniques/caching.md
@@ -10,6 +10,13 @@ First install [required packages](https://github.com/node-cache-manager/node-cac
 $ npm install cache-manager
 ```
 
+> warning **Warning**  As of version `>=9.2.1` of NestJS is compatible with both `cache-manager` v4 and v5.
+
+> warning **Warning**  `Cache-manager` version 4 uses seconds for `TTL (Time-To-Live)`. Current version of `cache-manager` (v5) has switched to using milliseconds instead. NestJS doesn't convert the value, and simply forwards the ttl you provide to the library. In other words:
+> * If using `cache-manager` v4, provide ttl in seconds
+> * If using `cache-manager` v5 or newer, provide ttl in milliseconds
+> Documentation is referring to seconds, since NestJS was released targeting version 4 of cache-manager.
+
 #### In-memory cache
 
 Nest provides a unified API for various cache storage providers. The built-in one is an in-memory data store. However, you can easily switch to a more comprehensive solution, like Redis.

--- a/content/techniques/caching.md
+++ b/content/techniques/caching.md
@@ -14,7 +14,7 @@ $ npm install cache-manager
 
 > warning **Warning** `cache-manager` version 4 uses seconds for `TTL (Time-To-Live)`. The current version of `cache-manager` (v5) has switched to using milliseconds instead. NestJS doesn't convert the value, and simply forwards the ttl you provide to the library. In other words:
 > * If using `cache-manager` v4, provide ttl in seconds
-> * If using `cache-manager` v5 or newer, provide ttl in milliseconds
+> * If using `cache-manager` v5, provide ttl in milliseconds
 > * Documentation is referring to seconds, since NestJS was released targeting version 4 of cache-manager.
 
 #### In-memory cache

--- a/content/techniques/caching.md
+++ b/content/techniques/caching.md
@@ -15,7 +15,7 @@ $ npm install cache-manager
 > warning **Warning**  `Cache-manager` version 4 uses seconds for `TTL (Time-To-Live)`. Current version of `cache-manager` (v5) has switched to using milliseconds instead. NestJS doesn't convert the value, and simply forwards the ttl you provide to the library. In other words:
 > * If using `cache-manager` v4, provide ttl in seconds
 > * If using `cache-manager` v5 or newer, provide ttl in milliseconds
-> Documentation is referring to seconds, since NestJS was released targeting version 4 of cache-manager.
+> * Documentation is referring to seconds, since NestJS was released targeting version 4 of cache-manager.
 
 #### In-memory cache
 

--- a/content/techniques/caching.md
+++ b/content/techniques/caching.md
@@ -10,7 +10,7 @@ First install [required packages](https://github.com/node-cache-manager/node-cac
 $ npm install cache-manager
 ```
 
-> warning **Warning**  As of version `>=9.2.1` of NestJS is compatible with both `cache-manager` v4 and v5.
+> info **Hint**  As of version `>=9.2.1`, NestJS is compatible with both `cache-manager` v4 and v5.
 
 > warning **Warning** `cache-manager` version 4 uses seconds for `TTL (Time-To-Live)`. The current version of `cache-manager` (v5) has switched to using milliseconds instead. NestJS doesn't convert the value, and simply forwards the ttl you provide to the library. In other words:
 > * If using `cache-manager` v4, provide ttl in seconds

--- a/content/techniques/caching.md
+++ b/content/techniques/caching.md
@@ -12,7 +12,7 @@ $ npm install cache-manager
 
 > warning **Warning**  As of version `>=9.2.1` of NestJS is compatible with both `cache-manager` v4 and v5.
 
-> warning **Warning**  `Cache-manager` version 4 uses seconds for `TTL (Time-To-Live)`. Current version of `cache-manager` (v5) has switched to using milliseconds instead. NestJS doesn't convert the value, and simply forwards the ttl you provide to the library. In other words:
+> warning **Warning** `cache-manager` version 4 uses seconds for `TTL (Time-To-Live)`. The current version of `cache-manager` (v5) has switched to using milliseconds instead. NestJS doesn't convert the value, and simply forwards the ttl you provide to the library. In other words:
 > * If using `cache-manager` v4, provide ttl in seconds
 > * If using `cache-manager` v5 or newer, provide ttl in milliseconds
 > * Documentation is referring to seconds, since NestJS was released targeting version 4 of cache-manager.


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
Proposal: 
  - Added warning to point out that the `CacheModule` works with both `v4` and `v5` versions of the `cache-manager`
  - Added warning that mentions that `cache-manager` v5 uses milliseconds but v4 uses seconds and since documents were written for v4 at that time.

see screenshot here: 
  
<img width="1355" alt="Screenshot 2023-01-16 alle 22 08 49" src="https://user-images.githubusercontent.com/11542387/212766001-f7f84c1e-1cd9-4643-858e-bf28250da89b.png">


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
If you use a version of NestJS less than v9.2 and install `cache-manager` v5 it gives the following error:

<img width="1045" alt="screenshot" src="https://user-images.githubusercontent.com/11542387/210268090-309d74ab-a624-4361-a4da-a8f4e937285f.png">


See also Discussion Discord (https://discord.com/channels/520622812742811698/1064176338996580424)