### PR TITLE
docs(vitest): explicitly specify swcrc option to avoid conflict with vite

### DIFF
--- a/content/recipes/swc.md
+++ b/content/recipes/swc.md
@@ -121,7 +121,13 @@ export default defineConfig({
     globals: true,
     root: './',
   },
-  plugins: [swc.vite()], // This is required to build the test files with SWC
+  plugins: [
+    // This is required to build the test files with SWC
+    swc.vite({
+      // Explicitly set the module type to avoid inheriting this value from a `.swcrc` config file
+      module: { type: 'es6' },
+    }),
+  ],
 });
 ```
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Error when running `vitest` with an existing `.swcrc` as outlined in the `swc` recipe.

As it stands, both the `swc` and `vitest` recipes work great in their own right. When used together however, the module type needs to be explicitly set in `vitest.config.ts`. Otherwise it will be inherited from the `.swcrc`, which leads to an error `Cannot find module...`.

Issue Number: N/A


## What is the new behavior?

No error when running `vitest` with an existing `.swcrc` as outlined in the `swc` recipe.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Thanks for adding these useful recipes.
