### PR TITLE
docs(openapi): align types in intro page with code updates

### DIFF
--- a/content/openapi/introduction.md
+++ b/content/openapi/introduction.md
@@ -119,16 +119,29 @@ export interface SwaggerDocumentOptions {
 
   /**
    * Custom operationIdFactory that will be used to generate the `operationId`
-   * based on the `controllerKey` and `methodKey`
-   * @default () => controllerKey_methodKey
+   * based on the `controllerKey`, `methodKey`, and version.
+   * @default () => controllerKey_methodKey_version
    */
-  operationIdFactory?: (controllerKey: string, methodKey: string) => string;
+  operationIdFactory?: OperationIdFactory;
+
+  /**
+   * Custom linkNameFactory that will be used to generate the name of links
+   * in the `links` field of responses
+   *
+   * @see [Link objects](https://swagger.io/docs/specification/links/)
+   *
+   * @default () => `${controllerKey}_${methodKey}_from_${fieldKey}`
+   */
+  linkNameFactory?: (
+    controllerKey: string,
+    methodKey: string,
+    fieldKey: string
+  ) => string;
 
   /*
    * Generate tags automatically based on the controller name.
    * If `false`, you must use the `@ApiTags()` decorator to define tags.
    * Otherwise, the controller name without the suffix `Controller` will be used.
-   *
    * @default true
    */
   autoTagControllers?: boolean;
@@ -197,10 +210,6 @@ export interface SwaggerCustomOptions {
   /**
    * If `true`, the selector of OpenAPI definitions is displayed in the Swagger UI interface.
    * Default: `false`.
-   *
-   * When `true` and `swaggerOptions.urls` is provided, a dropdown labeled "Select a definition"
-   * is shown in the Swagger UI, allowing users to select from the available API definitions
-   * specified in the `urls` array.
    */
   explorer?: boolean;
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
In the docs the types `SwaggerDocumentOptions `  and  `SwaggerCustomOptions` are outdated compared to the actual types in the nestjs swagger module

Issue Number: N/A

## What is the new behavior?
Update the types to match exactly whats in the repo

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
