### PR TITLE
Updated cookies.md with register signature

### DIFF
--- a/content/techniques/cookies.md
+++ b/content/techniques/cookies.md
@@ -71,7 +71,7 @@ const app = await NestFactory.create<NestFastifyApplication>(
   AppModule,
   new FastifyAdapter(),
 );
-await app.register(fastifyCookie, {
+await app.register(() => fastifyCookie, {
   secret: 'my-secret', // for cookies signature
 });
 ```


### PR DESCRIPTION
at 9.0.4 we should return a callback, or we've got a ts error:

TS2345: Argument of type 'typeof fastifyCookie' is not assignable to parameter of type 'FastifyPluginCallback  | FastifyPluginAsync  | Promise{ default: FastifyPluginCallback ; }> | Promise...>'.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [X] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
for @nestjs/platform-fastify 10.0.2 and fastify/cookies 9.0.4 we should return a callback inside register, or we've got a ts error:

TS2345: Argument of type 'typeof fastifyCookie' is not assignable to parameter of type 'FastifyPluginCallback  | FastifyPluginAsync  | Promise{ default: FastifyPluginCallback ; }> | Promise...>'.


Issue Number: N/A


## What is the new behavior?
it's about register cookies plugin for nest fastify plattform

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
