### PR TITLE
chore: remove deprecated import

### DIFF
--- a/content/graphql/complexity.md
+++ b/content/graphql/complexity.md
@@ -19,12 +19,13 @@ $ npm install --save graphql-query-complexity
 Once the installation process is complete, we can define the `ComplexityPlugin` class:
 
 ```typescript
-import { GraphQLSchemaHost } from "@nestjs/graphql";
-import { Plugin } from "@nestjs/apollo";
+import { GraphQLSchemaHost } from '@nestjs/graphql';
+import { Plugin } from '@nestjs/apollo';
 import {
   ApolloServerPlugin,
+  BaseContext,
   GraphQLRequestListener,
-} from 'apollo-server-plugin-base';
+} from '@apollo/server';
 import { GraphQLError } from 'graphql';
 import {
   fieldExtensionsEstimator,
@@ -36,7 +37,7 @@ import {
 export class ComplexityPlugin implements ApolloServerPlugin {
   constructor(private gqlSchemaHost: GraphQLSchemaHost) {}
 
-  async requestDidStart(): Promise<GraphQLRequestListener> {
+  async requestDidStart(): Promise<GraphQLRequestListener<BaseContext>> {
     const maxComplexity = 20;
     const { schema } = this.gqlSchemaHost;
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
![image](https://github.com/user-attachments/assets/e1b3a69a-c0e1-455e-a25d-66ca774c23a9)
Import from a deprecated lib.

Issue Number: https://github.com/nestjs/docs.nestjs.com/issues/3167


## What is the new behavior?
- Import from `@apollo/server`.
- Prettier converted single quote to double quote.
- I had to pass context type to `GraphQLRequestListener`.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
N/A.