### PR TITLE
docs(swagger): add ui/raws description, hint

### DIFF
--- a/content/openapi/introduction.md
+++ b/content/openapi/introduction.md
@@ -197,7 +197,6 @@ export interface SwaggerCustomOptions {
    */
   raw?: boolean | Array<'json' | 'yaml'>;
 
-
   /**
    * Url point the API definition to load in Swagger UI.
    */

--- a/content/openapi/introduction.md
+++ b/content/openapi/introduction.md
@@ -287,8 +287,7 @@ export interface SwaggerCustomOptions {
 
 }
 ```
-> info **Hint** `ui` and `raw` are independent options. Disabling Swagger UI (`ui: false`) does not disable API definitions (JSON/YAML).  
-> Conversely, disabling API definitions (`raw: []`) does not disable the Swagger UI.  
+> info **Hint** `ui` and `raw` are independent options. Disabling Swagger UI (`ui: false`) does not disable API definitions (JSON/YAML).  Conversely, disabling API definitions (`raw: []`) does not disable the Swagger UI.  
 >
 > For example, the following configuration will disable the Swagger UI but still allow access to API definitions:
 > ```typescript

--- a/content/openapi/introduction.md
+++ b/content/openapi/introduction.md
@@ -174,11 +174,29 @@ export interface SwaggerCustomOptions {
   useGlobalPrefix?: boolean;
 
   /**
-   * If `false`, only API definitions (JSON and YAML) will be served (on `/{path}-json` and `/{path}-yaml`).
-   * This is particularly useful if you are already hosting a Swagger UI somewhere else and just want to serve API definitions.
+   * If `false`, the Swagger UI will not be served. Only API definitions (JSON and YAML)
+   * will be accessible (on `/{path}-json` and `/{path}-yaml`). To fully disable both the Swagger UI and API definitions, use `raw: false`.
    * Default: `true`.
+   * @deprecated Use `ui` instead.
    */
   swaggerUiEnabled?: boolean;
+
+  /**
+   * If `false`, the Swagger UI will not be served. Only API definitions (JSON and YAML)
+   * will be accessible (on `/{path}-json` and `/{path}-yaml`). To fully disable both the Swagger UI and API definitions, use `raw: false`.
+   * Default: `true`.
+   */
+  ui?: boolean;
+
+  /**
+   * If `true`, raw definitions for all formats will be served.
+   * Alternatively, you can pass an array to specify the formats to be served, e.g., `raw: ['json']` to serve only JSON definitions.
+   * If omitted or set to an empty array, no definitions (JSON or YAML) will be served.
+   * Use this option to control the availability of Swagger-related endpoints.
+   * Default: `true`.
+   */
+  raw?: boolean | Array<'json' | 'yaml'>;
+
 
   /**
    * Url point the API definition to load in Swagger UI.
@@ -270,6 +288,20 @@ export interface SwaggerCustomOptions {
 
 }
 ```
+> info **Hint** `ui` and `raw` are independent options. Disabling Swagger UI (`ui: false`) does not disable API definitions (JSON/YAML).  
+> Conversely, disabling API definitions (`raw: []`) does not disable the Swagger UI.  
+>
+> For example, the following configuration will disable the Swagger UI but still allow access to API definitions:
+> ```typescript
+>const options: SwaggerCustomOptions = {
+>    ui: false, // Swagger UI is disabled
+>    raw: ['json'], // JSON API definition is still accessible (YAML is disabled)
+>};
+>SwaggerModule.setup('api', app, options);
+> ```
+>
+> In this case, http://localhost:3000/api-json will still be accessible, but http://localhost:3000/api (Swagger UI) will not.
+
 
 #### Example
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
Currently, the Swagger documentation does not provide a clear explanation of how the ui and raw options work independently. Users might assume that disabling the Swagger UI (ui: false) also disables JSON/YAML documentation or vice versa.

Issue Number: N/A


## What is the new behavior?

This PR is an document update for the changes below.

https://github.com/nestjs/swagger/pull/3185
https://github.com/nestjs/swagger/commit/675a0272ca3d60db716ee97bf17012dddfe38637

- Added a new section under Setup options explaining how ui and raw interact.
- Provided an example configuration demonstrating a case where the UI is disabled but JSON definitions remain available.
- Clarified Swagger UI and JSON/YAML accessibility behavior when different combinations of ui and raw are used.
- Improved readability by structuring explanations in a more user-friendly way.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No