### PR TITLE
Update Redis Configuration in NestJS Documentation

### DIFF
--- a/content/techniques/caching.md
+++ b/content/techniques/caching.md
@@ -226,20 +226,18 @@ class HttpCacheInterceptor extends CacheInterceptor {
 This service takes advantage of [cache-manager](https://github.com/node-cache-manager/node-cache-manager) under the hood. The `cache-manager` package supports a wide-range of useful stores, for example, [Redis store](https://github.com/dabroek/node-cache-manager-redis-store). A full list of supported stores is available [here](https://github.com/node-cache-manager/node-cache-manager#store-engines). To set up the Redis store, simply pass the package together with corresponding options to the `register()` method.
 
 ```typescript
-import type { RedisClientOptions } from 'redis';
-import * as redisStore from 'cache-manager-redis-store';
 import { Module } from '@nestjs/common';
+import type { RedisClientOptions } from 'redis';
 import { CacheModule } from '@nestjs/cache-manager';
-import { AppController } from './app.controller';
-
 @Module({
   imports: [
     CacheModule.register<RedisClientOptions>({
-      store: redisStore,
-
-      // Store-specific configuration:
-      host: 'localhost',
-      port: 6379,
+        // Store-specific configuration:
+        socket: {
+          host: 'localhost',
+          port: '6379',
+        },
+        database: 0,
     }),
   ],
   controllers: [AppController],

--- a/content/techniques/caching.md
+++ b/content/techniques/caching.md
@@ -229,6 +229,8 @@ This service takes advantage of [cache-manager](https://github.com/node-cache-ma
 import { Module } from '@nestjs/common';
 import type { RedisClientOptions } from 'redis';
 import { CacheModule } from '@nestjs/cache-manager';
+import { AppController } from './app.controller';
+
 @Module({
   imports: [
     CacheModule.register<RedisClientOptions>({


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The current behavior is an outdated Redis implementation in the NestJS documentation due to changes made in the `cache-manager-redis-store` package.

Issue Number: N/A


## What is the new behavior?

The new behavior includes updating the Redis configuration in the NestJS documentation to reflect the changes made in the `cache-manager-redis-store` package. The updated configuration includes specifying the `socket` object, setting the Redis `database`, and defining a `ttl` value for cache entries.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

N/A
