### PR TITLE
chore(exception-filters): typescript lib version when using cause error

### DIFF
--- a/content/exception-filters.md
+++ b/content/exception-filters.md
@@ -62,6 +62,8 @@ Best practice is to use the `HttpStatus` enum imported from `@nestjs/common`.
 
 There is a **third** constructor argument (optional) - `options` - that can be used to provide an error [cause](https://nodejs.org/en/blog/release/v16.9.0/#error-cause). This `cause` object is not serialized into the response object, but it can be useful for logging purposes, providing valuable information about the inner error that caused the `HttpException` to be thrown.
 
+> warning **Warning** When using NestJS with TypeScript, ensure the lib option or target in your tsconfig.json is set to at least "es2022" to avoid compilation errors.
+
 Here's an example overriding the entire response body and providing an error cause:
 
 ```typescript


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

https://stackoverflow.com/questions/73378375/error-cause-property-not-recognized-in-typescript

the default version of the target when initialize a nest is es2021, and the error cause works in es2022
