### PR TITLE
docs: Set res to ctx.req.res

### DIFF
--- a/content/security/rate-limiting.md
+++ b/content/security/rate-limiting.md
@@ -166,7 +166,7 @@ export class GqlThrottlerGuard extends ThrottlerGuard {
   getRequestResponse(context: ExecutionContext) {
     const gqlCtx = GqlExecutionContext.create(context);
     const ctx = gqlCtx.getContext();
-    return { req: ctx.req, res: ctx.res };
+    return { req: ctx.req, res: ctx.req.res };
   }
 }
 ```


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The current behavior leads to a runtime error as `ctx.res` is undefined.

My code following the docs:
```ts
import { ThrottlerGuard } from '@nestjs/throttler';
import { Injectable, ExecutionContext } from '@nestjs/common';
import { GqlExecutionContext } from '@nestjs/graphql';

@Injectable()
export class GqlThrottlerGuard extends ThrottlerGuard {
  getRequestResponse(context: ExecutionContext) {
    const gqlCtx = GqlExecutionContext.create(context);
    const ctx = gqlCtx.getContext();
    return { req: ctx.req, res: ctx.res };
  }
}
```

throws this runtime error:

```
[Nest] 41890  - 11/29/2023, 3:19:46 PM   ERROR [ExceptionsHandler] Cannot read properties of undefined (reading 'header')
TypeError: Cannot read properties of undefined (reading 'header')
```

When I logged the `ctx` I saw this:

```
{
  ctx: {
    req: IncomingMessage {
      _readableState: [ReadableState],
      _events: [Object: null prototype],
      _eventsCount: 1,
      _maxListeners: undefined,
      socket: [Socket],
      httpVersionMajor: 1,
      httpVersionMinor: 1,
      httpVersion: '1.1',
      complete: true,
      rawHeaders: [Array],
      rawTrailers: [],
      aborted: false,
      upgrade: false,
      url: '/',
      method: 'POST',
      statusCode: null,
      statusMessage: null,
      client: [Socket],
      _consuming: true,
      _dumped: false,
      next: [Function: next],
      baseUrl: '/graphql',
      originalUrl: '/graphql',
      _parsedUrl: [Url],
      params: {},
      query: {},
      res: [ServerResponse],
      body: [Object],
      _body: true,
      length: undefined,
      [Symbol(kCapture)]: false,
      [Symbol(kHeaders)]: [Object],
      [Symbol(kHeadersCount)]: 26,
      [Symbol(kTrailers)]: null,
      [Symbol(kTrailersCount)]: 0,
      [Symbol(RequestTimeout)]: undefined
    }
  }
}
```

You can see that `res` is inside `ctx.req`, not `ctx`.
So, I changed my code to set `res` to `ctx.req.res`, which fixes the issue.
New code:

```ts
  getRequestResponse(context: ExecutionContext) {
    const gqlCtx = GqlExecutionContext.create(context);
    const ctx = gqlCtx.getContext();
    return { req: ctx.req, res: ctx.req.res };
  }
```


## What is the new behavior?
The new behavior changes the documented code to set `res` to `ctx.req.res` instead of `ctx.res`, which fixes the runtime error.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
