### PR TITLE
docs(techniques):cookie-parser import changed

### DIFF
--- a/content/techniques/cookies.md
+++ b/content/techniques/cookies.md
@@ -14,7 +14,7 @@ $ npm i -D @types/cookie-parser
 Once the installation is complete, apply the `cookie-parser` middleware as global middleware (for example, in your `main.ts` file).
 
 ```typescript
-import * as cookieParser from 'cookie-parser';
+import cookieParser from 'cookie-parser';
 // somewhere in your initialization file
 app.use(cookieParser());
 ```


### PR DESCRIPTION
Previous import statement causes error. Wildcard should be removed to use cookie-parser middleware as shown in the document like " app.use(cookieParser()) ".

## PR Checklist
Please check if your PR fulfills the following requirements:

- [👍] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
Current import statement that is written in the document like:
```javascript
import * as cookieParser from 'cookie-parser';
// somewhere in your initialization file
app.use(cookieParser());
```
causes error like:
<img width="594" alt="image" src="https://github.com/nestjs/docs.nestjs.com/assets/108582413/c8e27352-d09e-451e-b827-e7c18f7cbfbc">



## What is the new behavior?
Just changing document like:
```javascript
import cookieParser from 'cookie-parser';
// somewhere in your initialization file
app.use(cookieParser());
```
and it causes no error.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
None.