### PR TITLE
fix: Update rate-limit websocket docs

### DIFF
--- a/content/security/rate-limiting.md
+++ b/content/security/rate-limiting.md
@@ -104,8 +104,7 @@ This module can work with websockets, but it requires some class extension. You 
 export class WsThrottlerGuard extends ThrottlerGuard {
   async handleRequest(context: ExecutionContext, limit: number, ttl: number): Promise<boolean> {
     const client = context.switchToWs().getClient();
-    // this is a generic method to switch between `ws` and `socket.io`. You can choose what is appropriate for you
-    const ip = ['conn', '_socket']
+    const ip = ['_socket']
       .map((key) => client[key])
       .filter((obj) => obj)
       .shift().remoteAddress;
@@ -120,6 +119,7 @@ export class WsThrottlerGuard extends ThrottlerGuard {
   }
 }
 ```
+> info **Hint** If you using ws, it is necessary to replace the `_socket` with `conn`
 
 There are some things to take keep in mind when working with websockets:
 

--- a/content/security/rate-limiting.md
+++ b/content/security/rate-limiting.md
@@ -104,10 +104,7 @@ This module can work with websockets, but it requires some class extension. You 
 export class WsThrottlerGuard extends ThrottlerGuard {
   async handleRequest(context: ExecutionContext, limit: number, ttl: number): Promise<boolean> {
     const client = context.switchToWs().getClient();
-    const ip = ['_socket']
-      .map((key) => client[key])
-      .filter((obj) => obj)
-      .shift().remoteAddress;
+    const ip = ['_socket'].shift().remoteAddress;
     const key = this.generateKey(context, ip);
     const { totalHits } = await this.storageService.increment(key, ttl);
 

--- a/content/security/rate-limiting.md
+++ b/content/security/rate-limiting.md
@@ -121,7 +121,7 @@ export class WsThrottlerGuard extends ThrottlerGuard {
 There's a few things to keep in mind when working with WebSockets:
 
 - You cannot bind the guard with `APP_GUARD` or `app.useGlobalGuards()` due to how Nest binds global guards.
-- When a limit is reached, Nest will emit an `exception` event, so make sure there is a listener ready for this.
+- When a limit is reached, Nest will emit an `exception` event, so make sure there is a listener ready for this
 
 > info **Hint** If you are using the `@nestjs/platform-ws` package you can use `client._socket.remoteAddress` instead.
 

--- a/content/security/rate-limiting.md
+++ b/content/security/rate-limiting.md
@@ -120,7 +120,7 @@ export class WsThrottlerGuard extends ThrottlerGuard {
 
 There's a few things to keep in mind when working with WebSockets:
 
-- You cannot bind the guard with `APP_GUARD` or `app.useGlobalGuards()` due to how Nest binds global guards.
+- Guard cannot be registered with the `APP_GUARD` or `app.useGlobalGuards()`
 - When a limit is reached, Nest will emit an `exception` event, so make sure there is a listener ready for this
 
 > info **Hint** If you are using the `@nestjs/platform-ws` package you can use `client._socket.remoteAddress` instead.

--- a/content/security/rate-limiting.md
+++ b/content/security/rate-limiting.md
@@ -104,7 +104,7 @@ This module can work with websockets, but it requires some class extension. You 
 export class WsThrottlerGuard extends ThrottlerGuard {
   async handleRequest(context: ExecutionContext, limit: number, ttl: number): Promise<boolean> {
     const client = context.switchToWs().getClient();
-    const ip = ['_socket'].shift().remoteAddress;
+    const ip = client._socket.remoteAddress
     const key = this.generateKey(context, ip);
     const { totalHits } = await this.storageService.increment(key, ttl);
 

--- a/content/security/rate-limiting.md
+++ b/content/security/rate-limiting.md
@@ -118,7 +118,7 @@ export class WsThrottlerGuard extends ThrottlerGuard {
 ```
 > info **Hint** If you using ws, it is necessary to replace the `_socket` with `conn`
 
-There are some things to take keep in mind when working with websockets:
+There's a few things to keep in mind when working with WebSockets:
 
 - You cannot bind the guard with `APP_GUARD` or `app.useGlobalGuards()` due to how Nest binds global guards.
 - When a limit is reached, Nest will emit an `exception` event, so make sure there is a listener ready for this.


### PR DESCRIPTION
I have update WsThrottlerGuard following new methods: https://github.com/nestjs/throttler#working-with-websockets

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
I have update `WsThrottlerGuard ` following this [pull](https://github.com/nestjs/throttler/pull/1304)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
