### PR TITLE
docs(automock): prepare docs for automock next version [WIP]

### DIFF
--- a/content/recipes/automock.md
+++ b/content/recipes/automock.md
@@ -1,35 +1,35 @@
 ### Automock
 
-Automock is a standalone library for unit testing. Using TypeScript Reflection
-API (`reflect-metadata`) internally to produce mock objects, Automock streamlines
-test development by automatically mocking class external dependencies.
+Automock is a standalone library for unit testing. Using TypeScript Reflection API (`reflect-metadata`) internally to
+produce mock objects, Automock streamlines test development by automatically mocking class dependencies.
 > info **info** `Automock` is a third party package and is not managed by the NestJS core team.
 > Please, report any issues found with the library in the [appropriate repository](https://github.com/omermorad/automock)
 
 #### Introduction
 
-The dependency injection (DI) container is an essential component of the Nest module system.
-This container is utilized both during testing, and the application execution.
-Unit tests vary from other types of tests, such as integration tests, in that they must
-fully override providers/services within the DI container. External class dependencies
-(providers) of the so-called "unit", have to be totally isolated. That is, all dependencies
-within the DI container should be replaced by mock objects.
-As a result, loading the target module and replacing the providers inside it is a process
-that loops back on itself. Automock tackles this issue by automatically mocking all the
-class external providers, resulting in total isolation of the unit under test.
+The dependency injection (DI) container is an essential component of the Nest module system. This container is utilized
+both during testing, and the application execution. Unit tests vary from other types of tests, such as integration
+tests, in that they must fully override providers/services within the DI container. External class dependencies
+(providers) of the so-called "unit", have to be totally isolated. That is, all dependencies within the DI container
+should be replaced by mock objects. As a result, loading the target module and replacing the providers inside it is a
+process that loops back on itself. Automock tackles this issue by automatically mocking all the class external
+providers, resulting in total isolation of the unit under test.
 
 #### Installation
 
+Automock simplifies installation by using `npx`. Execute the following command to initiate Automock:
+
 ```bash
-$ npm i -D @automock/jest
+$ npx automock init
 ```
 
-Automock does not require any additional setup.
-
-> info **info** Jest is the only test framework currently supported by Automock.
-Sinon will shortly be released.
+Or, install `automock` in your local project (`npm i -D automock`), and hit `automock init`.
+> info **info** When prompted, select either Sinon or Jest as your testing framework
+> and opt for NestJS as your chosen framework.
 
 #### Example
+The preceding examples are based on Jest, but the same applies to Sinon.
+Instead of importing from `@automock/jest`, import from `@automock/sinon`
 
 Consider the following cats service, which takes three constructor parameters:
 
@@ -43,40 +43,33 @@ export class CatsService {
     private logger: Logger,
     private httpService: HttpService,
     private catsDal: CatsDal,
-  ) {}
+  ) {
+  }
 
   async getAllCats() {
     const cats = await this.httpService.get('http://localhost:3000/api/cats');
     this.logger.log('Successfully fetched all cats');
-    
+
     this.catsDal.saveCats(cats);
   }
 }
 ```
 
-The service contains one public method, `getAllCats`, which is the method
-we use an example for the following unit test:
+The service contains one public method, `getAllCats`, which is the method we use an example for the following unit test:
 
 ```ts
 @@filename(cats.service.spec)
 import { TestBed } from '@automock/jest';
 import { CatsService } from './cats.service';
 
-describe('CatsService unit spec', () => {
+describe('Cats Service unit spec', () => {
   let underTest: CatsService;
   let logger: jest.Mocked<Logger>;
   let httpService: jest.Mocked<HttpService>;
   let catsDal: jest.Mocked<CatsDal>;
-  
+
   beforeAll(() => {
-    const { unit, unitRef } = TestBed.create(CatsService)
-      .mock(HttpService)
-      .using({ get: jest.fn() })
-      .mock(Logger)
-      .using({ log: jest.fn() })
-      .mock(CatsDal)
-      .using({ saveCats: jest.fn() })
-      .compile();
+    const { unit, unitRef } = TestBed.create(CatsService).compile();
 
     underTest = unit;
 
@@ -99,6 +92,8 @@ describe('CatsService unit spec', () => {
 
 > info **info** The jest.Mocked<Source> utility type returns the Source type
 > wrapped with type definitions of Jest mock function. ([reference](https://jestjs.io/docs/mock-function-api/#jestmockedsource))
+>
+> The same applies for Sinon - SinonStubbedInstance<Source>
 
 #### About `unit` and `unitRef`
 
@@ -112,9 +107,9 @@ Calling `.compile()` returns an object with two properties, `unit`, and `unitRef
 
 **`unit`** is the unit under test, it is an actual instance of class being tested.
 
-**`unitRef`** is the "unit reference", where the mocked dependencies of the tested class
-are stored, in a small container. The container's `.get()` method returns the mocked
-dependency with all of its methods automatically stubbed (using `jest.fn()`):
+**`unitRef`** is the "unit reference", where the mocked dependencies of the tested class are stored, in a small
+container. The container's `.get()` method returns the mocked dependency with all of its methods automatically stubbed (
+using `jest.fn()`):
 
 ```typescript
 const { unit, unitRef } = TestBed.create(CatsService).compile();
@@ -126,13 +121,13 @@ let httpServiceMock: jest.Mocked<HttpService> = unitRef.get(HttpService);
 > This essentially depends on how the provider is being injected to the class under test.
 
 #### Working with different providers
-Providers are one of the most important elements in Nest. You can think of many of
-the default Nest classes as providers, including services, repositories, factories,
-helpers, and so on. A provider's primary function is to take the form of an
+
+Providers are one of the most important elements in Nest. You can think of many of the default Nest classes as
+providers, including services, repositories, factories, helpers, and so on. A provider's primary function is to take the
+form of an
 `Injectable` dependency.
 
-Consider the following `CatsService`, it takes one parameter, which is an instance
-of the following `Logger` interface:
+Consider the following `CatsService`, it takes one parameter, which is an instance of the following `Logger` interface:
 
 ```typescript
 export interface Logger {
@@ -140,12 +135,13 @@ export interface Logger {
 }
 
 export class CatsService {
-  constructor(private logger: Logger) {}
+  constructor(private logger: Logger) {
+  }
 }
 ```
 
-TypeScript's Reflection API does not support interface reflection yet.
-Nest solves this issue with string-based injection tokens (see [Custom Providers](https://docs.nestjs.com/fundamentals/custom-providers)):
+TypeScript's Reflection API does not support interface reflection yet. Nest solves this issue with string-based
+injection tokens (see [Custom Providers](https://docs.nestjs.com/fundamentals/custom-providers)):
 
 ```typescript
 export const MyLoggerProvider = {
@@ -154,12 +150,13 @@ export const MyLoggerProvider = {
 }
 
 export class CatsService {
-  constructor(@Inject('MY_LOGGER_TOKEN') private readonly logger: Logger) {}
+  constructor(@Inject('MY_LOGGER_TOKEN') private readonly logger: Logger) {
+  }
 }
 ```
 
-Automock follows this practice and lets you provide a string-based token instead
-of providing the actual class in the `unitRef.get()` method:
+Automock follows this practice and lets you provide a string-based token instead of providing the actual class in
+the `unitRef.get()` method:
 
 ```typescript
 const { unit, unitRef } = TestBed.create(CatsService).compile();
@@ -168,5 +165,5 @@ let loggerMock: jest.Mocked<Logger> = unitRef.get('MY_LOGGER_TOKEN');
 ```
 
 #### More Information
-Visit [Automock GitHub repository](https://github.com/omermorad/automock) for more
-information.
+
+Visit [Automock GitHub repository](https://github.com/omermorad/automock) for more information.


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md

## PR Type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:

## More Information

**Hey everyone, just wanted to give you a heads up that I'm currently working on the next release of Automock (2.0.0). I'm also in the process of preparing the docs so we can discuss them.**

Upcoming changes for the Automock next release:
* Add support for Sinon (new package `@automock/sinon`).
* Remove `jest-mock-extended` dependency and replace it with a native solution for both Jest and Sinon.
* Utilize a plugin architecture; Support additional frameworks. So now it is required to install the appropriate package for your framework. So for example, using Jest with NestJS requires `npm i -D @automock/jest @automock/nestjs`. But instead, I came up with a solution - using a CLI to help initiate the project (GIF attached)

In addition, I'm revising some of the documentation to better demonstrate Automock's capabilities.

![automock-init](https://github.com/nestjs/docs.nestjs.com/assets/6696717/b47ced63-31ae-4bb6-a077-80103b4cfec5)