### PR TITLE
docs(common errors): added new section

### DIFF
--- a/content/faq/errors.md
+++ b/content/faq/errors.md
@@ -99,7 +99,6 @@ When you're using the NestJS CLI to start your application in watch mode it is d
 In order to fix this problem, you need to add a setting to your tsconfig.json file after the `"compilerOptions"` option as follows:
 
 ```bash
-```bash
   "watchOptions": {
     "watchFile": "fixedPollingInterval"
   }

--- a/content/faq/errors.md
+++ b/content/faq/errors.md
@@ -89,16 +89,21 @@ In the above image, the string in yellow is the host class of the dependency bei
 
 Windows users who are using TypeScript version 4.9 and up may encounter this problem.
 This happens when you're trying to run your application in watch mode, e.g `npm run start:dev` and see an endless loop of the log messages:
+
 ```bash
 XX:XX:XX AM - File change detected. Starting incremental compilation...
 XX:XX:XX AM - Found 0 errors. Watching for file changes.
 ```
+
 When you're using the NestJS CLI to start your application in watch mode it is done by calling `tsc --watch`, and as of version 4.9 of TypeScript, a [new strategy](https://devblogs.microsoft.com/typescript/announcing-typescript-4-9/#file-watching-now-uses-file-system-events) for detecting file changes is used which is likely to be the cause of this problem.
 In order to fix this problem, you need to add a setting to your tsconfig.json file after the `"compilerOptions"` option as follows:
+
+```bash
 ```bash
   "watchOptions": {
     "watchFile": "fixedPollingInterval"
   }
 ```
+
 This tells TypeScript to use the polling method for checking for file changes instead of file system events (the new default method), which can cause issues on some machines.
 You can read more about the `"watchFile"` option in [TypeScript documentation](https://www.typescriptlang.org/tsconfig#watch-watchDirectory).

--- a/content/faq/errors.md
+++ b/content/faq/errors.md
@@ -11,7 +11,7 @@ Nest can't resolve dependencies of the <provider> (?). Please make sure that the
 
 Potential solutions:
 - Is <module> a valid NestJS module?
-- If <unknown_token> is a provider, is it part of the current <module>?
+- If <unknown_token> is a provider, is it part of the current <module>? 
 - If <unknown_token> is exported from a separate @Module, is that module imported within <module>?
   @Module({
     imports: [ /* the Module containing <unknown_token> */ ]
@@ -84,3 +84,21 @@ Along with just manually verifying your dependencies are correct, as of Nest 8.1
 <figure><img src="/assets/injector_logs.png" /></figure>
 
 In the above image, the string in yellow is the host class of the dependency being injected, the string in blue is the name of the injected dependency, or its injection token, and the string in purple is the module in which the dependency is being searched for. Using this, you can usually trace back the dependency resolution for what's happening and why you're getting dependency injection problems.
+
+#### "File change detected" loops endlessly
+
+Windows users who are using TypeScript version 4.9 and up may encounter this problem.
+This happens when you're trying to run your application in watch mode, e.g `npm run start:dev` and see an endless loop of the log messages:
+```bash
+XX:XX:XX AM - File change detected. Starting incremental compilation...
+XX:XX:XX AM - Found 0 errors. Watching for file changes.
+```
+When you're using the NestJS CLI to start your application in watch mode it is done by calling `tsc --watch`, and as of version 4.9 of TypeScript, a [new method](https://devblogs.microsoft.com/typescript/announcing-typescript-4-9/#file-watching-now-uses-file-system-events) for detecting file changes is used which is the cause of this problem.
+In order to fix this problem, you need to add a setting to your tsconfig.json file after the `"compilerOptions"` option as follows:
+```bash
+  "watchOptions": {
+    "watchFile": "fixedPollingInterval"
+  }
+```
+This tells TypeScript to use the polling method for checking for file changes instead of file system events (the new default method), which can cause issues on some machines.
+You can read more about the `"watchFile"` options you can use in [this link](https://www.typescriptlang.org/tsconfig#watch-watchDirectory).

--- a/content/faq/errors.md
+++ b/content/faq/errors.md
@@ -101,4 +101,4 @@ In order to fix this problem, you need to add a setting to your tsconfig.json fi
   }
 ```
 This tells TypeScript to use the polling method for checking for file changes instead of file system events (the new default method), which can cause issues on some machines.
-You can read more about the `"watchFile"` options you can use in [this link](https://www.typescriptlang.org/tsconfig#watch-watchDirectory).
+You can read more about the `"watchFile"` option in [TypeScript documentation](https://www.typescriptlang.org/tsconfig#watch-watchDirectory).

--- a/content/faq/errors.md
+++ b/content/faq/errors.md
@@ -11,7 +11,7 @@ Nest can't resolve dependencies of the <provider> (?). Please make sure that the
 
 Potential solutions:
 - Is <module> a valid NestJS module?
-- If <unknown_token> is a provider, is it part of the current <module>? 
+- If <unknown_token> is a provider, is it part of the current <module>?
 - If <unknown_token> is exported from a separate @Module, is that module imported within <module>?
   @Module({
     imports: [ /* the Module containing <unknown_token> */ ]

--- a/content/faq/errors.md
+++ b/content/faq/errors.md
@@ -93,7 +93,7 @@ This happens when you're trying to run your application in watch mode, e.g `npm 
 XX:XX:XX AM - File change detected. Starting incremental compilation...
 XX:XX:XX AM - Found 0 errors. Watching for file changes.
 ```
-When you're using the NestJS CLI to start your application in watch mode it is done by calling `tsc --watch`, and as of version 4.9 of TypeScript, a [new strategy](https://devblogs.microsoft.com/typescript/announcing-typescript-4-9/#file-watching-now-uses-file-system-events) for detecting file changes is used which is like to be the cause of this problem.
+When you're using the NestJS CLI to start your application in watch mode it is done by calling `tsc --watch`, and as of version 4.9 of TypeScript, a [new strategy](https://devblogs.microsoft.com/typescript/announcing-typescript-4-9/#file-watching-now-uses-file-system-events) for detecting file changes is used which is likely to be the cause of this problem.
 In order to fix this problem, you need to add a setting to your tsconfig.json file after the `"compilerOptions"` option as follows:
 ```bash
   "watchOptions": {

--- a/content/faq/errors.md
+++ b/content/faq/errors.md
@@ -93,7 +93,7 @@ This happens when you're trying to run your application in watch mode, e.g `npm 
 XX:XX:XX AM - File change detected. Starting incremental compilation...
 XX:XX:XX AM - Found 0 errors. Watching for file changes.
 ```
-When you're using the NestJS CLI to start your application in watch mode it is done by calling `tsc --watch`, and as of version 4.9 of TypeScript, a [new method](https://devblogs.microsoft.com/typescript/announcing-typescript-4-9/#file-watching-now-uses-file-system-events) for detecting file changes is used which is the cause of this problem.
+When you're using the NestJS CLI to start your application in watch mode it is done by calling `tsc --watch`, and as of version 4.9 of TypeScript, a [new strategy](https://devblogs.microsoft.com/typescript/announcing-typescript-4-9/#file-watching-now-uses-file-system-events) for detecting file changes is used which is like to be the cause of this problem.
 In order to fix this problem, you need to add a setting to your tsconfig.json file after the `"compilerOptions"` option as follows:
 ```bash
   "watchOptions": {


### PR DESCRIPTION
I opened [this](https://github.com/nestjs/nest/issues/11038) issue a few hours ago which describes the problem I was having with running NestJS in watch mode.
I was asked by @micalevisk to add information about this problem to the "Common errors" page, and this is it.