### PR TITLE
docs(swagger): defaults api tag to controller name

### DIFF
--- a/content/openapi/introduction.md
+++ b/content/openapi/introduction.md
@@ -122,6 +122,11 @@ export interface SwaggerDocumentOptions {
    * @default () => controllerKey_methodKey
    */
   operationIdFactory?: (controllerKey: string, methodKey: string) => string;
+
+  /**
+   * If `true`, the name of the nest controller is included as a tag
+   */
+  includeControllerTag?: boolean;
 }
 ```
 


### PR DESCRIPTION
related to https://github.com/nestjs/swagger/pull/3017/files