### PR TITLE
Update module-reference.md

### DIFF
--- a/content/fundamentals/module-reference.md
+++ b/content/fundamentals/module-reference.md
@@ -162,7 +162,7 @@ export class CatsService {
 
 Manually generated context identifiers (with `ContextIdFactory.create()`) represent DI sub-trees in which `REQUEST` provider is `undefined` as they are not instantiated and managed by the Nest dependency injection system.
 
-To register a custom `REQUEST` object for a manually created DI sub-tree, use the `ModuleRef#registerRequestByContextId()` method, as follows:
+To register a custom `REQUEST` object for a manually created DI sub-tree, use the `ModuleRef.registerRequestByContextId()` method, as follows:
 
 ```typescript
 const contextId = ContextIdFactory.create();


### PR DESCRIPTION
docs: fix a typo

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
There was a typo in documentations. `#` should replace with `.` in `ModuleRef#registerRequestByContextId()`

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
