### PR TITLE
docs (mongo): update in subdocuments

### DIFF
--- a/content/techniques/mongo.md
+++ b/content/techniques/mongo.md
@@ -624,7 +624,7 @@ export class Person {
 export const PersonSchema = SchemaFactory.createForClass(Person);
 
 export type PersonDocumentOverride = {
-  name: Types.Subdocument<Types.ObjectId & Name>;
+  name: Types.Subdocument<Types.ObjectId> & Name;
 };
 
 export type PersonDocument = HydratedDocument<Person, PersonDocumentOverride>;


### PR DESCRIPTION
Fixa misleading type annotation error in the subdocuements section of the documentation when defining a type override for the parent document

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

In the documentation page for Mongoose [here](https://docs.nestjs.com/techniques/mongodb#subdocuments). The Subdocuments section the example shown for how to define a subdocument has a small error that is misleading and causes typescript to complain (rightfuly so). Here is the misleading bit:

```ts
export type PersonDocumentOverride = {
  name: Types.Subdocument<Types.ObjectId & Name>;
};
```

The correct example is taken directly from the mongoose docs [here](https://mongoosejs.com/docs/6.x/docs/typescript/subdocuments.html) where we can find this
```ts
type UserDocumentOverrides = {
  names: Types.Subdocument<Types.ObjectId> & Names; // the difference is where the & operation is performed
};
```

## What is the new behavior?

The information is adjusted according to what was found from the mongoose docs.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
