### PR TITLE
docs(security): update deprecated method from @casl/ability

### DIFF
--- a/content/security/authorization.md
+++ b/content/security/authorization.md
@@ -234,16 +234,16 @@ With this in place, we can define the `createForUser()` method on the `CaslAbili
 ```typescript
 type Subjects = InferSubjects<typeof Article | typeof User> | 'all';
 
-export type AppAbility = Ability<[Action, Subjects]>;
+type AppAbility = MongoAbility<[Action, Subjects]>;
 
 @Injectable()
 export class CaslAbilityFactory {
   createForUser(user: User) {
-    const { can, cannot, build } = new AbilityBuilder<
-      Ability<[Action, Subjects]>
-    >(Ability as AbilityClass<AppAbility>);
+    const { can, cannot, build } = new AbilityBuilder<AppAbility>(
+      createMongoAbility,
+    );
 
-    if (user.isAdmin) {
+    if (user) {
       can(Action.Manage, 'all'); // read-write access to everything
     } else {
       can(Action.Read, 'all'); // read-only access to everything
@@ -253,7 +253,7 @@ export class CaslAbilityFactory {
     cannot(Action.Delete, Article, { isPublished: true });
 
     return build({
-      // Read https://casl.js.org/v5/en/guide/subject-type-detection#use-classes-as-subject-types for details
+    // Read https://casl.js.org/v6/en/guide/subject-type-detection for details
       detectSubjectType: (item) =>
         item.constructor as ExtractSubjectType<Subjects>,
     });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [X] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Warning message - "@deprecated use createMongoAbility function instead and MongoAbility interface. In the next major version PureAbility will be renamed to Ability and this class will be removed"

## What is the new behavior?
Keep official documentation up to date!

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Happy to be able to keep up to date the official documentation of this exceptional framework that is Nest.js.