### PR TITLE
docs(overview): add warning for use provider app_guard

### DIFF
--- a/content/guards.md
+++ b/content/guards.md
@@ -142,6 +142,8 @@ export class AppModule {}
 > where the guard (`RolesGuard` in the example above) is defined. Also, `useClass` is not the only way of dealing with
 > custom provider registration. Learn more [here](/fundamentals/custom-providers).
 
+> warning **Warning** When using the provider syntax with `APP_GUARD`, it is not necessary to use the `useGlobalGuards()` method of the Nest application instance in the `main.ts` file.
+
 #### Setting roles per handler
 
 Our `RolesGuard` is working, but it's not very smart yet. We're not yet taking advantage of the most important guard feature - the [execution context](/fundamentals/execution-context). It doesn't yet know about roles, or which roles are allowed for each handler. The `CatsController`, for example, could have different permission schemes for different routes. Some might be available only for an admin user, and others could be open for everyone. How can we match roles to routes in a flexible and reusable way?


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [x] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
Add warning for use provider `APP_GUARD`.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Many people reading the documentation about guards find some confusion when they have to use a global guard using the provider (`APP_GUARD`), having the doubt that they also have to use the `useGlobalGuards()` method of the Nest application instance in the `main.ts` file. On Discord there are many discussion and help posts, I think a warning can help to solve this "confusion" in reading the documentation regarding guards.


