### PR TITLE
docs(queues): add hint to start consuming from queues

### DIFF
--- a/content/techniques/queues.md
+++ b/content/techniques/queues.md
@@ -207,6 +207,16 @@ export class AudioConsumer {}
 
 > info **Hint** Consumers must be registered as `providers` so the `@nestjs/bull` package can pick them up.
 
+Once registered as providers, the consumer will start consuming from the queue only if the app is either listening or the `init` hook has been called:
+
+```typescript
+// main.ts
+
+await app.listen(3000);
+// OR
+await app.init();
+```
+
 Where the decorator's string argument (e.g., `'audio'`) is the name of the queue to be associated with the class methods.
 
 Within a consumer class, declare job handlers by decorating handler methods with the `@Process()` decorator.


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Docs


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

No explanation on how Nest starts consuming from queues.


## What is the new behavior?
Explains how Nest starts consuming from queues.

## Does this PR introduce a breaking change?
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

