### PR TITLE
docs(caching): added warning for redis store

### DIFF
--- a/content/techniques/caching.md
+++ b/content/techniques/caching.md
@@ -246,6 +246,8 @@ import { AppController } from './app.controller';
 export class AppModule {}
 ```
 
+> warning**Warning** This snippets for configuration with Redis does not work with cache manager v5 but only with v4 version.
+
 > warning**Warning** `cache-manager-redis-store` does not support redis v4. In order for the `ClientOpts` interface to exist and work correctly you need to install the
 > latest `redis` 3.x.x major release. See this [issue](https://github.com/dabroek/node-cache-manager-redis-store/issues/40) to track the progress of this upgrade.
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
Proposal:

I thought I would add this warning because the code snippet of the cache manager with Redis described in the documentation confuses people a bit and they come to think that it also works with the v5 cache manager, instead it only works with the v4 version. (see screenshot).

<img width="1448" alt="screenshot-config-redis-cache" src="https://user-images.githubusercontent.com/11542387/229928052-70dbfa5e-e9f3-4171-8586-29fc14a68fc4.png">


Momentarily I think it is a good thing to add a warning. 

**So in the meantime we can prepare an 'update of the "Different Stores" and "Asynchronous Configuration" chapter of the "Caching" section because the TTL with the new configurations is set directly within the configuration (see code snippet) rather than as a module option**

```ts
CacheModule.registerAsync({
  useFactory: async () => {
      const store = await redisStore({
		socket: {
		  host: 'localhst',
		  port: '6379',
		  tls: true
		},
		password: 'redis-pass',
     });

     return {
	store: store as unknown as CacheStore,
	ttl: 60 * 60 * 24 * 7,  // 1 week
      };
   } 
})

```

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
