### PR TITLE
docs(Kafka): adding postfixId property in kafka client options

### DIFF
--- a/content/microservices/kafka.md
+++ b/content/microservices/kafka.md
@@ -112,6 +112,10 @@ The `options` property is specific to the chosen transporter. The <strong>Kafka<
     <td><code>producerOnlyMode</code></td>
     <td>Feature flag to skip consumer group registration and only act as a producer (<code>boolean</code>)</td>
   </tr>
+  <tr>
+    <td><code>postfixId</code></td>
+    <td>Change the suffix of the clientId value (<code>string</code>)</td>
+  </tr>
 </table>
 
 #### Client


### PR DESCRIPTION
When I was getting some error logs trying connect to the kafka server, I saw that the library added a "-server" or "-client" suffix to the value of the clientId property.

Well, in the documentation there is a very generic "HINT" on how to change this...

"Kafka client and consumer naming conventions can be customized by extending ClientKafka and KafkaServer in your own custom provider and overriding the constructor."

But looking at node_modules i found a property called "posfixId" in the file responsible for initializing the connection to the kafka server, which appeared to be responsible for prefixing of clientId value, so I put this setting in my configuration object in main.ts with an empty value, like "".

And it worked fine (the suffix was removed), so i think it would be nice to make it clear that this configuration exists, after all, some Kafka servers need a specific clientId where the value cannot be changed in any way.

You can see this property in https://github.com/nestjs/nest/blob/master/packages/microservices/server/server-kafka.ts line 60.

So, in conclusion, I'm proposing to put this as one more property in the "Options" object section.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
There is currently no reference to the option to change the suffix of the clientId property.


## What is the new behavior?
Making the existence of this property explicit in the client options section.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x ] No


## Other information
