### PR TITLE
docs(global-prefix): add path-to-regex hint

### DIFF
--- a/content/faq/global-prefix.md
+++ b/content/faq/global-prefix.md
@@ -20,3 +20,5 @@ Alternatively, you can specify route as a string (it will apply to every request
 ```typescript
 app.setGlobalPrefix('v1', { exclude: ['cats'] });
 ```
+
+> info **Hint** The `path` property supports wildcard parameters using the [path-to-regexp](https://github.com/pillarjs/path-to-regexp#parameters) package. Note: this does not accept wildcard asterisks `*`. Instead, you must use parameters (e.g., `(.*)`, `:splat*`).


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?

When passing paths to exclude to `app.setGlobalPrefix`, it's not mentioned that the string to `exclude` (either the raw `string` or `path` in `RouteInfo`) is internally handled using [path-to-regexp](https://github.com/pillarjs/path-to-regexp). In particular it doesn't make clear path-to-regexp's [lack of wildcard handling](https://github.com/pillarjs/path-to-regexp#compatibility-with-express--4x), meaning that strings containing wildcards or even conventional regexps (e.g. `auth/*`, `auth.*` etc) will not work. This was a major headache to figure out on my project, and we can very close to giving up on using `useGlobalPrefix` entirely.

## What is the new behavior?

Points this out in a hint, similar to the route wildcards part on the [middleware page](http://localhost:4200/middleware#route-wildcards). I've explicitly pointed out the wildcard behavior, as honestly, this is likely to save some people a lot of head-scratching.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


## Other information
