### PR TITLE
fix: Copy Icon is not restoring back from right tick ,when Copied

### DIFF
--- a/src/app/shared/components/copy-button/copy-button.component.ts
+++ b/src/app/shared/components/copy-button/copy-button.component.ts
@@ -29,6 +29,7 @@ export class CopyButtonComponent implements OnDestroy {
     this.revertIconTimeout = setTimeout(() => {
       this.copied = false;
       this.cdr.detectChanges();
+      this.revertIconTimeout = null;
     }, 2000);
   }
   

--- a/src/app/shared/components/copy-button/copy-button.component.ts
+++ b/src/app/shared/components/copy-button/copy-button.component.ts
@@ -31,6 +31,7 @@ export class CopyButtonComponent implements OnDestroy {
       this.cdr.detectChanges();
     }, 2000);
   }
+  
   ngOnDestroy(): void {
     if (this.revertIconTimeout) {
       clearTimeout(this.revertIconTimeout);

--- a/src/app/shared/components/copy-button/copy-button.component.ts
+++ b/src/app/shared/components/copy-button/copy-button.component.ts
@@ -1,13 +1,21 @@
-import { Component, ElementRef, inject } from '@angular/core';
+import {
+  Component,
+  ElementRef,
+  inject,
+  ChangeDetectorRef,
+  OnDestroy,
+} from '@angular/core';
 
 @Component({
   selector: 'app-copy-button',
   templateUrl: './copy-button.component.html',
   styleUrls: ['./copy-button.component.scss'],
 })
-export class CopyButtonComponent {
+export class CopyButtonComponent implements OnDestroy {
   public elRef = inject<ElementRef<HTMLElement>>(ElementRef<HTMLElement>);
   public copied = false;
+  public cdr = inject<ChangeDetectorRef>(ChangeDetectorRef);
+  private revertIconTimeout: ReturnType<typeof setTimeout | null> = null;
 
   onCopy() {
     const preRef = this.elRef.nativeElement.querySelector('pre:not(.hide)');
@@ -16,5 +24,16 @@ export class CopyButtonComponent {
     }
     navigator.clipboard.writeText(preRef.firstChild.textContent);
     this.copied = true;
+    this.cdr.detectChanges();
+
+    this.revertIconTimeout = setTimeout(() => {
+      this.copied = false;
+      this.cdr.detectChanges();
+    }, 2000);
+  }
+  ngOnDestroy(): void {
+    if (this.revertIconTimeout) {
+      clearTimeout(this.revertIconTimeout);
+    }
   }
 }


### PR DESCRIPTION
Fixes #3177 

## PR Type
Bug

## What is the current behavior?
Currently, It is copying and then not restoring back to copy icon after some timeout

Issue Number: #3177 

## What is the new behavior?
Now, I have added the setTimeout to 2s to toggle back to copy icon.

