### PR TITLE
docs(graphql): add warning section for field middleware

### DIFF
--- a/content/graphql/field-middleware.md
+++ b/content/graphql/field-middleware.md
@@ -43,7 +43,7 @@ Now whenever we request the `title` field of `Recipe` object type, the original 
 
 > info **Hint** To learn how you can implement a field-level permissions system with the use of [extensions](/graphql/extensions) feature, check out this [section](/graphql/extensions#using-custom-metadata).
 
-> warning **Warning** Field middleware can be applied ObjectType only. For more details, check out this [issue](https://github.com/nestjs/graphql/issues/2446).
+> warning **Warning** Field middleware can be applied only to `ObjectType` classes. For more details, check out this [issue](https://github.com/nestjs/graphql/issues/2446).
 
 Also, as mentioned above, we can control the field's value from within the middleware function. For demonstration purposes, let's capitalise a recipe's title (if present):
 

--- a/content/graphql/field-middleware.md
+++ b/content/graphql/field-middleware.md
@@ -43,6 +43,8 @@ Now whenever we request the `title` field of `Recipe` object type, the original 
 
 > info **Hint** To learn how you can implement a field-level permissions system with the use of [extensions](/graphql/extensions) feature, check out this [section](/graphql/extensions#using-custom-metadata).
 
+> warning **Warning** Field middleware can be applied ObjectType only. For more details, check out this [issue](https://github.com/nestjs/graphql/issues/2446).
+
 Also, as mentioned above, we can control the field's value from within the middleware function. For demonstration purposes, let's capitalise a recipe's title (if present):
 
 ```typescript


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Added warning section. This section describes that FieldMiddleware can be applied only ObjectType. After update docs, we know it does not apply to other types.

related issue: 
- https://github.com/nestjs/graphql/issues/2446
- https://github.com/nestjs/graphql/issues/2751