### PR TITLE
docs(exception-filters): correct status property

### DIFF
--- a/content/exception-filters.md
+++ b/content/exception-filters.md
@@ -72,7 +72,7 @@ async findAll() {
     await this.service.findAll()
   } catch (error) { 
     throw new HttpException({
-      statusCode: HttpStatus.FORBIDDEN,
+      status: HttpStatus.FORBIDDEN,
       error: 'This is a custom message',
     }, HttpStatus.FORBIDDEN, {
       cause: error


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [x] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
In #2988 status has been changed to statusCode, but it's inconsistent with an example:

![image](https://github.com/nestjs/docs.nestjs.com/assets/121371814/58276881-8195-49e9-a9f0-57f855de7b24)

I think it should be changed back to 'status,' or 'status' in the aforementioned example should be changed to 'statusCode.' It doesn't matter which. The case that @wilsonyiyi mentioned is irrelevant here. The docs say that we can pass an object, and there is no mention that it has to own a property called 'statusCode'.
> To override just the message portion of the JSON response body, supply a string in the response argument. To override the entire JSON response body, pass an object in the response argument. Nest will serialize the object and return it as the JSON response body.

## What is the new behavior?
Object properties used in the example will now remain consistent with the documentation.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
