### PR TITLE
fix: change standalone apps menu path to fix highlighting when active

### DIFF
--- a/src/app/homepage/menu/menu.component.ts
+++ b/src/app/homepage/menu/menu.component.ts
@@ -191,7 +191,7 @@ export class MenuComponent implements OnInit {
     {
       title: 'Standalone apps',
       isOpened: false,
-      path: '/application-context',
+      path: '/standalone-applications',
     },
     {
       title: 'CLI',


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

"Standalone Apps" menu is not highlighted when the "Standalone applications" page is open (https://docs.nestjs.com/standalone-applications).

<img width="592" alt="image" src="https://github.com/nestjs/docs.nestjs.com/assets/46542370/4dd77881-961b-4b2a-943f-28ffae51be6f">

Issue Number: N/A


## What is the new behavior?

The menu item is highlighted when the "Standalone applications" page is open.

<img width="591" alt="image" src="https://github.com/nestjs/docs.nestjs.com/assets/46542370/6dd40615-6e76-422b-a11f-737a4a2ec258">

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
