### PR TITLE
docs(raw-body): registering a different parser dynamically

### DIFF
--- a/content/faq/raw-body.md
+++ b/content/faq/raw-body.md
@@ -79,7 +79,7 @@ class CatsController {
 }
 ```
 
-##### Registering a Different Parser Dynamically with Fastify Body Parser
+#### Registering a different parser
 
 By default, only `application/json` and `application/x-www-form-urlencoded` parsers are registered. If you want to register a different parser on the fly, you will need to do so explicitly.
 

--- a/content/faq/raw-body.md
+++ b/content/faq/raw-body.md
@@ -13,7 +13,7 @@ import { NestFactory } from '@nestjs/core';
 import type { NestExpressApplication } from '@nestjs/platform-express';
 import { AppModule } from './app.module';
 
-
+// in the "bootstrap" function
 const app = await NestFactory.create<NestExpressApplication>(AppModule, {
   rawBody: true,
 });

--- a/content/faq/raw-body.md
+++ b/content/faq/raw-body.md
@@ -35,7 +35,7 @@ class CatsController {
 }
 ```
 
-##### Registering a Different Parser Dynamically with Express Body Parser
+#### Registering a different parser
 
 By default, only `json` and `urlencoded` parsers are registered. If you want to register a different parser on the fly, you will need to do so explicitly.
 

--- a/content/faq/raw-body.md
+++ b/content/faq/raw-body.md
@@ -9,7 +9,12 @@ One of the most common use-case for having access to the raw request body is per
 First enable the option when creating your Nest Express application:
 
 ```typescript
-const app = await NestFactory.create(AppModule, {
+import { NestFactory } from '@nestjs/core';
+import type { NestExpressApplication } from '@nestjs/platform-express';
+import { AppModule } from './app.module';
+
+
+const app = await NestFactory.create<NestExpressApplication>(AppModule, {
   rawBody: true,
 });
 await app.listen(3000);
@@ -30,11 +35,25 @@ class CatsController {
 }
 ```
 
+##### Registering a Different Parser Dynamically with Express Body Parser
+
+By default, only `json` and `urlencoded` parsers are registered. If you want to register a different parser on the fly, you will need to do so explicitly.
+
+For example, to register a `text` parser, you can use the following code:
+
+```typescript
+app.useBodyParser('text')
+```
+
 #### Use with Fastify
 
 First enable the option when creating your Nest Fastify application:
 
 ```typescript
+import { NestFactory } from '@nestjs/core';
+import { FastifyAdapter, NestFastifyApplication } from '@nestjs/platform-fastify';
+import { AppModule } from './app.module';
+
 const app = await NestFactory.create<NestFastifyApplication>(
   AppModule,
   new FastifyAdapter(),
@@ -58,4 +77,14 @@ class CatsController {
     const raw = req.rawBody; // returns a `Buffer`.
   }
 }
+```
+
+##### Registering a Different Parser Dynamically with Fastify Body Parser
+
+By default, only `application/json` and `application/x-www-form-urlencoded` parsers are registered. If you want to register a different parser on the fly, you will need to do so explicitly.
+
+For example, to register a `text/plain` parser, you can use the following code:
+
+```typescript
+app.useBodyParser('text/plain')
 ```

--- a/content/faq/raw-body.md
+++ b/content/faq/raw-body.md
@@ -54,6 +54,7 @@ import { NestFactory } from '@nestjs/core';
 import { FastifyAdapter, NestFastifyApplication } from '@nestjs/platform-fastify';
 import { AppModule } from './app.module';
 
+// in the "bootstrap" function
 const app = await NestFactory.create<NestFastifyApplication>(
   AppModule,
   new FastifyAdapter(),


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [X] Docs
- [ ] Other... Please describe:


## What is the current behavior?
N/A

Issue Number: N/A


## What is the new behavior?
This pull request updates the documentation for registering a different parser dynamically with Express and Fastify Body Parsers. The current documentation does not mention that only json and urlencoded parsers are registered by default. The updated documentation clarifies that if you want to register a different parser on the fly, you need to do so explicitly, and provides an example of how to register a text parser. 

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

## Other information
