### PR TITLE
docs(controllers): change Cache-Control header to no-store

### DIFF
--- a/content/controllers.md
+++ b/content/controllers.md
@@ -226,7 +226,7 @@ To specify a custom response header, you can either use a `@Header()` decorator 
 
 ```typescript
 @Post()
-@Header('Cache-Control', 'none')
+@Header('Cache-Control', 'no-store')
 create() {
   return 'This action adds a new cat';
 }


### PR DESCRIPTION
Change Cache-Control header to no-store

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
Docs suggests for `Cache-Control` header the value `none`. This is not a valid value.


## What is the new behavior?
Setting the `Cache-Control` header to value `no-store`. This is valid according to https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


## Other information
