### PR TITLE
Update exception-filters.md

### DIFF
--- a/content/exception-filters.md
+++ b/content/exception-filters.md
@@ -392,7 +392,7 @@ The first method is to inject the `HttpAdapter` reference when instantiating the
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
 
-  const { httpAdapter } = app.get(HttpAdapterHost);
+  const httpAdapter = app.get(HttpAdapterHost);
   app.useGlobalFilters(new AllExceptionsFilter(httpAdapter));
 
   await app.listen(3000);


### PR DESCRIPTION
HttpAdapterHost class is needed, not the httpAdapter in this class.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
In the code snippet, by mistake, the parameter `httpAdapter` has been taken from the class `HttpAdapterHost`, but what is injected in the `AllExceptionsFilter` class, is the `HttpAdapterHost`.

Issue Number: N/A


## What is the new behavior?
The correct injection to the exception filter class.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
