### PR TITLE
docs(migration): Adding a section for upgrading packages

### DIFF
--- a/content/migration.md
+++ b/content/migration.md
@@ -4,7 +4,7 @@ This article provides a set of guidelines for migrating from Nest version 9 to v
 To learn more about the new features we've added in v10, check out this (_ARTICLE AVAILABLE SOON_).
 There were some very minor breaking changes that shouldn't affect most users - you can find the full list of them [here](https://github.com/nestjs/nest/releases/tag/v10.0.0).
 
-### Upgrading Packages
+### Upgrading packages
 
 While you can upgrade your packages manually, we recommend using [ncu (npm check updates)](https://npmjs.com/package/npm-check-updates).
 

--- a/content/migration.md
+++ b/content/migration.md
@@ -6,7 +6,7 @@ There were some very minor breaking changes that shouldn't affect most users - y
 
 ### Upgrading Packages
 
-The Nest CLI does not include an `update` command. While you can upgrade your packages manually, we recommend using [ncu (npm check updates)](https://npmjs.com/package/npm-check-updates).
+While you can upgrade your packages manually, we recommend using [ncu (npm check updates)](https://npmjs.com/package/npm-check-updates).
 
 ### Cache module
 

--- a/content/migration.md
+++ b/content/migration.md
@@ -4,6 +4,10 @@ This article provides a set of guidelines for migrating from Nest version 9 to v
 To learn more about the new features we've added in v10, check out this (_ARTICLE AVAILABLE SOON_).
 There were some very minor breaking changes that shouldn't affect most users - you can find the full list of them [here](https://github.com/nestjs/nest/releases/tag/v10.0.0).
 
+### Upgrading Packages
+
+The Nest CLI does not include an `update` command. While you can upgrade your packages manually, we recommend using [ncu (npm check updates)](https://npmjs.com/package/npm-check-updates).
+
 ### Cache module
 
 The `CacheModule` has been removed from the `@nestjs/common` package and is now available as a standalone package - `@nestjs/cache-manager`. This change was made to avoid unnecessary dependencies in the `@nestjs/common` package. You can learn more about the `@nestjs/cache-manager` package [here](https://docs.nestjs.com/techniques/caching).


### PR DESCRIPTION
Adding a note that NestJS doesn't include an `update` command and to use npm-check-updates per Member recommendation.

The reason why I'd like to add this is I was recently looking to upgrading from V9 to V10 and figured the CLI included an `update` command but it was [removed](https://github.com/nestjs/nest-cli/pull/1699). Looking into this more it was recommended by @kamilmysliwiec to [use npm-check-updates](https://github.com/nestjs/nest-cli/issues/321). I figured others would benefit from this like I did by adding it to the Migration guide.

If no one thinks this is useful like I did, we can close this.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:

## What is the current behavior?

There is no current `update` command and it's recommended to use `ncu`.

## What is the new behavior?

A note that Nest CLI does not include an `update` command (yet) and to manually upgrade packages or use `ncu`.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information

N/A
