### PR TITLE
docs(caching): alternative for cache-manager-redis-store package

### DIFF
--- a/content/techniques/caching.md
+++ b/content/techniques/caching.md
@@ -249,6 +249,7 @@ export class AppModule {}
 
 > warning**Warning** `cache-manager-redis-store` does not support redis v4. In order for the `ClientOpts` interface to exist and work correctly you need to install the
 > latest `redis` 3.x.x major release. See this [issue](https://github.com/dabroek/node-cache-manager-redis-store/issues/40) to track the progress of this upgrade.
+> Using [cache-manager-redis-yet](https://www.npmjs.com/package/cache-manager-redis-yet) could be a better solution for the latest version of `redis` and `cache-manager`.
 
 #### Async configuration
 


### PR DESCRIPTION
Using cache-manager-redis-yet instead of cache-manager-redis-store could minimize the issues with the latest versions of redis and cache-manager

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
