### PR TITLE
docs: get namespace instance

### DIFF
--- a/content/websockets/gateways.md
+++ b/content/websockets/gateways.md
@@ -244,7 +244,7 @@ server: Server;
 Also, you can get namespace instance when you passed `namespace` option to `@WebSocketGateway()` decorator.
 
 ```typescript
-@WebSocketServer()
+@WebSocketServer({ namespace: 'something' })
 namespace: Namespace;
 ```
 

--- a/content/websockets/gateways.md
+++ b/content/websockets/gateways.md
@@ -232,13 +232,20 @@ There are 3 useful lifecycle hooks available. All of them have corresponding int
 
 > info **Hint** Each lifecycle interface is exposed from `@nestjs/websockets` package.
 
-#### Server
+#### Server and Namespace
 
 Occasionally, you may want to have a direct access to the native, **platform-specific** server instance. The reference to this object is passed as an argument to the `afterInit()` method (`OnGatewayInit` interface). Another option is to use the `@WebSocketServer()` decorator.
 
 ```typescript
 @WebSocketServer()
 server: Server;
+```
+
+Also, you can get namespace instance when you passed `namespace` property to `@WebSocketGateway` decorator.
+
+```typescript
+@WebSocketServer()
+namespace: Namespace;
 ```
 
 > warning **Notice** The `@WebSocketServer()` decorator is imported from the `@nestjs/websockets` package.

--- a/content/websockets/gateways.md
+++ b/content/websockets/gateways.md
@@ -241,7 +241,7 @@ Occasionally, you may want to have a direct access to the native, **platform-spe
 server: Server;
 ```
 
-Also, you can get namespace instance when you passed `namespace` property to `@WebSocketGateway` decorator.
+Also, you can get namespace instance when you passed `namespace` option to `@WebSocketGateway()` decorator.
 
 ```typescript
 @WebSocketServer()

--- a/content/websockets/gateways.md
+++ b/content/websockets/gateways.md
@@ -241,12 +241,11 @@ Occasionally, you may want to have a direct access to the native, **platform-spe
 server: Server;
 ```
 
-Also, you can get namespace instance when you passed `namespace` option to `@WebSocketGateway()` decorator.
+Also, you can retrieve the corresponding namespace using the `namespace` attribute, as follows:
 
 ```typescript
-@WebSocketServer({ namespace: 'something' })
+@WebSocketServer({ namespace: 'my-namespace' })
 namespace: Namespace;
-```
 
 > warning **Notice** The `@WebSocketServer()` decorator is imported from the `@nestjs/websockets` package.
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

When `namespace` options is used inside `@WebSocketGateway` decorator,
`@WebSocketServer()` will inject namespace instance instead server instance.
But it's not explained now.

## What is the new behavior?
For clear explanation, I added that information.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
