### PR TITLE
fix: fields in SDL are nullable by default

### DIFF
--- a/content/graphql/resolvers-map.md
+++ b/content/graphql/resolvers-map.md
@@ -67,7 +67,7 @@ The type function is required when there's the potential for ambiguity between t
 
 The options object can have any of the following key/value pairs:
 
-- `nullable`: for specifying whether a field is nullable (in SDL, each field is non-nullable by default); `boolean`
+- `nullable`: for specifying whether a field is nullable (in SDL, each field is nullable by default); `boolean`
 - `description`: for setting a field description; `string`
 - `deprecationReason`: for marking a field as deprecated; `string`
 


### PR DESCRIPTION
Fields in GraphQL are nullable by default and we opt for `non-nullable` by adding `!` after the type, [ref](https://graphql.org/learn/schema/#non-null)

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
"nullable: for specifying whether a field is nullable (in SDL, each field is non-nullable by default); boolean"

## What is the new behavior?
"nullable: for specifying whether a field is nullable (in SDL, each field is nullable by default); boolean"

## Does this PR introduce a breaking change?
- [ ] Yes
- [ x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
