### PR TITLE
docs(authentitcation): update the example secret

### DIFF
--- a/content/security/authentication.md
+++ b/content/security/authentication.md
@@ -465,11 +465,11 @@ First, create `constants.ts` in the `auth` folder, and add the following code:
 ```typescript
 @@filename(auth/constants)
 export const jwtConstants = {
-  secret: 'secretKey',
+  secret: 'DO NOT USE THIS VALUE. INSTEAD, CREATE A COMPLEX SECRET AND KEEP IT SAFE OUTSIDE OF THE SOURCE CODE.',
 };
 @@switch
 export const jwtConstants = {
-  secret: 'secretKey',
+  secret: 'DO NOT USE THIS VALUE. INSTEAD, CREATE A COMPLEX SECRET AND KEEP IT SAFE OUTSIDE OF THE SOURCE CODE.',
 };
 ```
 


### PR DESCRIPTION
Update de secret value used as example in order to avoid programmers to use it on production code

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
I've found a few companies using the example code without modifying the secret value, regardless the warning on the page.
I think that it is a honest mistake, because the current value seems like a enum value.

Issue Number: N/A


## What is the new behavior?

The goal of this modification is to use a more semantic value, informing to the the programmer that the secret value must be changed and kept safe.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
