### PR TITLE
docs(update): 📝 open api setup option

### DIFF
--- a/content/openapi/introduction.md
+++ b/content/openapi/introduction.md
@@ -162,7 +162,7 @@ export interface SwaggerCustomOptions {
 
   /**
    * Path of the YAML API definition to serve.
-   * Default: `<path>-json`.
+   * Default: `<path>-yaml`.
    */
   yamlDocumentUrl?: string;
 


### PR DESCRIPTION
it should be yaml instead of json.

```js
/**
   * Path of the YAML API definition to serve.
   * Default: `<path>-json`. */ 
   yamlDocumentUrl?: string;
```

changed to 
```js
/**
   * Path of the YAML API definition to serve.
   * Default: `<path>-yaml`. */ 
   yamlDocumentUrl?: string;
```


## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
