### PR TITLE
docs(openapi) fix reusable custom decorator explanation

### DIFF
--- a/content/openapi/operations.md
+++ b/content/openapi/operations.md
@@ -258,6 +258,7 @@ export const ApiPaginatedResponse = <TModel extends Type<any>>(
   model: TModel,
 ) => {
   return applyDecorators(
+    ApiExtraModels(model),
     ApiOkResponse({
       schema: {
         allOf: [
@@ -278,6 +279,8 @@ export const ApiPaginatedResponse = <TModel extends Type<any>>(
 ```
 
 > info **Hint** `Type<any>` interface and `applyDecorators` function are imported from the `@nestjs/common` package.
+
+To ensure that `SwaggerModule` will generate a definition for our model, we must add it as an extra model, like we did earlier with the `PaginatedDto` in the controller.
 
 With this in place, we can use the custom `@ApiPaginatedResponse()` decorator on our endpoint:
 


### PR DESCRIPTION
Ensure that when creating a reusable decorator `SwaggerModule` will create a definition for the used model by adding it as an extra model in the definition of the decorator.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
The guide on creating reusable pagination decorators can fail if the dto is not defined anywhere else. 

## What is the new behavior?
Adding the referenced model within `ApiExtraModels` ensures that the model definition will always be generated.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


## Other information
