### PR TITLE
fix: remove outdated section about shutdown hooks with prisma

### DIFF
--- a/content/recipes/prisma.md
+++ b/content/recipes/prisma.md
@@ -248,7 +248,7 @@ When setting up your NestJS application, you'll want to abstract away the Prisma
 Inside the `src` directory, create a new file called `prisma.service.ts` and add the following code to it:
 
 ```typescript
-import { INestApplication, Injectable, OnModuleInit } from '@nestjs/common';
+import { Injectable, OnModuleInit } from '@nestjs/common';
 import { PrismaClient } from '@prisma/client';
 
 @Injectable()
@@ -256,16 +256,10 @@ export class PrismaService extends PrismaClient implements OnModuleInit {
   async onModuleInit() {
     await this.$connect();
   }
-
-  async enableShutdownHooks(app: INestApplication) {
-    this.$on('beforeExit', async () => {
-      await app.close();
-    });
-  }
 }
 ```
 
-> info **Note** The `onModuleInit` is optional — if you leave it out, Prisma will connect lazily on its first call to the database. We don't bother with `onModuleDestroy`, since Prisma has its own shutdown hooks where it will destroy the connection. For more info on `enableShutdownHooks`, please see [Issues with `enableShutdownHooks`](recipes/prisma#issues-with-enableshutdownhooks)
+> info **Note** The `onModuleInit` is optional — if you leave it out, Prisma will connect lazily on its first call to the database.
 
 Next, you can write services that you can use to make database calls for the `User` and `Post` models from your Prisma schema.
 
@@ -517,26 +511,6 @@ This controller implements the following routes:
 ###### `DELETE`
 
 - `/post/:id`: Delete a post by its `id`
-
-#### Issues with `enableShutdownHooks`
-
-Prisma interferes with NestJS `enableShutdownHooks`. Prisma listens for shutdown signals and will call `process.exit()` before your application shutdown hooks fire. To deal with this, you would need to add a listener for Prisma `beforeExit` event.
-
-```typescript
-// main.ts
-...
-import { PrismaService } from './services/prisma/prisma.service';
-...
-async function bootstrap() {
-  ...
-  const prismaService = app.get(PrismaService);
-  await prismaService.enableShutdownHooks(app)
-  ...
-}
-bootstrap()
-```
-
-You can [read more](https://github.com/prisma/prisma/issues/2917#issuecomment-708340112) about Prisma handling of shutdown signal, and `beforeExit` event.
 
 #### Summary
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Current Prisma guide needs to be updated as custom `enableShutdownHooks` method has not been necessary since Prisma 3, and now the example doesn't compile since Prisma 5.

This leads to confusion for users: https://github.com/prisma/prisma/issues/20171
Release notes: https://github.com/prisma/prisma/releases/tag/5.0.0


## What is the new behavior?

The outdated section is removed.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

This section has not been relevant since the introduction of the library engine as the default in Prisma 3. Now, in Prisma 5, the code example does not compile anymore since the `beforeExit` event was removed from Prisma Client (except when generating the client with the binary engine type, which most users should not do unless they have good reasons).

Note that even in Prisma 2 or when switching to the binary engine, using `beforeExit` would've only been necessary to be able to run database queries in lifecycle hooks, and wouldn't be necessary otherwise. The justification for using `beforeExit` that was present in this section was not fully accurate because while the bug it refers to (https://github.com/prisma/prisma/issues/3773) was fixed together with the introduction of `beforeExit` hook (which I believe led to the confusion), those were not strictly related changes.