### PR TITLE
docs(sequelize): fix wrong file name and relation name in sequelize

### DIFF
--- a/content/techniques/sql.md
+++ b/content/techniques/sql.md
@@ -439,12 +439,7 @@ async createMany(users: User[]) {
 With TypeORM [subscribers](https://typeorm.io/#/listeners-and-subscribers/what-is-a-subscriber), you can listen to specific entity events.
 
 ```typescript
-import {
-  DataSource,
-  EntitySubscriberInterface,
-  EventSubscriber,
-  InsertEvent,
-} from 'typeorm';
+import { DataSource, EntitySubscriberInterface, EventSubscriber, InsertEvent } from 'typeorm';
 import { User } from './user.entity';
 
 @EventSubscriber()
@@ -543,10 +538,7 @@ At this point, you have `User` and `Album` entities registered with their own da
 
 ```typescript
 @Module({
-  imports: [
-    TypeOrmModule.forFeature([User]),
-    TypeOrmModule.forFeature([Album], 'albumsConnection'),
-  ],
+  imports: [TypeOrmModule.forFeature([User]), TypeOrmModule.forFeature([Album], 'albumsConnection')],
 })
 export class AppModule {}
 ```
@@ -992,10 +984,10 @@ There are three types of relations:
   </tr>
 </table>
 
-To define relations in entities, use the corresponding **decorators**. For example, to define that each `User` can have multiple photos, use the `@HasMany()` decorator.
+To define relations in models, use the corresponding **decorators**. For example, to define that each `User` can have multiple photos, use the `@HasMany()` decorator.
 
 ```typescript
-@@filename(user.entity)
+@@filename(user.model)
 import { Column, Model, Table, HasMany } from 'sequelize-typescript';
 import { Photo } from '../photos/photo.model';
 
@@ -1133,10 +1125,7 @@ At this point, you have `User` and `Album` models registered with their own conn
 
 ```typescript
 @Module({
-  imports: [
-    SequelizeModule.forFeature([User]),
-    SequelizeModule.forFeature([Album], 'albumsConnection'),
-  ],
+  imports: [SequelizeModule.forFeature([User]), SequelizeModule.forFeature([Album], 'albumsConnection')],
 })
 export class AppModule {}
 ```


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Replaced file name from user.entity to user.model in sequelize Integration section.
Replaced entity text to model text in sequelize Integration section to keep persistence. 

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
