### PR TITLE
docs(caching): add note about of cache-manager

### DIFF
--- a/content/techniques/caching.md
+++ b/content/techniques/caching.md
@@ -17,6 +17,8 @@ $ npm install @nestjs/cache-manager cache-manager
 
 #### In-memory cache
 
+> warning **Note** `In-memory cache` can only store values of types that are supported by [the structured clone algorithm](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm#javascript_types).
+
 Nest provides a unified API for various cache storage providers. The built-in one is an in-memory data store. However, you can easily switch to a more comprehensive solution, like Redis.
 
 In order to enable caching, import the `CacheModule` and call its `register()` method.


### PR DESCRIPTION
Since cache manager's In-memory store uses `lodash.clonedeep` internally, it can only store values of types supported by 'lodash'.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
- Property descriptors, setters, getters, and similar metadata-like features are not duplicated. For example, if an object is marked readonly with a [property descriptor](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyDescriptor), it will be read/write in the duplicate, since that's the default. [mdn-Structured_clone_algorithm](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm)

```ts
import { ObjectId } from "bson"; // import package to test invalid type which uses 
import { CACHE_MANAGER } from '@nestjs/cache-manager';
import { Cache } from 'cache-manager';

export class ExampleService {
  constructor (
    @Inject(CACHE_MANAGER)
    private cacheManagerService: Cache;
  ) {}

  async generatesNodeInternalError() {
    const objectId = new ObjectId("some id..."); // has OwnPropertyDescriptors
    const map = new Map();
    map.set('mapKey', objectId);  
    
    const cacheKey = 'cacheKey';

    await this.cacheManagerService.set(cacheKey, map);
    // Since `console.log` uses custom inspect function of ObjectId,
    // which requires properties in original object, an exception will occur below.
    console.log(await this.cacheManagerService.get(cacheKey));
  }
}

```

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
1. `@nestjs/cache-module` is not passing `isCachable` to `node-cache-manager`. [link](https://github.com/nestjs/cache-manager/blob/master/lib/cache.providers.ts)
2. `node-cache-manager` clones value by `lodash.clonedeep`. [link](https://github.com/node-cache-manager/node-cache-manager/blob/master/src/stores/memory.ts#L6)
3. Then call `set` of lru-cache. After here, cached value's PropertyDescriptors are omitted. [link](https://github.com/node-cache-manager/node-cache-manager/blob/master/src/stores/memory.ts)