### PR TITLE
docs(exception-filters): replace status with statusCode

### DIFF
--- a/content/exception-filters.md
+++ b/content/exception-filters.md
@@ -72,7 +72,7 @@ async findAll() {
     await this.service.findAll()
   } catch (error) { 
     throw new HttpException({
-      status: HttpStatus.FORBIDDEN,
+      statusCode: HttpStatus.FORBIDDEN,
       error: 'This is a custom message',
     }, HttpStatus.FORBIDDEN, {
       cause: error


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
the [exception-filters](https://docs.nestjs.com/exception-filters#throwing-standard-exceptions) documentation describes that the JSON response body contains two properties: 'statusCode' and 'message', but the demo code in `cats.controller.ts'` uses the property 'status'.
<img width="1203" alt="image" src="https://github.com/nestjs/docs.nestjs.com/assets/20815934/1ec1cf8a-bc66-4722-9b4e-b8bdd20e26bf">


## What is the new behavior?
the object properties used in the example remain consistent with the documentation, replace 'status' with 'statusCode'


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
