### PR TITLE
docs(cli-plugin): update documentation for skipAutoHttpCode option

### DIFF
--- a/content/openapi/cli-plugin.md
+++ b/content/openapi/cli-plugin.md
@@ -153,7 +153,8 @@ You can use the `options` property to customize the behavior of the plugin.
         "name": "@nestjs/swagger",
         "options": {
           "classValidatorShim": false,
-          "introspectComments": true
+          "introspectComments": true,
+          "skipAutoHttpCode": true
         }
       }
     ]
@@ -171,6 +172,7 @@ export interface PluginOptions {
   dtoKeyOfComment?: string;
   controllerKeyOfComment?: string;
   introspectComments?: boolean;
+  skipAutoHttpCode?: boolean;
 }
 ```
 
@@ -209,6 +211,11 @@ export interface PluginOptions {
     <td><code>introspectComments</code></td>
     <td><code>false</code></td>
     <td>If set to true, plugin will generate descriptions and example values for properties based on comments</td>
+  </tr>
+  <tr>
+    <td><code>skipAutoHttpCode</code></td>
+    <td><code>false</code></td>
+    <td>Disables the automatic addition of <code>@HttpCode()</code> in controllers</td>
   </tr>
 </table>
 


### PR DESCRIPTION
## Summary
Updates the outdated `@nestjs/swagger/plugin` CLI options table to reflect the latest changes introduced in https://github.com/nestjs/swagger/pull/3151.

## Changes
- Added `skipAutoHttpCode` option to `cli-plugin.md`
- Updated the options table with `skipAutoHttpCode`
- Provided an example JSON configuration for `nest-cli.json`

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #3221

## What is the new behavior?
This PR updates the documentation to reflect the new `skipAutoHttpCode` option introduced in [#3151](https://github.com/nestjs/swagger/pull/3151)
- The `@nestjs/swagger/plugin` now supports disabling automatic `@HttpCode()` annotation by setting `"skipAutoHttpCode": true`.
- The CLI Plugin documentation has been updated to include this option in the options table.
- A JSON example has been provided to demonstrate how to configure this option in `nest-cli.json`.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
