### PR TITLE
docs: Fix cache-manager TTL documentation

### DIFF
--- a/content/techniques/caching.md
+++ b/content/techniques/caching.md
@@ -62,7 +62,7 @@ The default expiration time of the cache is 5 seconds.
 You can manually specify a TTL (expiration time in seconds) for this specific key, as follows:
 
 ```typescript
-await this.cacheManager.set('key', 'value', 1000);
+await this.cacheManager.set('key', 'value', {ttl: 1} as any);
 ```
 
 To disable expiration of the cache, set the `ttl` configuration property to `0`:


### PR DESCRIPTION
### Issue Description
The NestJS Cache Manager documentation states that TTL should be passed in milliseconds when using `await this.cacheManager.set('key', 'value', 1000);`. However, in practice, this does not work. Instead, passing the TTL as part of an options object in seconds (`{ ttl: <seconds> }`) works correctly.

### Steps to Reproduce:
1. Follow the current documentation to pass the TTL in milliseconds. The cache key is not set as expected.
2. Using `{ ttl: 1 }` in seconds successfully sets the cache key.

### Fix:
Updated the documentation to reflect that the TTL should be passed in seconds via an options object instead of milliseconds.

