### PR TITLE
feat: respect user's preferred color scheme (dark mode repair)

### DIFF
--- a/src/app/shared/components/theme-mode-toggle/theme-mode-toggle.component.html
+++ b/src/app/shared/components/theme-mode-toggle/theme-mode-toggle.component.html
@@ -1,4 +1,12 @@
 <button class="theme-mode-toggle">
-  <span class="material-icons" *ngIf="!isDarkMode" (click)="toggleThemeMode()"> light_mode </span>
-  <span class="material-icons" *ngIf="isDarkMode" (click)="toggleThemeMode()"> dark_mode </span>
+  <span class="material-icons" *ngIf="theme === 'dark'" (click)="toggleTheme()">
+    light_mode
+  </span>
+  <span
+    class="material-icons"
+    *ngIf="theme === 'light'"
+    (click)="toggleTheme()"
+  >
+    dark_mode
+  </span>
 </button>

--- a/src/app/shared/components/theme-mode-toggle/theme-mode-toggle.component.ts
+++ b/src/app/shared/components/theme-mode-toggle/theme-mode-toggle.component.ts
@@ -21,18 +21,18 @@ export class ThemeModeToggleComponent implements OnInit {
   ) {}
 
   ngOnInit() {
-    const preferredScheme = this.mediaMatcher.matchMedia(
+    const darkSchemeMatcher = this.mediaMatcher.matchMedia(
       '(prefers-color-scheme: dark)',
     );
 
-    preferredScheme.onchange = () => {
-      if (!this.getStoredTheme()) this.toggleTheme(true);
+    darkSchemeMatcher.onchange = ({ matches }) => {
+      if (!this.getStoredTheme()) this.setTheme(matches ? 'dark' : 'light');
     };
 
-    const isDarkSchemePreferred = preferredScheme.matches;
+    const preferredScheme = darkSchemeMatcher.matches ? 'dark' : 'light';
     const storedTheme = this.getStoredTheme();
 
-    this.theme = storedTheme ?? (isDarkSchemePreferred ? 'dark' : 'light');
+    this.theme = storedTheme ?? preferredScheme;
     this.setTheme(this.theme);
   }
 

--- a/src/app/shared/components/theme-mode-toggle/theme-mode-toggle.component.ts
+++ b/src/app/shared/components/theme-mode-toggle/theme-mode-toggle.component.ts
@@ -1,6 +1,6 @@
-import { Component, Inject, OnInit } from '@angular/core';
-import { DOCUMENT } from '@angular/common';
 import { MediaMatcher } from '@angular/cdk/layout';
+import { DOCUMENT } from '@angular/common';
+import { ChangeDetectorRef, Component, Inject, OnInit } from '@angular/core';
 import { StorageService } from '../../services/storage.service';
 
 type Theme = 'light' | 'dark';
@@ -18,6 +18,7 @@ export class ThemeModeToggleComponent implements OnInit {
     private readonly document: Document,
     private readonly mediaMatcher: MediaMatcher,
     private readonly storageService: StorageService,
+    private readonly changeDetector: ChangeDetectorRef,
   ) {}
 
   ngOnInit() {
@@ -32,17 +33,16 @@ export class ThemeModeToggleComponent implements OnInit {
     const preferredScheme = darkSchemeMatcher.matches ? 'dark' : 'light';
     const storedTheme = this.getStoredTheme();
 
-    this.theme = storedTheme ?? preferredScheme;
-    this.setTheme(this.theme);
+    this.setTheme(storedTheme ?? preferredScheme);
   }
 
   toggleTheme(skipStorage = false) {
-    this.theme = this.theme === 'dark' ? 'light' : 'dark';
+    const newTheme = this.theme === 'dark' ? 'light' : 'dark';
     // NOTE: We should skip saving theme in storage when toggle is caused by matchMedia change event
     // Otherwise, once saved, it'll no longer correspond to the system preferences,
     // despite the user not touching the toggle button themselves
-    if (!skipStorage) this.storageService.set('theme', this.theme);
-    this.setTheme(this.theme);
+    if (!skipStorage) this.storageService.set('theme', newTheme);
+    this.setTheme(newTheme);
   }
 
   private getStoredTheme() {
@@ -50,6 +50,8 @@ export class ThemeModeToggleComponent implements OnInit {
   }
 
   private setTheme(theme: Theme) {
+    this.theme = theme;
     this.document.documentElement.setAttribute('mode', theme);
+    this.changeDetector.detectChanges();
   }
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently, the Nest.js documentation site does not respect the user's system preferences regarding the color scheme (light or dark). As a result, opening the site in a new browser or in an Incognito session always defaults to light mode, ignoring the system preferences.

Manually toggling the theme will save the current theme in `localStorage`, so the next time the user opens the site, it will remain the same.

Issue Number: N/A


## What is the new behavior?
The new behavior respects the user's system preferences. If their preferred color scheme is dark, the Nest.js site will default to dark mode, and similarly, if their preferred color scheme is light, it will be in light mode. It now also listens for changes in the preferred color scheme, and the Nest.js site will automatically change its theme according to the current system preferences.

If the user manually toggles the theme button, the theme will be stored in `localStorage` and remain there. In this case, the theme will not respect the system preferences. Instead, `localStorage` will be the source of truth.

Please see the attached video.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information


https://github.com/user-attachments/assets/3656f7de-3dfc-419f-9ced-51853460f9f5

