### PR TITLE
docs(queues): correct event listener example for BullMQ

### DIFF
--- a/content/techniques/queues.md
+++ b/content/techniques/queues.md
@@ -304,7 +304,6 @@ import { Job } from 'bullmq';
 
 @Processor('audio')
 export class AudioConsumer {
-
   @OnWorkerEvent('active')
   onActive(job: Job) {
     console.log(

--- a/content/techniques/queues.md
+++ b/content/techniques/queues.md
@@ -312,6 +312,7 @@ export class AudioConsumer {
   }
 
   // ...
+}
 ```
 
 You can see the complete list of events and their arguments as properties of WorkerListener [here](https://api.docs.bullmq.io/interfaces/v4.WorkerListener.html).

--- a/content/techniques/queues.md
+++ b/content/techniques/queues.md
@@ -324,7 +324,6 @@ import { QueueEventsHost, QueueEventsListener, OnQueueEvent } from '@nestjs/bull
 
 @QueueEventsListener('audio')
 export class AudioEventsListener extends QueueEventsHost {
-
   @OnQueueEvent('active')
   onActive(job: { jobId: string; prev?: string; }) {
     console.log(
@@ -333,6 +332,7 @@ export class AudioEventsListener extends QueueEventsHost {
   }
 
   // ...
+}
 ```
 
 > info **Hint** QueueEvent Listeners must be registered as `providers` so the `@nestjs/bullmq` package can pick them up.


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The existing documentation was not updated correctly for the newer BullMQ package, and does not cover all use cases provided by the new package.

Issue Number: N/A


## What is the new behavior?

Docs updated to work with BullMQ.

This matches the documentation that is found in the official BullMQ docs: 
https://docs.bullmq.io/guide/nestjs#processor
https://docs.bullmq.io/guide/nestjs/queue-events-listeners

As well as the code behaviour and comments:
https://github.com/nestjs/bull/blob/master/packages/bullmq/lib/decorators/on-worker-event.decorator.ts
https://github.com/nestjs/bull/blob/master/packages/bullmq/lib/decorators/on-queue-event.decorator.ts


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
