### PR TITLE
docs(oas/swagger): provide examples of the example and examples keys

### DIFF
--- a/content/openapi/types-and-parameters.md
+++ b/content/openapi/types-and-parameters.md
@@ -203,6 +203,31 @@ CatBreed:
 
 > info **Hint** Any **decorator** that takes `enum` as a property will also take `enumName`.
 
+#### Examples Of Properties
+
+You can set a single example for a property by utilizing the `example` key like this:
+
+```typescript
+@ApiProperty({
+  example: 'persian',
+})
+breed: string;
+```
+
+If you want to give multiple examples, you can utilize the `examples` key by passing in an object structured like this:
+
+```typescript
+@ApiProperty({
+  examples: {
+    Persian: { value: 'persian' },
+    Tabby: { value: 'tabby' },
+    Siamese: { value: 'siamese' },
+    'Scottish Fold': { value: 'scottish_fold' },
+  },
+})
+breed: string;
+```
+
 #### Raw definitions
 
 In some specific scenarios (e.g., deeply nested arrays, matrices), you may want to describe your type by hand.


### PR DESCRIPTION
Provide examples to users on how to set example and examples keys in the @ApiProperty annotation

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?

Currently the documentation does not have any indication of how to use the `example` or `examples` keys in the `@ApiProperty(...)` annotation.

Issue Number: N/A


## What is the new behavior?

This PR adds an example for the `example` and an example for the `examples` keys to the documentation to help show how to use them.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information

N/A - This is a pretty straightforward PR.