### PR TITLE
fix: update image color for dark mode in the "shared module" section.

### DIFF
--- a/content/modules.md
+++ b/content/modules.md
@@ -79,7 +79,7 @@ Here is how our directory structure looks now:
 
 In Nest, modules are **singletons** by default, and thus you can share the same instance of any provider between multiple modules effortlessly.
 
-<figure><img src="/assets/Shared_Module_1.png" /></figure>
+<figure><img class="illustrative-image" src="/assets/Shared_Module_1.png" /></figure>
 
 Every module is automatically a **shared module**. Once created it can be reused by any module. Let's imagine that we want to share an instance of the `CatsService` between several other modules. In order to do that, we first need to **export** the `CatsService` provider by adding it to the module's `exports` array, as shown below:
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
 - Added `"illustrative-image"` class css for dark mode in the illustrative-image `"shared module"` so that it is in line with other images when there is dark mode ( see screenshot ) 

<img width="1326" alt="screen-dark-mode" src="https://github.com/user-attachments/assets/a78f79ac-9c64-4449-a385-80291956500e">

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
