### PR TITLE
docs(caching.md): update redis example

### DIFF
--- a/content/techniques/caching.md
+++ b/content/techniques/caching.md
@@ -13,7 +13,6 @@ $ npm install @nestjs/cache-manager cache-manager
 > warning **Warning** `cache-manager` version 4 uses seconds for `TTL (Time-To-Live)`. The current version of `cache-manager` (v5) has switched to using milliseconds instead. NestJS doesn't convert the value, and simply forwards the ttl you provide to the library. In other words:
 > * If using `cache-manager` v4, provide ttl in seconds
 > * If using `cache-manager` v5, provide ttl in milliseconds
-> * Documentation is referring to seconds, since NestJS was released targeting version 4 of cache-manager.
 
 #### In-memory cache
 
@@ -223,11 +222,11 @@ class HttpCacheInterceptor extends CacheInterceptor {
 
 #### Different stores
 
-This service takes advantage of [cache-manager](https://github.com/node-cache-manager/node-cache-manager) under the hood. The `cache-manager` package supports a wide-range of useful stores, for example, [Redis store](https://github.com/dabroek/node-cache-manager-redis-store). A full list of supported stores is available [here](https://github.com/node-cache-manager/node-cache-manager#store-engines). To set up the Redis store, simply pass the package together with corresponding options to the `register()` method.
+This service takes advantage of [cache-manager](https://github.com/node-cache-manager/node-cache-manager) under the hood. The `cache-manager` package supports a wide-range of useful stores, for example, [Redis store](https://github.com/node-cache-manager/node-cache-manager-redis-yet). A full list of supported stores is available [here](https://github.com/node-cache-manager/node-cache-manager#store-engines). To set up the Redis store, simply pass the package together with corresponding options to the `register()` method.
 
 ```typescript
 import type { RedisClientOptions } from 'redis';
-import * as redisStore from 'cache-manager-redis-store';
+import { redisStore } from 'cache-manager-redis-yet';
 import { Module } from '@nestjs/common';
 import { CacheModule } from '@nestjs/cache-manager';
 import { AppController } from './app.controller';
@@ -236,19 +235,17 @@ import { AppController } from './app.controller';
   imports: [
     CacheModule.register<RedisClientOptions>({
       store: redisStore,
-
-      // Store-specific configuration:
-      host: 'localhost',
-      port: 6379,
+      socket: {
+        // Store-specific configuration:
+        host: 'localhost',
+        port: 6379,
+      },
     }),
   ],
   controllers: [AppController],
 })
 export class AppModule {}
 ```
-
-> warning**Warning** `cache-manager-redis-store` does not support redis v4. In order for the `ClientOpts` interface to exist and work correctly you need to install the
-> latest `redis` 3.x.x major release. See this [issue](https://github.com/dabroek/node-cache-manager-redis-store/issues/40) to track the progress of this upgrade.
 
 #### Async configuration
 


### PR DESCRIPTION
replace legacy https://github.com/dabroek/node-cache-manager-redis-store with forked https://github.com/node-cache-manager/node-cache-manager-redis-yet

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
The original redis example of caching does not work with the latest version of cache manager. It looks like the package maintainers have abandoned the project [node-cache-manager-redis-store](https://github.com/dabroek/node-cache-manager-redis-store). 

Issue Number: N/A


## What is the new behavior?
A new redis example is introduced that makes use of the forked repo [node-manager-redis-yet](https://github.com/node-cache-manager/node-cache-manager-redis-yet).


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
