### PR TITLE
docs(openapi): prefer lazy over eager creation of the document

### DIFF
--- a/content/openapi/introduction.md
+++ b/content/openapi/introduction.md
@@ -37,7 +37,7 @@ async function bootstrap() {
 bootstrap();
 ```
 
-> info **Hint** The return of `SwaggerModule#createDocument()` is a serializable object conforming to [OpenAPI Document](https://swagger.io/specification/#openapi-document). Instead of hosting it via HTTP, you could also save it as a JSON/YAML file, and consume it in different ways.
+> info **Hint** The factory around `SwaggerModule#createDocument()` is only used to create the document when you actually request Swagger, saving some initialization time and is a serializable object conforming to [OpenAPI Document](https://swagger.io/specification/#openapi-document). Instead of hosting it via HTTP, you could also save it as a JSON/YAML file, and consume it in different ways.
 
 The `DocumentBuilder` helps to structure a base document that conforms to the OpenAPI Specification. It provides several methods that allow setting such properties as title, description, version, etc. In order to create a full document (with all HTTP routes defined) we use the `createDocument()` method of the `SwaggerModule` class. This method takes two arguments, an application instance and a Swagger options object. Alternatively, we can provide a third argument, which should be of type `SwaggerDocumentOptions`. More on this in the [Document options section](/openapi/introduction#document-options).
 

--- a/content/openapi/introduction.md
+++ b/content/openapi/introduction.md
@@ -29,15 +29,15 @@ async function bootstrap() {
     .setVersion('1.0')
     .addTag('cats')
     .build();
-  const document = SwaggerModule.createDocument(app, config);
-  SwaggerModule.setup('api', app, document);
+  const documentFactory = () => SwaggerModule.createDocument(app, config);
+  SwaggerModule.setup('api', app, documentFactory);
 
   await app.listen(3000);
 }
 bootstrap();
 ```
 
-> info **Hint** `document` (returned by the `SwaggerModule#createDocument()` method) is a serializable object conforming to [OpenAPI Document](https://swagger.io/specification/#openapi-document). Instead of hosting it via HTTP, you could also save it as a JSON/YAML file, and consume it in different ways.
+> info **Hint** The return of `SwaggerModule#createDocument()` is a serializable object conforming to [OpenAPI Document](https://swagger.io/specification/#openapi-document). Instead of hosting it via HTTP, you could also save it as a JSON/YAML file, and consume it in different ways.
 
 The `DocumentBuilder` helps to structure a base document that conforms to the OpenAPI Specification. It provides several methods that allow setting such properties as title, description, version, etc. In order to create a full document (with all HTTP routes defined) we use the `createDocument()` method of the `SwaggerModule` class. This method takes two arguments, an application instance and a Swagger options object. Alternatively, we can provide a third argument, which should be of type `SwaggerDocumentOptions`. More on this in the [Document options section](/openapi/introduction#document-options).
 
@@ -126,7 +126,7 @@ const options: SwaggerDocumentOptions =  {
     methodKey: string
   ) => methodKey
 };
-const document = SwaggerModule.createDocument(app, config, options);
+const documentFactory = () => SwaggerModule.createDocument(app, config, options);
 ```
 
 #### Setup options

--- a/content/openapi/other-features.md
+++ b/content/openapi/other-features.md
@@ -47,10 +47,10 @@ async function bootstrap() {
     .addTag('cats')
     .build();
 
-  const catDocument = SwaggerModule.createDocument(app, options, {
+  const catDocumentFactory = () => SwaggerModule.createDocument(app, options, {
     include: [CatsModule],
   });
-  SwaggerModule.setup('api/cats', app, catDocument);
+  SwaggerModule.setup('api/cats', app, catDocumentFactory);
 
   const secondOptions = new DocumentBuilder()
     .setTitle('Dogs example')
@@ -59,10 +59,10 @@ async function bootstrap() {
     .addTag('dogs')
     .build();
 
-  const dogDocument = SwaggerModule.createDocument(app, secondOptions, {
+  const dogDocumentFactory = () => SwaggerModule.createDocument(app, secondOptions, {
     include: [DogsModule],
   });
-  SwaggerModule.setup('api/dogs', app, dogDocument);
+  SwaggerModule.setup('api/dogs', app, dogDocumentFactory);
 
   await app.listen(3000);
 }

--- a/content/openapi/types-and-parameters.md
+++ b/content/openapi/types-and-parameters.md
@@ -251,7 +251,7 @@ export class CreateCatDto {}
 Alternatively, you can pass an options object with the `extraModels` property specified to the `SwaggerModule#createDocument()` method, as follows:
 
 ```typescript
-const document = SwaggerModule.createDocument(app, options, {
+const documentFactory = () => SwaggerModule.createDocument(app, options, {
   extraModels: [ExtraModel],
 });
 ```


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?

NestJS does not use the new feature of lazy initialization of Swagger, which adds some time to startup.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Associated with https://github.com/nestjs/swagger/pull/2392

## What is the new behavior?

Now, by default, we use always the lazy initialization in favor of the initialization speed.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
