### PR TITLE
docs: add warning for webpack

### DIFF
--- a/content/faq/serverless.md
+++ b/content/faq/serverless.md
@@ -106,6 +106,8 @@ module.exports = (options, webpack) => {
 
 > info **Hint** To instruct Nest CLI to use this configuration, create a new `webpack.config.js` file in the root directory of your project.
 
+> warning **Warning** It is not recommended to bundle `node_modules` for Node.js applications. This is for demonstration purposes only. Check out this [comment](https://github.com/nestjs/nest/issues/1706#issuecomment-579248915) for more information.
+
 With this configuration, we received the following results:
 
 |                                      |                  |


### PR DESCRIPTION
Bundling node_modules with webpack can cause issues.

fix #2806

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

- [x] Docs


## What is the current behavior?
The serverless FAQ page mentions using webpack to bundle node_modules.

Issue Number: 2806


## What is the new behavior?
Warn against bundling node_modules with webpack as it can cause issues.

## Does this PR introduce a breaking change?
- [x] No