### PR TITLE
docs(exception-filters): pass full HttpAdapterHost

### DIFF
--- a/content/exception-filters.md
+++ b/content/exception-filters.md
@@ -392,7 +392,7 @@ The first method is to inject the `HttpAdapter` reference when instantiating the
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
 
-  const { httpAdapter } = app.get(HttpAdapterHost);
+  const httpAdapterHost = app.get(HttpAdapterHost);
   app.useGlobalFilters(new AllExceptionsFilter(httpAdapter));
 
   await app.listen(3000);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

Fix documentation issue: pass in the entire HttpAdapterHost as the example code requires

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?

Typescript error when using the example code
```
Argument of type 'AbstractHttpAdapter<any, any, any>' is not assignable to parameter of type 'HttpAdapterHost<AbstractHttpAdapter<any, any, any>>'.
  Property 'httpAdapter' is missing in type 'AbstractHttpAdapter<any, any, any>' but required in type 'HttpAdapterHost<AbstractHttpAdapter<any, any, any>>'.
```

## What is the new behavior?

Fix typescript error

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


## Other information

None