### PR TITLE
docs(recipes): remove duplicates occurrence of 'and' word

### DIFF
--- a/content/recipes/async-local-storage.md
+++ b/content/recipes/async-local-storage.md
@@ -55,7 +55,7 @@ export class AppModule implements NestModule {
         const store = {
           userId: req.headers['x-user-id'],
         };
-        // and and pass the "next" function as callback
+        // and pass the "next" function as callback
         // to the "als.run" method together with the store.
         als.run(store, () => next());
       })
@@ -85,7 +85,7 @@ export class AppModule {
         const store = {
           userId: req.headers['x-user-id'],
         };
-        // and and pass the "next" function as callback
+        // and pass the "next" function as callback
         // to the "als.run" method together with the store.
         als.run(store, () => next());
       })


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
In the code examples included in the Async Local Storage documentation, there is a duplicate of the word 'and',
```
// and and pass the "next" function as callback
```

Issue Number: N/A


## What is the new behavior?
Removed duplicated occurrence 

```
// and pass the "next" function as callback
```

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No




