### PR TITLE
docs(introduction): Casing and remove extraneous "-" from introduction.md

### DIFF
--- a/content/introduction.md
+++ b/content/introduction.md
@@ -8,7 +8,7 @@ Nest provides a level of abstraction above these common Node.js frameworks (Expr
 
 #### Philosophy
 
-In recent years, thanks to Node.js, JavaScript has become the “lingua franca” of the web for both front and backend applications. This has given rise to awesome projects like [Angular](https://angular.dev/), [React](https://github.com/facebook/react) and [Vue](https://github.com/vuejs/vue), which improve developer productivity and enable the creation of fast, testable, and extensible frontend applications. However, while plenty of superb libraries, helpers, and tools exist for Node (and server-side JavaScript), none of them effectively solve the main problem of - **Architecture**.
+In recent years, thanks to Node.js, JavaScript has become the “lingua franca” of the web for both front and backend applications. This has given rise to awesome projects like [Angular](https://angular.dev/), [React](https://github.com/facebook/react) and [Vue](https://github.com/vuejs/vue), which improve developer productivity and enable the creation of fast, testable, and extensible frontend applications. However, while plenty of superb libraries, helpers, and tools exist for Node (and server-side JavaScript), none of them effectively solve the main problem of **architecture**.
 
 Nest provides an out-of-the-box application architecture which allows developers and teams to create highly testable, scalable, loosely coupled, and easily maintainable applications. The architecture is heavily inspired by Angular.
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

The current introduction.md, visible upon visiting "https://docs.nestjs.com/", contains an extraneous "-" character. Additionally, it would appear the "A" in "Architecture" should not be capitalized.

Though this is certainly not a big issue, I think fixing it in this specific scenario may be justified since the introduction serves as many people's first impression of NestJS.

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?

The "Philosophy" section of the introduction.md reads, ". . .none of them effectively solve the main problem of - **Architecture**."

Issue Number: N/A

## What is the new behavior?

The "Philosophy" section of the introduction.md reads, ". . .none of them effectively solve the main problem of  **architecture**."

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information

N/A
