### PR TITLE
docs(mongo): change mongoose model type

### DIFF
--- a/content/techniques/mongo.md
+++ b/content/techniques/mongo.md
@@ -138,12 +138,12 @@ Once you've registered the schema, you can inject a `Cat` model into the `CatsSe
 import { Model } from 'mongoose';
 import { Injectable } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
-import { Cat, CatDocument } from './schemas/cat.schema';
+import { Cat } from './schemas/cat.schema';
 import { CreateCatDto } from './dto/create-cat.dto';
 
 @Injectable()
 export class CatsService {
-  constructor(@InjectModel(Cat.name) private catModel: Model<CatDocument>) {}
+  constructor(@InjectModel(Cat.name) private catModel: Model<Cat>) {}
 
   async create(createCatDto: CreateCatDto): Promise<Cat> {
     const createdCat = new this.catModel(createCatDto);
@@ -259,7 +259,7 @@ If you are just looking to inject the model from a named database, you can use t
 @@filename(cats.service)
 @Injectable()
 export class CatsService {
-  constructor(@InjectModel(Cat.name, 'cats') private catModel: Model<CatDocument>) {}
+  constructor(@InjectModel(Cat.name, 'cats') private catModel: Model<Cat>) {}
 }
 @@switch
 @Injectable()


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The current example uses `Model<CatDocument>` as a Mongoose model type. The result model type doesn't match the plain Mongoose model type. It wasn't a problem in v6. But the `Model` interface was changed in v7 and now it leads to some type mismatch problems if we use `Document` in generic.

For example, lean documents still have document properties and functions when they shouldn't.

```typescript
// Mongoose v6
type CatDocumentModel = Model<CatDocument>
// Model<Document<unknown, any, Cat> & Cat & { _id: Types.ObjectId }, {}, {}, {}, any>
type CatModel = Model<Cat>
// Model<Cat, {}, {}, {}, any>

// ref: https://mongoosejs.com/docs/6.x/docs/typescript.html#creating-your-first-document
const mongooseCatModel = model<Cat>('Cat', catSchema)
// Model<Cat, {}, {}, {}, any>


// Mongoose v7
type CatDocumentModel = Model<CatDocument>
// Model<Document<unknown, {}, Cat> & Omit<Cat & { _id: Types.ObjectId }, never>, {}, {}, {}, Document<unknown, {}, Document<unknown, {}, Cat> & Omit<...>> & Omit<...>, any>
type CatModel = Model<Cat>
// Model<Cat, {}, {}, {}, Document<unknown, {}, Cat> & Omit<Cat & { _id: Types.ObjectId }, never>, any>

// ref: https://mongoosejs.com/docs/typescript.html#creating-your-first-document
const mongooseCatModel = model<Cat>('Cat', catSchema)
// Model<Cat, {}, {}, {}, Document<unknown, {}, Cat> & Omit<Cat & { _id: Types.ObjectId }, never>, any>
```

## What is the new behavior?

The Mongoose model type in the example uses `Model<Cat>`. It matches the plain Mongoose model type and provides proper typing.

ref: https://github.com/Automattic/mongoose/pull/12924/files#diff-ea95265448afcd58460d834ad313d09f7147696fbaa96a31629e3d4b9bb12585


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
