### PR TITLE
docs(mqtt): description on how to set qos on subscriptions

### DIFF
--- a/content/microservices/mqtt.md
+++ b/content/microservices/mqtt.md
@@ -118,7 +118,7 @@ getTemperature(context) {
 
 #### Quality of Service (QoS)
 
-Any subscription created with the `@MessagePattern` decorator will subscribe with QoS 0. If a higher QoS is required, it can be set globally using the `subscribeOptions` block when establishing the connection as follows:
+Any subscription created with `@MessagePattern` or `@EventPattern` decorators will subscribe with QoS 0. If a higher QoS is required, it can be set globally using the `subscribeOptions` block when establishing the connection as follows:
 ```typescript
 @@filename(main)
 const app = await NestFactory.createMicroservice<MicroserviceOptions>(AppModule, {

--- a/content/microservices/mqtt.md
+++ b/content/microservices/mqtt.md
@@ -116,6 +116,33 @@ getTemperature(context) {
 }
 ```
 
+#### Quality of Service (QoS)
+
+Any subscription created with the `@MessagePattern` decorator will subscribe with QoS 0. If a higher QoS is required, it can be set globally using the `subscribeOptions` block when establishing the connection as follows:
+```typescript
+@@filename(main)
+const app = await NestFactory.createMicroservice<MicroserviceOptions>(AppModule, {
+  transport: Transport.MQTT,
+  options: {
+    url: 'mqtt://localhost:1883',
+    subscribeOptions: {
+      qos: 2
+    },
+  },
+});
+@@switch
+const app = await NestFactory.createMicroservice(AppModule, {
+  transport: Transport.MQTT,
+  options: {
+    url: 'mqtt://localhost:1883',
+    subscribeOptions: {
+      qos: 2
+    },
+  },
+});
+```
+If a topic specific QoS is required, consider creating a [Custom transporter](https://docs.nestjs.com/microservices/custom-transport).
+
 #### Record builders
 
 To configure message options (adjust the QoS level, set the Retain or DUP flags, or add additional properties to the payload), you can use the `MqttRecordBuilder` class. For example, to set `QoS` to `2` use the `setQoS` method, as follows:


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [X ] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [X ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

The current state of the documentation refers to creating a custom transporter to set a QoS other than 0 on subscriptions created with the `@MessagePattern` decorator. The option added in the PR has not been documented, yet.