### PR TITLE
docs(techniques): Make the use of ObjectId less ambiguous

### DIFF
--- a/content/techniques/mongo.md
+++ b/content/techniques/mongo.md
@@ -89,6 +89,27 @@ In case there are multiple owners, your property configuration should look as fo
 owners: Owner[];
 ```
 
+If you do not plan on always populating a reference to another collection, you should consider using `mongoose.Types.ObjectId` as the type instead:
+
+```typescript
+@Prop({ type: { type: mongoose.Schema.Types.ObjectId, ref: 'Owner' } })
+// This is crucial to not confuse the field with a populated reference
+owner: mongoose.Types.ObjectId;
+```
+
+Then when you want to selectively populate it later, you can make use of a repository function that specifies the correct type:
+
+```typescript
+import { Owner } from './schemas/owner.schema';
+
+// e.g. inside a service or repository
+async findAllPopulated() {
+  return this.catModel.find().populate<{ owner: Owner }>("owner");
+}
+```
+
+> info **Hint** If there is no foreign document to populate, the type might be `Owner | null` depending on your (mongoose configuration)[https://mongoosejs.com/docs/populate.html#doc-not-found], or it might throw, in which case the type will be `Owner`.
+
 Finally, the **raw** schema definition can also be passed to the decorator. This is useful when, for example, a property represents a nested object which is not defined as a class. For this, use the `raw()` function from the `@nestjs/mongoose` package, as follows:
 
 ```typescript


### PR DESCRIPTION
Clarify how to get better typesafety when using `mongoose.Schema.Types.ObjectId` as a type in `@Prop()`

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
I want clear up some documentation that I think is confusing to people that are new to typescript / nestjs / mongoose.

I think it was not clear enough what the correct type should be if people choose to not populate the references on mongoose schemas.

I added some examples and comments about how you might go about adding `mongoose.Schema.Types.ObjectId`s to the schemas if you don't plan on always populating those.

Thank you for a lovely library.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
