### PR TITLE
Update cookies.md import syntax

### DIFF
--- a/content/techniques/cookies.md
+++ b/content/techniques/cookies.md
@@ -14,7 +14,7 @@ $ npm i -D @types/cookie-parser
 Once the installation is complete, apply the `cookie-parser` middleware as global middleware (for example, in your `main.ts` file).
 
 ```typescript
-import * as cookieParser from 'cookie-parser';
+import cookieParser from 'cookie-parser';
 // somewhere in your initialization file
 app.use(cookieParser());
 ```


### PR DESCRIPTION
the previous syntax did not work for me and just produced the following error:
```
src/main.ts:47:11 - error TS2349: This expression is not callable.
  Type 'typeof cookieParser' has no call signatures.
```
when I switched up to the new import call it worked fine. This will save time for the next person that would have wasted their time on this :)

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
