### PR TITLE
docs(providers-services): Fix create method parameter to use CreateCatDto for TypeScript

### DIFF
--- a/content/components.md
+++ b/content/components.md
@@ -15,14 +15,15 @@ Let's start by creating a simple `CatsService`. This service will be responsible
 ```typescript
 @@filename(cats.service)
 import { Injectable } from '@nestjs/common';
+import { CreateCatDto } from './dto/create-cat.dto';
 import { Cat } from './interfaces/cat.interface';
 
 @Injectable()
 export class CatsService {
   private readonly cats: Cat[] = [];
 
-  create(cat: Cat) {
-    this.cats.push(cat);
+  create(createCatDto: CreateCatDto) {
+    this.cats.push({...createCatDto});
   }
 
   findAll(): Cat[] {


### PR DESCRIPTION
Fix the parameter of the create method to use CreateCatDto instead of User, as this method is invoked in the controller using CreateCatDto.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The parameter of the create method of service cats.service.ts uses User instead of CreateUserDto, this method is invoked in the controller cats.controller.ts and use CreateCatDto as the parameter.

Issue Number: N/A


## What is the new behavior?
The parameter of the create method of service cats.service.ts uses CreateCatDto instead of User, as this method is invoked in the controller cats.controller.ts using CreateCatDto.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
