### PR TITLE
Update controllers.md (type 'params' as 'any')

### DIFF
--- a/content/controllers.md
+++ b/content/controllers.md
@@ -273,7 +273,7 @@ Routes with static paths won't work when you need to accept **dynamic data** as 
 ```typescript
 @@filename()
 @Get(':id')
-findOne(@Param() params): string {
+findOne(@Param() params: any): string {
   console.log(params.id);
   return `This action returns a #${params.id} cat`;
 }


### PR DESCRIPTION
Without specifying the variable 'params' as type 'any' I received the following error on a fresh project while following the documentation:

```typescript
findOne(@Param() params): string {
```

```
error TS7006: Parameter 'params' implicitly has an 'any' type.
```

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
