### PR TITLE
docs(introduction): replace 'degit' reference with shallow cloning the repository

### DIFF
--- a/content/introduction.md
+++ b/content/introduction.md
@@ -27,16 +27,16 @@ $ nest new project-name
 
 #### Alternatives
 
-Alternatively, to install the TypeScript starter project with **Git**:
+You can download the TypeScript starter project in a zip file here: https://github.com/nestjs/typescript-starter  
+Or with **Git**:
 
 ```bash
-$ git clone https://github.com/nestjs/typescript-starter.git project
+$ git clone --depth=1 https://github.com/nestjs/typescript-starter.git project
 $ cd project
+$ rm -r .git
 $ npm install
 $ npm run start
 ```
-
-> info **Hint** If you'd like to clone the repository without the git history, you can use [degit](https://github.com/Rich-Harris/degit).
 
 Open your browser and navigate to [`http://localhost:3000/`](http://localhost:3000/).
 

--- a/content/introduction.md
+++ b/content/introduction.md
@@ -33,7 +33,6 @@ Or with **Git**:
 ```bash
 $ git clone --depth=1 https://github.com/nestjs/typescript-starter.git project
 $ cd project
-$ rm -r .git
 $ npm install
 $ npm run start
 ```


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

the introduction page has a hint for those that don't want to use Git. But it is pointing to another tool that is not related with NestJS: degit

## What is the new behavior?

1. avoid another references to a 3rd-party temporary tools
2. one less _hint_ block
3. add shallow cloning of the starter repository, ~followed by removing the `.git` as this directory is useless (in this context). The `rm` command is not that cross-platform so I can drop this step if needed~
3. clarify that people can use GitHub to download the project without the git history

![image](https://github.com/user-attachments/assets/5956b256-9cf0-4cbc-b36b-90de7f92eeb3)



## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

