### PR TITLE
docs(route-wildcards): add warning to route wildcards section

### DIFF
--- a/content/controllers.md
+++ b/content/controllers.md
@@ -202,7 +202,7 @@ findAll() {
 
 The `'ab*cd'` route path will match `abcd`, `ab_cd`, `abecd`, and so on. The characters `?`, `+`, `*`, and `()` may be used in a route path, and are subsets of their regular expression counterparts. The hyphen ( `-`) and the dot (`.`) are interpreted literally by string-based paths.
 
-> **Warning** A wildcard in the middle of the route is only supported by express.
+> warning **Warning** A wildcard in the middle of the route is only supported by express.
 
 #### Status code
 

--- a/content/controllers.md
+++ b/content/controllers.md
@@ -202,6 +202,8 @@ findAll() {
 
 The `'ab*cd'` route path will match `abcd`, `ab_cd`, `abecd`, and so on. The characters `?`, `+`, `*`, and `()` may be used in a route path, and are subsets of their regular expression counterparts. The hyphen ( `-`) and the dot (`.`) are interpreted literally by string-based paths.
 
+> **Warning** A wildcard in the middle of the route is only supported by express.
+
 #### Status code
 
 As mentioned, the response **status code** is always **200** by default, except for POST requests which are **201**. We can easily change this behavior by adding the `@HttpCode(...)` decorator at a handler level.


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [X] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The original issue describing that was opened in the main nest repository, after discussing it was closed and I was oriented to address this in here.

Issue Number: [Wildcard must be the last character in the route](https://github.com/nestjs/nest/issues/11543)
Try it out on: [Minimum reproducible repository](https://github.com/pedroluiznogueira/nestjs-minimum-reproducible-route-wildcards)

A detailed explanation of the behavior is:

While following the documentation on section [Controllers - Route Wildcards](https://docs.nestjs.com/controllers#route-wildcards).

The provided example does not work as expected, when using `fastify` as the underlying http adapter.

```typescript
@Get('ab*cd')
findAll() {
  return 'This route uses a wildcard';
}
```

When running the application I get:

```
throw new Error('Wildcard must be the last character in the route')
              ^
Error: Wildcard must be the last character in the route
A wildcard at the end works just fine
```

```typescript
@Get('abcd*')
findAll() {
  return 'This route uses a wildcard';
}
```

## What is the new behavior?

Warn readers that the example code only works for express.

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information


