### PR TITLE
docs(documentation): updated swc documentation with gotcha

### DIFF
--- a/content/recipes/swc.md
+++ b/content/recipes/swc.md
@@ -178,7 +178,10 @@ export class User {
 }
 ```
 
-> info **Hint** `Relation` type is exported from the `typeorm` package.
+> info **Hint** `Relation` type is exported from the `typeorm` package and should be imported as a type.
+> ```typescript
+>  import type { Relation } from 'typeorm';
+> ```
 
 Doing this prevents the type of the property from being saved in the transpiled code in the property metadata, preventing circular dependency issues.
 


### PR DESCRIPTION
Updated swd.md to add the example on how to import the type Relation from typeorm

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Added a gotcha to the swc documentation.

The Relation type should be imported as a type instead of directly from typeorm as happens when you use the auto import in the ides. I think it should be documented so nobody loses 45min debugging this again (💀)