### PR TITLE
fix(docs): asset cleaning errors on windows

### DIFF
--- a/tools/transforms/nestjs-package/processors/cleanGeneratedFiles.ts
+++ b/tools/transforms/nestjs-package/processors/cleanGeneratedFiles.ts
@@ -9,7 +9,7 @@ export class CleanGeneratedFiles implements Processor {
   $runAfter = ['writing-files'];
   $runBefore = ['writeFilesProcessor'];
   $process() {
-    rimraf.sync(`${OUTPUT_PATH}/{docs,*.json}`);
+    rimraf.sync(`${OUTPUT_PATH}/{docs,*.json}`, { glob: true });
   }
 }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
[rimraf v4 recently removed support for glob patterns](https://github.com/isaacs/rimraf/issues/249), then subsequently added them back, but requiring the `{ glob: true }` in the options passed to rimraf API methods. My understanding is, on POSIX-compliant OSs, it'll use the native shell handling of glob patterns anyway, but on Windows, now needs to passed this option for it to use the [node-glob](https://github.com/isaacs/node-glob), which handles glob patterns on Windows.

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Docs
- [ ] Other... Please describe:


## What is the current behavior?
As mentioned in the below issue, the `rimraf.sync` call in `cleanGeneratedFiles.ts` will error with "Illegal characters in path." when the `${OUTPUT_PATH}/{docs,*.json}` glob is passed in, apparently only on Windows (I'm on Windows 11 and get the exact same output as #2635).

Issue Number: #2635


## What is the new behavior?
Explicitly uses the built-in glob handling, which now runs fine on Windows. This may change behavior on other OSs, which at least since rimraf v4 were doing glob handling using native shell functionality, but I assume that getting identical behavior between different operating systems is why you're using rimraf in the first place.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


## Other information
