### PR TITLE
docs(queues): fix undeclared loop variable and progress method in example

### DIFF
--- a/content/techniques/queues.md
+++ b/content/techniques/queues.md
@@ -218,10 +218,10 @@ import { Job } from 'bullmq';
 export class AudioConsumer extends WorkerHost {
   async process(job: Job<any, any, string>): Promise<any> {
     let progress = 0;
-    for (i = 0; i < 100; i++) {
+    for (let i = 0; i < 100; i++) {
       await doSomething(job.data);
       progress += 1;
-      await job.progress(progress);
+      await job.updateProgress(progress);
     }
     return {};
   }


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines

## PR Type
- [x] Docs

## What is the current behavior?
The BullMQ queue example contains two issues:
1. Undeclared loop variable `i` in `for` loop
2. Incorrect `job.progress()` method instead of `job.updateProgress()`

## What is the new behavior?
- Declares loop variable with `let i`
- Uses correct `job.updateProgress()` method

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No