### PR TITLE
Update RxJS Observable URL to newer version + Fix some spelling mistakes

### DIFF
--- a/content/controllers.md
+++ b/content/controllers.md
@@ -354,7 +354,7 @@ async findAll() {
 }
 ```
 
-The above code is fully valid. Furthermore, Nest route handlers are even more powerful by being able to return RxJS [observable streams](http://reactivex.io/rxjs/class/es6/Observable.js~Observable.html). Nest will automatically subscribe to the source underneath and take the last emitted value (once the stream is completed).
+The above code is fully valid. Furthermore, Nest route handlers are even more powerful by being able to return RxJS [observable streams](https://rxjs-dev.firebaseapp.com/guide/observable). Nest will automatically subscribe to the source underneath and take the last emitted value (once the stream is completed).
 
 ```typescript
 @@filename(cats.controller)

--- a/content/devtools/ci-cd.md
+++ b/content/devtools/ci-cd.md
@@ -71,7 +71,7 @@ Similarly, if we're working on a **large codebase** and we modify a module to be
 
 #### Build preview
 
-For every published graph we can go back in time and preview how it looked before by clicking at the **Preview** button. Furthermore, if the report was generated, we should see the differences higlighted on our graph:
+For every published graph we can go back in time and preview how it looked before by clicking at the **Preview** button. Furthermore, if the report was generated, we should see the differences highlighted on our graph:
 
 - green nodes represent added elements
 - light white nodes represent updated elements

--- a/content/devtools/ci-cd.md
+++ b/content/devtools/ci-cd.md
@@ -132,7 +132,7 @@ jobs:
 
 Ideally, `DEVTOOLS_API_KEY` environment variable should be retrieved from GitHub Secrets, read more [here](https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository) .
 
-This workflow will run per each pull request that's targeting the `master` branch OR in case there's a direct commit to the `master` branch. Feel free to align this configuration to whatever your project needs. What's essential here is that we provide necessary environment varaiables for our `GraphPublisher` class (to run).
+This workflow will run per each pull request that's targeting the `master` branch OR in case there's a direct commit to the `master` branch. Feel free to align this configuration to whatever your project needs. What's essential here is that we provide necessary environment variables for our `GraphPublisher` class (to run).
 
 However, there's one variable that needs to be updated before we can start using this workflow - `DEVTOOLS_API_KEY`. We can generate an API key dedicated for our project on this [page](https://devtools.nestjs.com/settings/manage-api-keys).
 

--- a/content/microservices/redis.md
+++ b/content/microservices/redis.md
@@ -60,7 +60,7 @@ The `options` property is specific to the chosen transporter. The <strong>Redis<
   </tr>
    <tr>
     <td><code>wildcards</code></td>
-    <td>Enables Redis wilcard subscriptions, instructing transporter to use <code>psubscribe</code>/<code>pmessage</code> under the hood. (default: <code>false</code>)</td>
+    <td>Enables Redis wildcard subscriptions, instructing transporter to use <code>psubscribe</code>/<code>pmessage</code> under the hood. (default: <code>false</code>)</td>
   </tr>
 </table>
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [X] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently the observable streams url point to: http://reactivex.io/rxjs/class/es6/Observable.js~Observable.html. However if you're on that site and click home it will bring you to their newer doc site. 

Also a few things are currently misspelled.

Issue Number: N/A


## What is the new behavior?
Updating the link to point to the latest observable docs here: https://rxjs-dev.firebaseapp.com/guide/observable. 

Also, fixing some misspellings. 

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
N/A