### PR TITLE
docs(spelling): caching ttl is milliseconds

### DIFF
--- a/content/techniques/caching.md
+++ b/content/techniques/caching.md
@@ -128,7 +128,7 @@ All cached data has its own expiration time ([TTL](https://en.wikipedia.org/wiki
 
 ```typescript
 CacheModule.register({
-  ttl: 5, // seconds
+  ttl: 2000, // milliseconds
   max: 10, // maximum number of items in cache
 });
 ```


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [✅] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [✅ ] Docs
- [ ] Other... Please describe:


## What is the current behavior?
N/A

Issue Number: N/A


## What is the new behavior?
N/A

## Does this PR introduce a breaking change?
- [ ] Yes
- [✅] No

## Other information
In the caching module document, there was a comment saying "seconds" for  **ttl** property but it is actually milliseconds. I fixed it. I am very proud of myself that I found something to fix in this framework.

