### PR TITLE
docs(task-scheduling): update cron-job method descriptions and fix return types

### DIFF
--- a/content/techniques/task-scheduling.md
+++ b/content/techniques/task-scheduling.md
@@ -252,10 +252,11 @@ The `getCronJob()` method returns the named cron job. The returned `CronJob` obj
 - `stop()` - stops a job that is scheduled to run.
 - `start()` - restarts a job that has been stopped.
 - `setTime(time: CronTime)` - stops a job, sets a new time for it, and then starts it
-- `lastDate()` - returns a string representation of the last date a job executed
-- `nextDates(count: number)` - returns an array (size `count`) of `moment` objects representing upcoming job execution dates.
+- `lastDate()` - returns a `DateTime` representation of the date on which the last execution of a job occurred.
+- `nextDate()` - returns a `DateTime` representation of the date when the next execution of a job is scheduled.
+- `nextDates(count: number)` - Provides an array (size `count`) of `DateTime` representations for the next set of dates that will trigger job execution. `count` defaults to 0, returning an empty array.
 
-> info **Hint** Use `toDate()` on `moment` objects to render them in human readable form.
+> info **Hint** Use `toJSDate()` on `DateTime` objects to render them as a JavaScript Date equivalent to this DateTime.
 
 **Create** a new cron job dynamically using the `SchedulerRegistry#addCronJob` method, as follows:
 
@@ -295,7 +296,7 @@ getCrons() {
   jobs.forEach((value, key, map) => {
     let next;
     try {
-      next = value.nextDates().toDate();
+      next = value.nextDate().toJSDate();
     } catch (e) {
       next = 'error: next fire date is in the past!';
     }
@@ -304,7 +305,7 @@ getCrons() {
 }
 ```
 
-The `getCronJobs()` method returns a `map`. In this code, we iterate over the map and attempt to access the `nextDates()` method of each `CronJob`. In the `CronJob` API, if a job has already fired and has no future firing dates, it throws an exception.
+The `getCronJobs()` method returns a `map`. In this code, we iterate over the map and attempt to access the `nextDate()` method of each `CronJob`. In the `CronJob` API, if a job has already fired and has no future firing date, it throws an exception.
 
 #### Dynamic intervals
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
When reviewing the `CronJob` methods:

- `lastDate()`: The documentation states that it returns a string representation of the last date a job was executed. However, it actually returns a `DateTime` (luxon) object.
- `nextDates(count: number)`: The documentation mentions that it returns an array (with a size of 'count') of moment objects representing upcoming job execution dates. In reality, it returns an array of `DateTime` (luxon) objects.
- It's important to note that there is no `toDate()` function available for `DateTime` (luxon) objects.

## What is the new behavior?

Adjusting CronJob methods:
- `lastDate()` - returns a `DateTime` representation of the date on which the last execution of a job occurred.
- `nextDates(count: number)` - Provides an array (size count) of `DateTime` representations for the next set of dates that will trigger job execution. count defaults to 0, returning an empty array.

 Adding a reference to a method called `nextDate()`:
- `nextDate()` - returns a `DateTime` representation of the date when the next execution of a job is scheduled.

Changing the reference of `toDate()` to `toJSDate()`.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
