### PR TITLE
fix(openapi): passed `PaginatedDto` to `ApiExtraModels` in `ApiPaginatedResponse` decorator

### DIFF
--- a/content/openapi/operations.md
+++ b/content/openapi/operations.md
@@ -258,7 +258,7 @@ export const ApiPaginatedResponse = <TModel extends Type<any>>(
   model: TModel,
 ) => {
   return applyDecorators(
-    ApiExtraModels(model),
+    ApiExtraModels(PaginatedDto, model),
     ApiOkResponse({
       schema: {
         allOf: [


### PR DESCRIPTION

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Mistake "Could not resolve reference" in swagger api if you use an [example with PaginatedDto](https://docs.nestjs.com/openapi/operations) 
Now there will be no error in the swagger api like "Could not resolve reference"

Issue Number: N/A


## What is the new behavior?
Now there will be no error in the swagger api like "Could not resolve reference"

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
