### PR TITLE
refactor(): update redirect guard

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -217,7 +217,7 @@ const routes: Routes = [
       preloadingStrategy: PreloadAllModules,
     }),
   ],
-  providers: [RedirectGuard],
+  providers: [],
   exports: [RouterModule],
 })
 export class AppRoutingModule {}

--- a/src/app/shared/guards/redirect.guard.ts
+++ b/src/app/shared/guards/redirect.guard.ts
@@ -1,17 +1,13 @@
-import { Injectable } from '@angular/core';
 import {
   ActivatedRouteSnapshot,
-  CanActivate,
+  CanActivateFn,
   RouterStateSnapshot,
 } from '@angular/router';
 
-@Injectable()
-export class RedirectGuard implements CanActivate {
-  canActivate(
-    route: ActivatedRouteSnapshot,
-    state: RouterStateSnapshot,
-  ): boolean {
-    window.location.href = route.data['externalUrl'];
-    return true;
-  }
-}
+export const RedirectGuard: CanActivateFn = (
+  route: ActivatedRouteSnapshot,
+  state: RouterStateSnapshot,
+) => {
+  window.location.href = route.data['externalUrl'];
+  return true;
+};


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Docs
- [x] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
Proposal:

- Refactor the guard `redirect`, because as of Angular version 15.x interface `CanActivate` has been deprecated (see screenshot),  in the future it will be removed and they have turned the guard configuration from class to function(arrow function). 

<img width="1080" alt="screen-guard" src="https://github.com/nestjs/docs.nestjs.com/assets/11542387/b3518b05-e1e9-4867-bba9-0414cdcbc682">

## Does this PR introduce a breaking change?
- [x] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

For others information see here: https://angular.io/guide/deprecations#router-class-and-injectiontoken-guards-and-resolvers