### PR TITLE
feat(express): add docs for proposed multer.none support

### DIFF
--- a/content/techniques/file-upload.md
+++ b/content/techniques/file-upload.md
@@ -236,6 +236,18 @@ uploadFile(files) {
 }
 ```
 
+#### No files
+
+To accept `multipart/form-data` but not allow any files to be uploaded, use the `NoFilesInterceptor`. This sets multipart data as attributes on the request body. Any files sent with the request will throw a `BadRequestException`.
+
+```typescript
+@Post('upload')
+@UseInterceptors(NoFilesInterceptor())
+handleMultiPartData(@Body() body) {
+  console.log(body)
+}
+```
+
 #### Default options
 
 You can specify multer options in the file interceptors as described above. To set default options, you can call the static `register()` method when you import the `MulterModule`, passing in supported options. You can use all options listed [here](https://github.com/expressjs/multer#multeropts).


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

I am implementing a feature that uses the [Sendgrid Inbound Parse API](https://docs.sendgrid.com/for-developers/parsing-email/setting-up-the-inbound-parse-webhook#raw-parameters). This sends the data encoded as multipart/form-data however the payload includes no files. I believe all data are sent as strings/text.

I reached for the Nest.js MulterModule but it currently does not support [multer's none option](https://github.com/expressjs/multer#none). multer.none parses only the text fields in the body and raises an exception if any files are submitted.


## What is the new behavior?

There is a PR on the main nest project that introduces a new NoFilesInterceptor as part of the MulterModule. This PR is the documentation counterpart to this proposed addition. https://github.com/nestjs/nest/pull/11667


## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
