### PR TITLE
fix: correct npm command for starting REPL and watch mode

### DIFF
--- a/content/recipes/repl.md
+++ b/content/recipes/repl.md
@@ -29,7 +29,7 @@ bootstrap();
 Now in your terminal, start the REPL with the following command:
 
 ```bash
-$ npm run start -- --entryFile repl
+$ npm run start --entryFile repl
 ```
 
 > info **Hint** `repl` returns a [Node.js REPL server](https://nodejs.org/api/repl.html) object.
@@ -113,7 +113,7 @@ Interface: $(token: InjectionToken) => any
 During development it is useful to run REPL in a watch mode to reflect all the code changes automatically:
 
 ```bash
-$ npm run start -- --watch --entryFile repl
+$ npm run start --watch --entryFile repl
 ```
 
 This has one flaw, the REPL's command history is discarded after each reload which might be cumbersome.


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?

The REPL start and watch commands in the documentation are incorrect.

Issue Number: N/A


## What is the new behavior?

The incorrect REPL start and watch commands have been corrected.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


## Other information

This PR fixes minor documentation errors related to the NestJS REPL start commands.