### PR TITLE
docs(queues): add concurrency warning when defining multiple consumers

### DIFF
--- a/content/techniques/queues.md
+++ b/content/techniques/queues.md
@@ -241,6 +241,8 @@ You can designate that a job handler method will handle **only** jobs of a certa
 async transcode(job: Job<unknown>) { ... }
 ```
 
+> Warning **Warning** When defining multiple consumers for the same queue, the `concurrency` option in `@Process({ concurrency: 1 })` won't take effect. The minimum `concurrency` will match the number of consumers defined. This also applies even if `@Process()` handlers use a different `name` to handle named jobs.
+
 #### Request-scoped consumers
 
 When a consumer is flagged as request-scoped (learn more about the injection scopes [here](/fundamentals/injection-scopes#provider-scope)), a new instance of the class will be created exclusively for each job. The instance will be garbage-collected after the job has completed.


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
There is no information about the consequences of defining multiple `@Processor()` or `@Proces()`.
The documentation contemplates the use of multiple processors, yet doesn't warn that the concurrency will become *at least* the number of processors.

This is stated in the [BullMQ docs](https://docs.bullmq.io/guide/workers/concurrency) but I think it's worth adding a warning in NestJS docs.

Issue Number: N/A


## What is the new behavior?
Added a warning section:

> Warning: When defining multiple consumers for the same queue, the `concurrency` option in `@Process({ concurrency: 1 })` won't take effect. The minimum concurrency will match the number of consumers defined. This also applies even if `@Process()` handlers use a different `name` to handle named jobs.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
