### PR TITLE
docs: example of sequelize injection for a named connection

### DIFF
--- a/content/techniques/sql.md
+++ b/content/techniques/sql.md
@@ -1147,7 +1147,7 @@ You can also inject the `Sequelize` instance for a given connection:
 @Injectable()
 export class AlbumsService {
   constructor(
-    @InjectDataSource('albumsConnection')
+    @InjectConnection('albumsConnection')
     private sequelize: Sequelize,
   ) {}
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
In the docs there is a section that says that to do Sequelize multiple connections, we must use `@InjectDataSource` to inject the named connection. However, the module `@nestjs/sequelize` don't has this import. Actually, `@InjectDataSource` is an annotations for TypeORM.
https://docs.nestjs.com/techniques/database#multiple-databases-1

Issue Number: N/A


## What is the new behavior?
To fix the issue, I replaced `@InjectDataSource` for `@InjectConnection` that is the correct annotation.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
