### PR TITLE
docs(raw-body): add examples and explainers for body parser limits with `app.useBodyParser`

### DIFF
--- a/content/faq/raw-body.md
+++ b/content/faq/raw-body.md
@@ -42,8 +42,20 @@ By default, only `json` and `urlencoded` parsers are registered. If you want to 
 For example, to register a `text` parser, you can use the following code:
 
 ```typescript
-app.useBodyParser('text')
+app.useBodyParser('text');
 ```
+
+> warning **Warning** Ensure that you are providing the correct application type to the `NestFactory.create` call. For Express applications, the correct type is `NestExpressApplication`. Otherwise the `.useBodyParser` method will not be found.
+
+#### Body parser size limit
+
+If your application needs to parse a body larger than the default `100kb` of Express, use the following:
+
+```typescript
+app.useBodyParser('json', { limit: '10mb' });
+```
+
+The `.useBodyParser` method will respect the `rawBody` option that is passed in the application options.
 
 #### Use with Fastify
 
@@ -51,7 +63,10 @@ First enable the option when creating your Nest Fastify application:
 
 ```typescript
 import { NestFactory } from '@nestjs/core';
-import { FastifyAdapter, NestFastifyApplication } from '@nestjs/platform-fastify';
+import {
+  FastifyAdapter,
+  NestFastifyApplication,
+} from '@nestjs/platform-fastify';
 import { AppModule } from './app.module';
 
 // in the "bootstrap" function
@@ -60,7 +75,7 @@ const app = await NestFactory.create<NestFastifyApplication>(
   new FastifyAdapter(),
   {
     rawBody: true,
-  }
+  },
 );
 await app.listen(3000);
 ```
@@ -87,5 +102,18 @@ By default, only `application/json` and `application/x-www-form-urlencoded` pars
 For example, to register a `text/plain` parser, you can use the following code:
 
 ```typescript
-app.useBodyParser('text/plain')
+app.useBodyParser('text/plain');
 ```
+
+> warning **Warning** Ensure that you are providing the correct application type to the `NestFactory.create` call. For Fastify applications, the correct type is `NestFastifyApplication`. Otherwise the `.useBodyParser` method will not be found.
+
+#### Body parser size limit
+
+If your application needs to parse a body larger than the default 1MiB of Fastify, use the following:
+
+```typescript
+const bodyLimit = 10_485_760; // 10MiB
+app.useBodyParser('application/json', { bodyLimit });
+```
+
+The `.useBodyParser` method will respect the `rawBody` option that is passed in the application options.


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

I noticed a lot of questions on how `.useBodyParser` works in the original issue that was opened about this feature.

## What is the new behavior?

- Some devs mentioning that they cannot find the `.useBodyParser` method because they forget to type their application as `NestExpressApplication` or `NestFastifyApplication`. This is now a `warning` block.
- I added the reason for adding `.useBodyParser`: to allow registering body parsers with their own options, while respecting the `rawBody: true` application option.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

See questions in https://github.com/nestjs/nest/issues/10471
