### PR TITLE
docs: example of decorator composition with `Reflector#createDecorator`

### DIFF
--- a/content/custom-decorators.md
+++ b/content/custom-decorators.md
@@ -183,22 +183,24 @@ Nest provides a helper method to compose multiple decorators. For example, suppo
 
 ```typescript
 @@filename(auth.decorator)
-import { applyDecorators } from '@nestjs/common';
+import { applyDecorators, SetMetadata, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiUnauthorizedResponse } from '@nestjs/swagger';
 
 export function Auth(...roles: Role[]) {
   return applyDecorators(
-    SetMetadata('roles', roles),
+    SetMetadata('roles', roles), // custom metadata
     UseGuards(AuthGuard, RolesGuard),
     ApiBearerAuth(),
     ApiUnauthorizedResponse({ description: 'Unauthorized' }),
   );
 }
 @@switch
-import { applyDecorators } from '@nestjs/common';
+import { applyDecorators, SetMetadata, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiUnauthorizedResponse } from '@nestjs/swagger';
 
 export function Auth(...roles) {
   return applyDecorators(
-    SetMetadata('roles', roles),
+    SetMetadata('roles', roles), // custom metadata
     UseGuards(AuthGuard, RolesGuard),
     ApiBearerAuth(),
     ApiUnauthorizedResponse({ description: 'Unauthorized' }),

--- a/content/custom-decorators.md
+++ b/content/custom-decorators.md
@@ -179,16 +179,21 @@ async findOne(user) {
 
 #### Decorator composition
 
-Nest provides a helper method to compose multiple decorators. For example, suppose you want to combine all decorators related to authentication into a single decorator. This could be done with the following construction:
+Nest provides a helper method to compose multiple decorators.  
+For example, suppose you want to combine all decorators related to authentication into a single decorator. Here we can use those decorators created via `Reflector#createDecorator` (as explained in the [execution context chapter](/fundamentals/execution-context#reflection-and-metadata)).
+
+This could be done with the following construction:
 
 ```typescript
 @@filename(auth.decorator)
 import { applyDecorators, SetMetadata, UseGuards } from '@nestjs/common';
 import { ApiBearerAuth, ApiUnauthorizedResponse } from '@nestjs/swagger';
+import { Roles } from './roles.decorator'; // an example for `Reflector#createDecorator`
 
 export function Auth(...roles: Role[]) {
   return applyDecorators(
-    SetMetadata('roles', roles), // custom metadata
+    SetMetadata('has_auth', true), // custom metadata
+    Roles(roles), // custom decorator created via Reflector#createDecorator
     UseGuards(AuthGuard, RolesGuard),
     ApiBearerAuth(),
     ApiUnauthorizedResponse({ description: 'Unauthorized' }),
@@ -197,10 +202,12 @@ export function Auth(...roles: Role[]) {
 @@switch
 import { applyDecorators, SetMetadata, UseGuards } from '@nestjs/common';
 import { ApiBearerAuth, ApiUnauthorizedResponse } from '@nestjs/swagger';
+import { Roles } from './roles.decorator'; // an example for `Reflector#createDecorator`
 
 export function Auth(...roles) {
   return applyDecorators(
-    SetMetadata('roles', roles), // custom metadata
+    SetMetadata('has_auth', true), // custom metadata
+    Roles(roles), // custom decorator created via Reflector#createDecorator
     UseGuards(AuthGuard, RolesGuard),
     ApiBearerAuth(),
     ApiUnauthorizedResponse({ description: 'Unauthorized' }),


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

no examples on how to compose decorators created via `Reflector#createDecorator`


## What is the new behavior?

as the `Roles` decorator in the docs was created via `Reflector#createDecorator` [here](https://docs.nestjs.com/fundamentals/execution-context#reflection-and-metadata), we can use it for the demo of decorators composition

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

