### PR TITLE
docs(cli): add command-line arguments to the options of `nest start`

### DIFF
--- a/content/cli/usages.md
+++ b/content/cli/usages.md
@@ -146,6 +146,7 @@ $ nest start <name> [options]
 | `--webpackPath`         | Path to webpack configuration.                                                                                       |
 | `--tsc`                 | Force use `tsc` for compilation.                                                                                     |
 | `--exec [binary]`       | Binary to run (default: `node`). <br/>Alias `-e`                                                                     |
+| `-- [key=value]`        | Command-line arguments that can be referenced with `process.argv`.                                                   |
 
 #### nest add
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Arbitrary command-line arguments can be passed by `--` parameter with `nest start`.
The feature was introduced by https://github.com/nestjs/nest-cli/issues/1844.

However, the document of cli has not reflected the change.

## What is the new behavior?

Add command-line arguments to the options of `nest start` in cli usages.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
