### PR TITLE
docs(automock): update code example to match  api

### DIFF
--- a/content/recipes/automock.md
+++ b/content/recipes/automock.md
@@ -71,6 +71,11 @@ describe('CatsService unit spec', () => {
   beforeAll(() => {
     const { unit, unitRef } = TestBed.create(CatsService)
       .mock(HttpService)
+      .use({ get: jest.fn() })
+      .mock(Logger)
+      .use({ log: jest.fn() })
+      .mock(CatsDal)
+      .use({ saveCats: jest.fn() })
       .compile();
 
     underTest = unit;
@@ -82,7 +87,7 @@ describe('CatsService unit spec', () => {
 
   describe('when getting all the cats', () => {
     test('then meet some expectations', async () => {
-      httpService.mockResolvedValueOnce([{ id: 1, name: 'Catty' }]);
+      httpService.get.mockResolvedValueOnce([{ id: 1, name: 'Catty' }]);
       await catsService.getAllCats();
 
       expect(logger.log).toBeCalled();


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
Example matches old api.

## What is the new behavior?
New `@automock/jest` api requires a `use` mock. See [this](https://github.com/sahellebusch/nestjs-cats-example/blob/automock-example/src/cats/cats.service.spec.ts) working example.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information
None.
