### PR TITLE
docs(fundamentals): clarify triggering behavior of init phases

### DIFF
--- a/content/fundamentals/lifecycle-events.md
+++ b/content/fundamentals/lifecycle-events.md
@@ -12,6 +12,8 @@ The following diagram depicts the sequence of key application lifecycle events, 
 
 Lifecycle events happen during application bootstrapping and shutdown. Nest calls registered lifecycle hook methods on modules, providers and controllers at each of the following lifecycle events (**shutdown hooks** need to be enabled first, as described [below](https://docs.nestjs.com/fundamentals/lifecycle-events#application-shutdown)). As shown in the diagram above, Nest also calls the appropriate underlying methods to begin listening for connections, and to stop listening for connections.
 
+In the following table, `onModuleInit` and `onApplicationBootstrap` are only triggered if you explicitly call `app.init()` or `app.listen()`.
+
 In the following table, `onModuleDestroy`, `beforeApplicationShutdown` and `onApplicationShutdown` are only triggered if you explicitly call `app.close()` or if the process receives a special system signal (such as SIGTERM) and you have correctly called `enableShutdownHooks` at application bootstrap (see below **Application shutdown** part).
 
 | Lifecycle hook method           | Lifecycle event triggering the hook method call                                                                                                                                                                   |


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

I didn't found so clear that if we don't call `app.init()`/`app.listen()`, few lifecycle hooks won't be triggered, as we have for `app.close()` already


## What is the new behavior?

![image](https://github.com/user-attachments/assets/62eece5b-4cfb-42d6-be12-f25bbebc1fee)

a minor note to clarify the expected triggering behavior of init phase hooks

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No
