### PR TITLE
docs(swc): add vitest alias resolution configuration

### DIFF
--- a/content/recipes/swc.md
+++ b/content/recipes/swc.md
@@ -280,6 +280,12 @@ export default defineConfig({
       module: { type: 'es6' },
     }),
   ],
+  resolve: {
+    alias: {
+      // Ensure Vitest correctly resolves TypeScript path aliases
+      'src': resolve(__dirname, './src'),
+    },
+  },
 });
 ```
 
@@ -326,6 +332,23 @@ export default defineConfig({
 });
 ```
 
+### Handling Path Aliases in Vitest
+
+Unlike Jest, Vitest does not automatically resolve TypeScript path aliases like `src/`. This may lead to dependency resolution errors during testing. To resolve this issue, add the following `resolve.alias` configuration in your `vitest.config.ts` file:
+
+```ts
+import { resolve } from 'path';
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      'src': resolve(__dirname, './src'),
+    },
+  },
+});
+```
+This ensures that Vitest correctly resolves module imports, preventing errors related to missing dependencies.
+
 #### Update imports in E2E tests
 
 Change any E2E test imports using `import * as request from 'supertest'` to `import request from 'supertest'`. This is necessary because Vitest, when bundled with Vite, expects a default import for supertest. Using a namespace import may cause issues in this specific setup.
@@ -343,6 +366,7 @@ Lastly, update the test scripts in your package.json file to the following:
   }
 }
 ```
+
 
 These scripts configure Vitest for running tests, watching for changes, generating code coverage reports, and debugging. The test:e2e script is specifically for running E2E tests with a custom configuration file.
 

--- a/content/recipes/swc.md
+++ b/content/recipes/swc.md
@@ -332,7 +332,7 @@ export default defineConfig({
 });
 ```
 
-### Handling Path Aliases in Vitest
+### Path aliases
 
 Unlike Jest, Vitest does not automatically resolve TypeScript path aliases like `src/`. This may lead to dependency resolution errors during testing. To resolve this issue, add the following `resolve.alias` configuration in your `vitest.config.ts` file:
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?

Vitest does not automatically resolve TypeScript path aliases (`src/`), unlike Jest, which uses `moduleNameMapper`. 
This can lead to dependency resolution errors when running tests

Issue Number: https://github.com/nestjs/nest/issues/14653


## What is the new behavior?

- Updated the SWC documentation to include a fix for Vitest path alias resolution.
- Added `resolve.alias` configuration in `vitest.config.ts` to ensure correct module resolution.
- Explained why Vitest requires explicit path alias configuration, improving clarity for users.
- Ensured consistency with Jest’s `moduleNameMapper` behavior.



## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No



## Other information

This PR improves the official documentation by adding an alias resolution configuration to prevent common Vitest issues when running tests in NestJS projects. This ensures a smoother developer experience and avoids dependency resolution errors.
