### PR TITLE
docs(@nestjs/swagger): add description on how to expose swagger json file

### DIFF
--- a/content/openapi/introduction.md
+++ b/content/openapi/introduction.md
@@ -61,6 +61,14 @@ While the application is running, open your browser and navigate to `http://loca
 As you can see, the `SwaggerModule` automatically reflects all of your endpoints.
 
 > info **Hint** To generate and download a Swagger JSON file, navigate to `http://localhost:3000/api-json` (assuming that your Swagger documentation is available under `http://localhost:3000/api`).
+> It is also possible to expose it on a route of your choice using only the setup method from `@nestjs/swagger`, like this:
+> ```typescript
+> SwaggerModule.setup('swagger', app, document, {
+>   jsonDocumentUrl: 'swagger/json',
+> });
+> ```
+> Which would expose it at `http://localhost:3000/swagger/json`
+
 
 > warning **Warning** When using `fastify` and `helmet`, there may be a problem with [CSP](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP), to solve this collision, configure the CSP as shown below:
 >


### PR DESCRIPTION
Docs weren't complete on exposing json spec with using only @nestjs/swagger

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?

This documentation change adds an option that wasn't documented before for exposing json spec file with swagger. The documentation made it seem like it's only possible with other extensions however there is an option with just `@nestjs/swagger` to expose the document. 


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information


I've been looking on how to do this for a while and couldn't find a working solution anywhere so I think this would be useful.

Cheers 
