### PR TITLE
docs(cli): add hint on manual restart for tsc watch mode

### DIFF
--- a/content/cli/usages.md
+++ b/content/cli/usages.md
@@ -107,14 +107,14 @@ $ nest build <name> [options]
 
 ##### Options
 
-| Option            | Description                                            |
-| ----------------- | ------------------------------------------------------ |
-| `--path [path]`   | Path to `tsconfig` file. <br/>Alias `-p`               |
-| `--config [path]` | Path to `nest-cli` configuration file. <br/>Alias `-c` |
-| `--watch`         | Run in watch mode (live-reload) <br/>Alias `-w`        |
-| `--webpack`       | Use webpack for compilation.                           |
-| `--webpackPath`   | Path to webpack configuration.                         |
-| `--tsc`           | Force use `tsc` for compilation.                       |
+| Option            | Description                                                                                                                           |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `--path [path]`   | Path to `tsconfig` file. <br/>Alias `-p`                                                                                              |
+| `--config [path]` | Path to `nest-cli` configuration file. <br/>Alias `-c`                                                                                |
+| `--watch`         | Run in watch mode (live-reload). If you're using `tsc` for compilation, you can type `rs` to restart the application. <br/>Alias `-w` |
+| `--webpack`       | Use webpack for compilation.                                                                                                          |
+| `--webpackPath`   | Path to webpack configuration.                                                                                                        |
+| `--tsc`           | Force use `tsc` for compilation.                                                                                                      |
 
 #### nest start
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:

## What is the new behavior?

![image](https://user-images.githubusercontent.com/13461315/233371231-31b5b20f-e140-4a60-b762-97b5848aee1e.png)


add documentation about this feature introduced in `@nestjs/cli` 9.4: https://github.com/nestjs/nest-cli/pull/2011

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
