### PR TITLE
docs(build): add clarification

### DIFF
--- a/content/cli/scripts.md
+++ b/content/cli/scripts.md
@@ -16,7 +16,7 @@ The `nest` command is an OS level binary (i.e., runs from the OS command line). 
 
 #### Build
 
-`nest build` is a wrapper on top of the standard `tsc` compiler (for [standard projects](https://docs.nestjs.com/cli/overview#project-structure)) or the webpack compiler (for [monorepos](https://docs.nestjs.com/cli/overview#project-structure)). It does not add any other compilation features or steps except for handling `tsconfig-paths` out of the box. The reason it exists is that most developers, especially when starting out with Nest, do not need to adjust compiler options (e.g., `tsconfig.json` file) which can sometimes be tricky.
+`nest build` is a wrapper on top of the standard `tsc` compiler (for [standard projects](https://docs.nestjs.com/cli/overview#project-structure)) or the webpack bundler using the `ts-loader` (for [monorepos](https://docs.nestjs.com/cli/overview#project-structure)). It does not add any other compilation features or steps except for handling `tsconfig-paths` out of the box. The reason it exists is that most developers, especially when starting out with Nest, do not need to adjust compiler options (e.g., `tsconfig.json` file) which can sometimes be tricky.
 
 See the [nest build](https://docs.nestjs.com/cli/usages#nest-build) documentation for more details.
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

[The current cli build script documentation states that the build script is a wrapper around the tsc compiler or the webpack compiler](https://docs.nestjs.com/cli/scripts#build) but in webpack's documentation it's said that it uses tsc in it's ts-loader.

## What is the new behavior?
The documentation states that the build script for monorepos is a wrapper for webpack's bundler that uses ts-loader.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
I'm fairly new to proper js development environment and this is my first PR. The build script doc got me uncertain and led me on a tangent to read webpack's doc again to be sure I was not mistaken. To be honest, reading the other PRs made me think mine is not really necessary, but please, give feedback.