### PR TITLE
docs(compression): fix wrong import information

### DIFF
--- a/content/techniques/compression.md
+++ b/content/techniques/compression.md
@@ -17,7 +17,7 @@ $ npm i --save compression
 Once the installation is complete, apply the compression middleware as global middleware.
 
 ```typescript
-import * as compression from 'compression';
+import compression from 'compression';
 // somewhere in your initialization file
 app.use(compression());
 ```


### PR DESCRIPTION
The `import * as compression from 'compression'` causes an error because of the wrong importing. this commit will changeit to the correct way `import compression from 'compression'`

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The docs has the old information of importing the compression package which causes the problem mentioned in the following issue.
Issue Number: [#13555](https://github.com/nestjs/nest/issues/13555)


## What is the new behavior?
The docs contain the correct information for importing the compression package.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
