### PR TITLE
Added the compiler options to be added in nest-cli.json file

### DIFF
--- a/content/openapi/introduction.md
+++ b/content/openapi/introduction.md
@@ -9,6 +9,22 @@ To begin using it, we first install the required dependency.
 ```bash
 $ npm install --save @nestjs/swagger
 ```
+Include the plugin `@nestjs/swagger` in the compiler option in the `nest-cli.json` file:
+```json
+{
+  "compilerOptions": {
+    "plugins": [
+      {
+        "name": "@nestjs/swagger",
+        "options": {
+          "introspectComments": true
+        }
+      }
+    ]
+  }
+}
+```
+
 
 #### Bootstrap
 


### PR DESCRIPTION
Schema's do not load if the swagger plugin is not added inside the compiler option. Added the same description and sample code taken from the example repo 

https://github.com/nestjs/nest/blob/master/sample/11-swagger/nest-cli.json

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:

## What is the current behavior?
Current documentation does not mention that the swagger plugin is required in the compiler options. If this is not added, the schemas generated will be empty if not added with @ApiProperty decorator. 

Issue Number: N/A

## What is the new behavior?
Added the instruction and sample compiler options taken from the example repository

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information
