### PR TITLE
Typo in CQRS doc

### DIFF
--- a/content/recipes/cqrs.md
+++ b/content/recipes/cqrs.md
@@ -494,7 +494,7 @@ Using request-scoped providers alongside CQRS can be complex because the `Comman
 To make a handler request-scoped, you can either:
 
 1. Depend on a request-scoped provider.
-2. Explicitly set its scope to `REQUEST` using the `@CommandHandler`, `@QueryHandler`, or `@EventHandler` decorator, as shown:
+2. Explicitly set its scope to `REQUEST` using the `@CommandHandler`, `@QueryHandler`, or `@EventsHandler` decorator, as shown:
 
 ```typescript
 @CommandHandler(KillDragonCommand, {


### PR DESCRIPTION
`@EventsHandler` and not `@EventHandler`

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [x] Other... Please describe: Typo fix


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
