### PR TITLE
docs: `CacheManagerStore` type in `cache-manager` v6

### DIFF
--- a/content/techniques/caching.md
+++ b/content/techniques/caching.md
@@ -13,7 +13,7 @@ $ npm install @nestjs/cache-manager cache-manager
 > warning **Warning** `cache-manager` version 4 uses seconds for `TTL (Time-To-Live)`. The current version of `cache-manager` (v5) has switched to using milliseconds instead. NestJS doesn't convert the value, and simply forwards the ttl you provide to the library. In other words:
 >
 > - If using `cache-manager` v4, provide ttl in seconds
-> - If using `cache-manager` v5, provide ttl in milliseconds
+> - If using `cache-manager` v5 or later, provide ttl in milliseconds
 > - Documentation is referring to seconds, since NestJS was released targeting version 4 of cache-manager.
 
 #### In-memory cache
@@ -43,6 +43,8 @@ constructor(@Inject(CACHE_MANAGER) private cacheManager: Cache) {}
 ```
 
 > info **Hint** The `Cache` class is imported from the `cache-manager`, while `CACHE_MANAGER` token from the `@nestjs/cache-manager` package.
+
+> warning **Note** For `cache-manager` v6, use the `CacheManagerStore` type instead of the `Cache` class.
 
 The `get` method on the `Cache` instance (from the `cache-manager` package) is used to retrieve items from the cache. If the item does not exist in the cache, `null` will be returned.
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
`cache-manager` v6 does not export `Cache` class, type`CacheManagerStore`  is  [exported](https://github.com/jaredwray/cacheable/blob/main/packages/cache-manager/src/keyv-adapter.ts#L3)  instead
<!-- Please check the one that applies to this PR using "x". --> 


- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
