### PR TITLE
fix: modify where mapped types are imported

### DIFF
--- a/content/openapi/mapped-types.md
+++ b/content/openapi/mapped-types.md
@@ -31,7 +31,7 @@ By default, all of these fields are required. To create a type with the same fie
 export class UpdateCatDto extends PartialType(CreateCatDto) {}
 ```
 
-> info **Hint** The `PartialType()` function is imported from the `@nestjs/swagger` package.
+> info **Hint** The `PartialType()` function is imported from the `@nestjs/mapped-types` package.
 
 #### Pick
 
@@ -58,7 +58,7 @@ We can pick a set of properties from this class using the `PickType()` utility f
 export class UpdateCatAgeDto extends PickType(CreateCatDto, ['age'] as const) {}
 ```
 
-> info **Hint** The `PickType()` function is imported from the `@nestjs/swagger` package.
+> info **Hint** The `PickType()` function is imported from the `@nestjs/mapped-types` package.
 
 #### Omit
 
@@ -85,7 +85,7 @@ We can generate a derived type that has every property **except** `name` as show
 export class UpdateCatDto extends OmitType(CreateCatDto, ['name'] as const) {}
 ```
 
-> info **Hint** The `OmitType()` function is imported from the `@nestjs/swagger` package.
+> info **Hint** The `OmitType()` function is imported from the `@nestjs/mapped-types` package.
 
 #### Intersection
 
@@ -117,7 +117,7 @@ export class UpdateCatDto extends IntersectionType(
 ) {}
 ```
 
-> info **Hint** The `IntersectionType()` function is imported from the `@nestjs/swagger` package.
+> info **Hint** The `IntersectionType()` function is imported from the `@nestjs/mapped-types` package.
 
 #### Composition
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

I think the hint was wrong. mapped types are imported from `@nestjs/mapped-types`.