### PR TITLE
docs(module-reference): make CatsService request-scoped in code example

### DIFF
--- a/content/fundamentals/module-reference.md
+++ b/content/fundamentals/module-reference.md
@@ -175,7 +175,7 @@ Occasionally, you may want to resolve an instance of a request-scoped provider w
 
 ```typescript
 @@filename(cats.service)
-@Injectable()
+@Injectable({ scope: Scope.REQUEST })
 export class CatsService {
   constructor(
     @Inject(REQUEST) private request: Record<string, unknown>,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

![image](https://user-images.githubusercontent.com/19539377/217604043-a6e5d23d-6394-4c18-bf5d-1ea3c2b8fc87.png)

The documentation refers to `CatsService` as being request-scoped, however in the code sample, the service has the default singleton scope.

## What is the new behavior?

The `CatsService` in the code sample is now request-scoped.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
