### PR TITLE
docs(openapi): prefer lazy mode version of `SwaggerModule.setup`

### DIFF
--- a/content/openapi/introduction.md
+++ b/content/openapi/introduction.md
@@ -29,15 +29,15 @@ async function bootstrap() {
     .setVersion('1.0')
     .addTag('cats')
     .build();
-  const document = SwaggerModule.createDocument(app, config);
-  SwaggerModule.setup('api', app, document);
+  const makeDocument = () => SwaggerModule.createDocument(app, config);
+  SwaggerModule.setup('api', app, makeDocument);
 
   await app.listen(3000);
 }
 bootstrap();
 ```
 
-> info **Hint** `document` (returned by the `SwaggerModule#createDocument()` method) is a serializable object conforming to [OpenAPI Document](https://swagger.io/specification/#openapi-document). Instead of hosting it via HTTP, you could also save it as a JSON/YAML file, and consume it in different ways.
+> info **Hint** `document` (returned by the `SwaggerModule#createDocument()` method) is a serializable object conforming to [OpenAPI Document](https://swagger.io/specification/#openapi-document). Instead of hosting it via HTTP, you could also save it as a JSON/YAML file, and consume it in different ways. Since it can take some time depending on the number of endpoints that your application has, we are passing a function fo `SwaggerModule.setup` instead of the created document to avoid impacting the bootstrapping time.
 
 The `DocumentBuilder` helps to structure a base document that conforms to the OpenAPI Specification. It provides several methods that allow setting such properties as title, description, version, etc. In order to create a full document (with all HTTP routes defined) we use the `createDocument()` method of the `SwaggerModule` class. This method takes two arguments, an application instance and a Swagger options object. Alternatively, we can provide a third argument, which should be of type `SwaggerDocumentOptions`. More on this in the [Document options section](/openapi/introduction#document-options).
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


there is no mention about the lazy mode version of `SwaggerModule.setup` for creating the document

## What is the new behavior?

to encourage a faster bootstrapping time, I think that it's be better to showcase the lazy mode version instead of the eager one.

Note that if the document building is failing, we won't see it until we access openapi spec's page

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->