### PR TITLE
docs(spelling): caching ttl is milliseconds

### DIFF
--- a/content/techniques/caching.md
+++ b/content/techniques/caching.md
@@ -128,7 +128,7 @@ All cached data has its own expiration time ([TTL](https://en.wikipedia.org/wiki
 
 ```typescript
 CacheModule.register({
-  ttl: 5, // seconds
+  ttl: 2000, // milliseconds
   max: 10, // maximum number of items in cache
 });
 ```


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
The cache ttl comment says it is seconds but actually it is milliseconds.

Issue Number: N/A


## What is the new behavior?
Corrected the second to milliseconds.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


## Other information
N/A