### PR TITLE
docs(devtools): change writeFileSync to fs.writeFileSync

### DIFF
--- a/content/devtools/overview.md
+++ b/content/devtools/overview.md
@@ -70,7 +70,7 @@ First, open up the `main.ts` file and update the `bootstrap()` call, as follows:
 
 ```typescript
 bootstrap().catch((err) => {
-  writeFileSync('graph.json', PartialGraphHost.toString() ?? '');
+  fs.writeFileSync('graph.json', PartialGraphHost.toString() ?? '');
   process.exit(1);
 });
 ```

--- a/content/devtools/overview.md
+++ b/content/devtools/overview.md
@@ -130,7 +130,7 @@ To save a serialized graph to a file, use the following code:
 
 ```typescript
 await app.listen(3000); // OR await app.init()
-writeFileSync('./graph.json', app.get(SerializedGraph).toString());
+fs.writeFileSync('./graph.json', app.get(SerializedGraph).toString());
 ```
 
 > info **Hint** `SerializedGraph` is exported from the `@nestjs/core` package.


### PR DESCRIPTION
Updated to need to call `fs.writeFileSync`

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

```ts
// error TS2304: Cannot find name 'writeFileSync'.

bootstrap().catch((err) => {
  writeFileSync('graph.json', PartialGraphHost.toString() ?? '');
  process.exit(1);
});

writeFileSync('./graph.json', app.get(SerializedGraph).toString());
```

Issue Number: N/A


## What is the new behavior?

```ts
import * as fs from 'fs';

fs.writeFileSync('graph.json', PartialGraphHost.toString() ?? '');

fs.writeFileSync('./graph.json', app.get(SerializedGraph).toString());
```


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
