### PR TITLE
fix: better wording + adding a hint about typing nullable fields

### DIFF
--- a/content/graphql/mutations.md
+++ b/content/graphql/mutations.md
@@ -41,35 +41,6 @@ export class UpvotePostInput {
 
 > info **Hint** The `@InputType()` decorator takes an options object as an argument, so you can, for example, specify the input type's description. Note that, due to TypeScript's metadata reflection system limitations, you must either use the `@Field` decorator to manually indicate a type, or use a [CLI plugin](/graphql/cli-plugin).
 
-> info **Hint** When a field is nullable you need to type it verbosely in order to prevent any runtime issue:
->
-> ```ts
-> @Field(() => String, {{ '{' }} nullable: true {{ '}' }}) title?: string | null;
-> ```
->
-> This is particularly important when dealing with partial updates in your API, especially if the corresponding database field is non-nullable (let's assume `author.title` is a mandatory field in database).
->
-> Problem: assume you want to allow users to perform partial updates on `author`'s info. So you define the `title` field in your `Input` object type:
->
-> ```ts
-> @Field(() => String, {{ '{' }} nullable: true {{ '}' }}) title?: string;
-> ```
->
-> Indicating that user can skip `title` entirely in an update mutation. However if a user sends `null` explicitly for `title` and you pass the DTO directly to your database, something like this:
->
-> ```ts
-> prisma.author.update({{ '{' }}
->   where: {{ '{' }}
->     id: author.id
->   {{ '}' }},
->   data: dto
-> {{ '}' }})
-> ```
->
-> Then your database will throw an error because `null` is not assignable to `title` which is non-nullable.
->
-> Solution: To prevent this from happening you can be more specific when you're defining `title`'s type: `@Field(() => String, {{ '{' }} nullable: true {{ '}' }}) title?: string | null;`. Now when you're passing your DTO directly to the underlying ORM TS complain that `null` is not assignable to `string`.
-
 We can then use this type in the resolver class:
 
 ```typescript

--- a/content/graphql/mutations.md
+++ b/content/graphql/mutations.md
@@ -41,6 +41,35 @@ export class UpvotePostInput {
 
 > info **Hint** The `@InputType()` decorator takes an options object as an argument, so you can, for example, specify the input type's description. Note that, due to TypeScript's metadata reflection system limitations, you must either use the `@Field` decorator to manually indicate a type, or use a [CLI plugin](/graphql/cli-plugin).
 
+> info **Hint** When a field is nullable you need to type it verbosely in order to prevent any runtime issue:
+>
+> ```ts
+> @Field(() => String, {{ '{' }} nullable: true {{ '}' }}) title?: string | null;
+> ```
+>
+> This is particularly important when dealing with partial updates in your API, especially if the corresponding database field is non-nullable (let's assume `author.title` is a mandatory field in database).
+>
+> Problem: assume you want to allow users to perform partial updates on `author`'s info. So you define the `title` field in your `Input` object type:
+>
+> ```ts
+> @Field(() => String, {{ '{' }} nullable: true {{ '}' }}) title?: string;
+> ```
+>
+> Indicating that user can skip `title` entirely in an update mutation. However if a user sends `null` explicitly for `title` and you pass the DTO directly to your database, something like this:
+>
+> ```ts
+> prisma.author.update({{ '{' }}
+>   where: {{ '{' }}
+>     id: author.id
+>   {{ '}' }},
+>   data: dto
+> {{ '}' }})
+> ```
+>
+> Then your database will throw an error because `null` is not assignable to `title` which is non-nullable.
+>
+> Solution: To prevent this from happening you can be more specific when you're defining `title`'s type: `@Field(() => String, {{ '{' }} nullable: true {{ '}' }}) title?: string | null;`. Now when you're passing your DTO directly to the underlying ORM TS complain that `null` is not assignable to `string`.
+
 We can then use this type in the resolver class:
 
 ```typescript

--- a/content/graphql/resolvers-map.md
+++ b/content/graphql/resolvers-map.md
@@ -78,8 +78,6 @@ For example:
 title: string;
 ```
 
-> info **Hint** When a field is nullable you need to type it verbosely in order to prevent any runtime issue: `@Field(() => String, {nullable: true}) title?: string | null;`. This particularly important when dealing with parcial updates in your API, especially if the corresponding database field is non-nullable (e.g. `author.title`). **Problem**: assume the `title` field is defined like this: `@Field(() => String, { nullable: true }) title?: string;`, indicating that user can skip `title` entirely in an update mutation. However if a user sends `null` explicitly for `title` and you pass the DTO directly to your database: `prisma.author.update({ where: { id: author.id }, data: dto })` your database will throw an error because `null` is not assignable to `title` which is non-nullable. **Solution**: To prevent this from happening you can be more specific when you're defining `title`'s type: `@Field(() => String, {nullable: true}) title?: string | null;`. Now when you're passing your DTO directly to the underlying ORM TS complain that `null` is not assignable to `string`.
-
 > info **Hint** You can also add a description to, or deprecate, the whole object type: `@ObjectType({{ '{' }} description: 'Author model' {{ '}' }})`.
 
 When the field is an array, we must manually indicate the array type in the `Field()` decorator's type function, as shown below:

--- a/content/graphql/resolvers-map.md
+++ b/content/graphql/resolvers-map.md
@@ -67,7 +67,7 @@ The type function is required when there's the potential for ambiguity between t
 
 The options object can have any of the following key/value pairs:
 
-- `nullable`: for specifying whether a field is nullable (in SDL, each field is non-nullable by default); `boolean`
+- `nullable`: for specifying whether a field is nullable (in `@nestjs/graphql`, each field is non-nullable by default); `boolean`
 - `description`: for setting a field description; `string`
 - `deprecationReason`: for marking a field as deprecated; `string`
 
@@ -77,6 +77,12 @@ For example:
 @Field({ description: `Book title`, deprecationReason: 'Not useful in v2 schema' })
 title: string;
 ```
+
+> info **Hint** When a field is nullable you need to type it verbosely in order to prevent any runtime issue: `@Field(() => String, {nullable: true}) title?: string | null;`. This particularly important when dealing with parcial updates in your API, especially if the corresponding database field is non-nullable (e.g. `author.title`).
+>
+> **Problem**: assume the `title` field is defined like this: `@Field(() => String, { nullable: true }) title?: string;`, indicating that user can skip `title` entirely in an update mutation. However if a user sends `null` explicitly for `title` and you pass the DTO directly to your database: `prisma.author.update({ where: { id: author.id }, data: dto })` your database will throw an error because `null` is not assignable to `title` which is non-nullable.
+>
+> **Solution**: To prevent this from happening you can be more specific when you're defining `title`'s type: `@Field(() => String, {nullable: true}) title?: string | null;`. Now when you're passing your DTO directly to the underlying ORM TS complain that `null` is not assignable to `string`.
 
 > info **Hint** You can also add a description to, or deprecate, the whole object type: `@ObjectType({{ '{' }} description: 'Author model' {{ '}' }})`.
 

--- a/content/graphql/resolvers-map.md
+++ b/content/graphql/resolvers-map.md
@@ -78,11 +78,7 @@ For example:
 title: string;
 ```
 
-> info **Hint** When a field is nullable you need to type it verbosely in order to prevent any runtime issue: `@Field(() => String, {nullable: true}) title?: string | null;`. This particularly important when dealing with parcial updates in your API, especially if the corresponding database field is non-nullable (e.g. `author.title`).
->
-> **Problem**: assume the `title` field is defined like this: `@Field(() => String, { nullable: true }) title?: string;`, indicating that user can skip `title` entirely in an update mutation. However if a user sends `null` explicitly for `title` and you pass the DTO directly to your database: `prisma.author.update({ where: { id: author.id }, data: dto })` your database will throw an error because `null` is not assignable to `title` which is non-nullable.
->
-> **Solution**: To prevent this from happening you can be more specific when you're defining `title`'s type: `@Field(() => String, {nullable: true}) title?: string | null;`. Now when you're passing your DTO directly to the underlying ORM TS complain that `null` is not assignable to `string`.
+> info **Hint** When a field is nullable you need to type it verbosely in order to prevent any runtime issue: `@Field(() => String, {nullable: true}) title?: string | null;`. This particularly important when dealing with parcial updates in your API, especially if the corresponding database field is non-nullable (e.g. `author.title`). **Problem**: assume the `title` field is defined like this: `@Field(() => String, { nullable: true }) title?: string;`, indicating that user can skip `title` entirely in an update mutation. However if a user sends `null` explicitly for `title` and you pass the DTO directly to your database: `prisma.author.update({ where: { id: author.id }, data: dto })` your database will throw an error because `null` is not assignable to `title` which is non-nullable. **Solution**: To prevent this from happening you can be more specific when you're defining `title`'s type: `@Field(() => String, {nullable: true}) title?: string | null;`. Now when you're passing your DTO directly to the underlying ORM TS complain that `null` is not assignable to `string`.
 
 > info **Hint** You can also add a description to, or deprecate, the whole object type: `@ObjectType({{ '{' }} description: 'Author model' {{ '}' }})`.
 

--- a/content/graphql/subscriptions.md
+++ b/content/graphql/subscriptions.md
@@ -34,7 +34,7 @@ GraphQLModule.forRoot<ApolloDriverConfig>({
 
 To create a subscription using the code first approach, we use the `@Subscription()` decorator (exported from the `@nestjs/graphql` package) and the `PubSub` class from the `graphql-subscriptions` package, which provides a simple **publish/subscribe API**.
 
-The following subscription handler takes care of **subscribing** to an event by calling `PubSub#asyncIterator`. This method takes a single argument, the `triggerName`, which corresponds to an event topic name.
+The following subscription handler takes care of **subscribing** to an event by calling `PubSub#asyncIterableIterator`. This method takes a single argument, the `triggerName`, which corresponds to an event topic name.
 
 ```typescript
 const pubSub = new PubSub();
@@ -44,7 +44,7 @@ export class AuthorResolver {
   // ...
   @Subscription(() => Comment)
   commentAdded() {
-    return pubSub.asyncIterator('commentAdded');
+    return pubSub.asyncIterableIterator('commentAdded');
   }
 }
 ```
@@ -68,7 +68,7 @@ Note that subscriptions, by definition, return an object with a single top level
   name: 'commentAdded',
 })
 subscribeToCommentAdded() {
-  return pubSub.asyncIterator('commentAdded');
+  return pubSub.asyncIterableIterator('commentAdded');
 }
 ```
 
@@ -111,7 +111,7 @@ To filter out specific events, set the `filter` property to a filter function. T
     payload.commentAdded.title === variables.title,
 })
 commentAdded(@Args('title') title: string) {
-  return pubSub.asyncIterator('commentAdded');
+  return pubSub.asyncIterableIterator('commentAdded');
 }
 ```
 
@@ -124,7 +124,7 @@ To mutate the published event payload, set the `resolve` property to a function.
   resolve: value => value,
 })
 commentAdded() {
-  return pubSub.asyncIterator('commentAdded');
+  return pubSub.asyncIterableIterator('commentAdded');
 }
 ```
 
@@ -140,7 +140,7 @@ If you need to access injected providers (e.g., use an external service to valid
   }
 })
 commentAdded() {
-  return pubSub.asyncIterator('commentAdded');
+  return pubSub.asyncIterableIterator('commentAdded');
 }
 ```
 
@@ -154,7 +154,7 @@ The same construction works with filters:
   }
 })
 commentAdded() {
-  return pubSub.asyncIterator('commentAdded');
+  return pubSub.asyncIterableIterator('commentAdded');
 }
 ```
 
@@ -170,7 +170,7 @@ export class AuthorResolver {
   // ...
   @Subscription()
   commentAdded() {
-    return pubSub.asyncIterator('commentAdded');
+    return pubSub.asyncIterableIterator('commentAdded');
   }
 }
 ```
@@ -183,7 +183,7 @@ To filter out specific events based on context and arguments, set the `filter` p
     payload.commentAdded.title === variables.title,
 })
 commentAdded() {
-  return pubSub.asyncIterator('commentAdded');
+  return pubSub.asyncIterableIterator('commentAdded');
 }
 ```
 
@@ -194,7 +194,7 @@ To mutate the published payload, we can use a `resolve` function.
   resolve: value => value,
 })
 commentAdded() {
-  return pubSub.asyncIterator('commentAdded');
+  return pubSub.asyncIterableIterator('commentAdded');
 }
 ```
 
@@ -208,7 +208,7 @@ If you need to access injected providers (e.g., use an external service to valid
   }
 })
 commentAdded() {
-  return pubSub.asyncIterator('commentAdded');
+  return pubSub.asyncIterableIterator('commentAdded');
 }
 ```
 
@@ -222,7 +222,7 @@ The same construction works with filters:
   }
 })
 commentAdded() {
-  return pubSub.asyncIterator('commentAdded');
+  return pubSub.asyncIterableIterator('commentAdded');
 }
 ```
 
@@ -369,7 +369,7 @@ GraphQLModule.forRoot<MercuriusDriverConfig>({
 
 To create a subscription using the code first approach, we use the `@Subscription()` decorator (exported from the `@nestjs/graphql` package) and the `PubSub` class from the `mercurius` package, which provides a simple **publish/subscribe API**.
 
-The following subscription handler takes care of **subscribing** to an event by calling `PubSub#asyncIterator`. This method takes a single argument, the `triggerName`, which corresponds to an event topic name.
+The following subscription handler takes care of **subscribing** to an event by calling `PubSub#asyncIterableIterator`. This method takes a single argument, the `triggerName`, which corresponds to an event topic name.
 
 ```typescript
 @Resolver(() => Author)


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

I am proposing these changes to prevent the confusion that I had when I read the doc and add a hint to prevent a common pitfall that you might face in your app. 

Closes https://github.com/nestjs/docs.nestjs.com/issues/3149


## What is the new behavior?

- `nullable`: for specifying whether a field is nullable (in SDL, each field is non-nullable by default); `boolean`  is rephrased like this: `nullable`: for specifying whether a field is nullable (in `@nestjs/graphql`, each field is non-nullable by default); `boolean`.
- And a hint is added (though I am not quite sure if I did a good job at phrasing it).

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
n/a