### PR TITLE
docs(sequelize): fix wrong file name and relation name in sequelize

### DIFF
--- a/content/techniques/sql.md
+++ b/content/techniques/sql.md
@@ -992,10 +992,10 @@ There are three types of relations:
   </tr>
 </table>
 
-To define relations in entities, use the corresponding **decorators**. For example, to define that each `User` can have multiple photos, use the `@HasMany()` decorator.
+To define relations in models, use the corresponding **decorators**. For example, to define that each `User` can have multiple photos, use the `@HasMany()` decorator.
 
 ```typescript
-@@filename(user.entity)
+@@filename(user.model)
 import { Column, Model, Table, HasMany } from 'sequelize-typescript';
 import { Photo } from '../photos/photo.model';
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
Change file name in code snippet from entity to model to persist consistency in file names in Relations section in In Sequelize Integration
Change `entities` word to `models` in Relations section in In Sequelize Integration

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
File name in Relations in Sequelize Integration is `user.entity` instead of `user.model` which is not persistent naming since it was introduced as `user.model` above
 
When introducing Relations in Sequelize Integration the word `entity` is used instead of `model` which is confusing for those who read the TypeORM integration. 

Issue Number: N/A


## What is the new behavior?
File naming is persistent  where in sequelize `user.model` is used instead of `user.entity`
When introducing Relations in Sequelize Integration the word `model` is used instead of `entity`

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
