### PR TITLE
docs(techniques): fix wrong reference to `SchedulerRegistry` class & fix import statement for `cookie-parser`

### DIFF
--- a/content/techniques/cookies.md
+++ b/content/techniques/cookies.md
@@ -14,7 +14,7 @@ $ npm i -D @types/cookie-parser
 Once the installation is complete, apply the `cookie-parser` middleware as global middleware (for example, in your `main.ts` file).
 
 ```typescript
-import cookieParser from 'cookie-parser';
+import * as cookieParser from 'cookie-parser';
 // somewhere in your initialization file
 app.use(cookieParser());
 ```

--- a/content/techniques/task-scheduling.md
+++ b/content/techniques/task-scheduling.md
@@ -225,7 +225,7 @@ The `@nestjs/schedule` module provides a dynamic API that enables managing decla
 Obtain a reference to a `CronJob` instance by name from anywhere in your code using the `SchedulerRegistry` API. First, inject `SchedulerRegistry` using standard constructor injection:
 
 ```typescript
-constructor(private schedulerRegistry: SchedulerRegistry) {}
+constructor(private readonly schedulerRegistry: SchedulerRegistry) {}
 ```
 
 > info **Hint** Import the `SchedulerRegistry` from the `@nestjs/schedule` package.
@@ -258,7 +258,7 @@ The `getCronJob()` method returns the named cron job. The returned `CronJob` obj
 
 > info **Hint** Use `toDate()` on `moment` objects to render them in human readable form.
 
-**Create** a new cron job dynamically using the `SchedulerRegistry.addCronJob()` method, as follows:
+**Create** a new cron job dynamically using the `SchedulerRegistry#addCronJob` method, as follows:
 
 ```typescript
 addCronJob(name: string, seconds: string) {
@@ -275,11 +275,11 @@ addCronJob(name: string, seconds: string) {
 }
 ```
 
-In this code, we use the `CronJob` object from the `cron` package to create the cron job. The `CronJob` constructor takes a cron pattern (just like the `@Cron()` <a href="techniques/task-scheduling#declarative-cron-jobs">decorator</a>) as its first argument, and a callback to be executed when the cron timer fires as its second argument. The `SchedulerRegistry.addCronJob()` method takes two arguments: a name for the `CronJob`, and the `CronJob` object itself.
+In this code, we use the `CronJob` object from the `cron` package to create the cron job. The `CronJob` constructor takes a cron pattern (just like the `@Cron()` <a href="techniques/task-scheduling#declarative-cron-jobs">decorator</a>) as its first argument, and a callback to be executed when the cron timer fires as its second argument. The `SchedulerRegistry#addCronJob` method takes two arguments: a name for the `CronJob`, and the `CronJob` object itself.
 
 > warning **Warning** Remember to inject the `SchedulerRegistry` before accessing it. Import `CronJob` from the `cron` package.
 
-**Delete** a named cron job using the `SchedulerRegistry.deleteCronJob()` method, as follows:
+**Delete** a named cron job using the `SchedulerRegistry#deleteCronJob` method, as follows:
 
 ```typescript
 deleteCron(name: string) {
@@ -288,7 +288,7 @@ deleteCron(name: string) {
 }
 ```
 
-**List** all cron jobs using the `SchedulerRegistry.getCronJobs()` method as follows:
+**List** all cron jobs using the `SchedulerRegistry#getCronJobs` method as follows:
 
 ```typescript
 getCrons() {
@@ -309,7 +309,7 @@ The `getCronJobs()` method returns a `map`. In this code, we iterate over the ma
 
 #### Dynamic intervals
 
-Obtain a reference to an interval with the `SchedulerRegistry.getInterval()` method. As above, inject `SchedulerRegistry` using standard constructor injection:
+Obtain a reference to an interval with the `SchedulerRegistry#getInterval` method. As above, inject `SchedulerRegistry` using standard constructor injection:
 
 ```typescript
 constructor(private schedulerRegistry: SchedulerRegistry) {}
@@ -322,7 +322,7 @@ const interval = this.schedulerRegistry.getInterval('notifications');
 clearInterval(interval);
 ```
 
-**Create** a new interval dynamically using the `SchedulerRegistry.addInterval()` method, as follows:
+**Create** a new interval dynamically using the `SchedulerRegistry#addInterval` method, as follows:
 
 ```typescript
 addInterval(name: string, milliseconds: number) {
@@ -335,10 +335,10 @@ addInterval(name: string, milliseconds: number) {
 }
 ```
 
-In this code, we create a standard JavaScript interval, then pass it to the `ScheduleRegistry.addInterval()` method.
+In this code, we create a standard JavaScript interval, then pass it to the `SchedulerRegistry#addInterval` method.
 That method takes two arguments: a name for the interval, and the interval itself.
 
-**Delete** a named interval using the `SchedulerRegistry.deleteInterval()` method, as follows:
+**Delete** a named interval using the `SchedulerRegistry#deleteInterval` method, as follows:
 
 ```typescript
 deleteInterval(name: string) {
@@ -347,7 +347,7 @@ deleteInterval(name: string) {
 }
 ```
 
-**List** all intervals using the `SchedulerRegistry.getIntervals()` method as follows:
+**List** all intervals using the `SchedulerRegistry#getIntervals` method as follows:
 
 ```typescript
 getIntervals() {
@@ -358,10 +358,10 @@ getIntervals() {
 
 #### Dynamic timeouts
 
-Obtain a reference to a timeout with the `SchedulerRegistry.getTimeout()` method. As above, inject `SchedulerRegistry` using standard constructor injection:
+Obtain a reference to a timeout with the `SchedulerRegistry#getTimeout` method. As above, inject `SchedulerRegistry` using standard constructor injection:
 
 ```typescript
-constructor(private schedulerRegistry: SchedulerRegistry) {}
+constructor(private readonly schedulerRegistry: SchedulerRegistry) {}
 ```
 
 And use it as follows:
@@ -371,7 +371,7 @@ const timeout = this.schedulerRegistry.getTimeout('notifications');
 clearTimeout(timeout);
 ```
 
-**Create** a new timeout dynamically using the `SchedulerRegistry.addTimeout()` method, as follows:
+**Create** a new timeout dynamically using the `SchedulerRegistry#addTimeout` method, as follows:
 
 ```typescript
 addTimeout(name: string, milliseconds: number) {
@@ -384,10 +384,10 @@ addTimeout(name: string, milliseconds: number) {
 }
 ```
 
-In this code, we create a standard JavaScript timeout, then pass it to the `ScheduleRegistry.addTimeout()` method.
+In this code, we create a standard JavaScript timeout, then pass it to the `SchedulerRegistry#addTimeout` method.
 That method takes two arguments: a name for the timeout, and the timeout itself.
 
-**Delete** a named timeout using the `SchedulerRegistry.deleteTimeout()` method, as follows:
+**Delete** a named timeout using the `SchedulerRegistry#deleteTimeout` method, as follows:
 
 ```typescript
 deleteTimeout(name: string) {
@@ -396,7 +396,7 @@ deleteTimeout(name: string) {
 }
 ```
 
-**List** all timeouts using the `SchedulerRegistry.getTimeouts()` method as follows:
+**List** all timeouts using the `SchedulerRegistry#getTimeouts` method as follows:
 
 ```typescript
 getTimeouts() {

--- a/content/techniques/task-scheduling.md
+++ b/content/techniques/task-scheduling.md
@@ -225,7 +225,7 @@ The `@nestjs/schedule` module provides a dynamic API that enables managing decla
 Obtain a reference to a `CronJob` instance by name from anywhere in your code using the `SchedulerRegistry` API. First, inject `SchedulerRegistry` using standard constructor injection:
 
 ```typescript
-constructor(private readonly schedulerRegistry: SchedulerRegistry) {}
+constructor(private schedulerRegistry: SchedulerRegistry) {}
 ```
 
 > info **Hint** Import the `SchedulerRegistry` from the `@nestjs/schedule` package.


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

- referencing `ScheduleRegistry` instead of `SchedulerRegistry` in one place.
- using default import instead of named one for `cookie-parser`, which is not supported unless you have `esModuleInterop: true`

## What is the new behavior?

- fix the wrong reference & align code snippets a bit more with others doc pages
- change the import statement for `cookie-parser` to follow the defaults of https://github.com/nestjs/typescript-starter `tsconfig.json`

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
