### PR TITLE
docs(openapi): add explicit type for single file upload

### DIFF
--- a/content/openapi/operations.md
+++ b/content/openapi/operations.md
@@ -138,7 +138,7 @@ You can enable file upload for a specific method with the `@ApiBody` decorator t
   description: 'List of cats',
   type: FileUploadDto,
 })
-uploadFile(@UploadedFile() file) {}
+uploadFile(@UploadedFile() file: Express.Multer.File) {}
 ```
 
 Where `FileUploadDto` is defined as follows:


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [X] Docs
- [ ] Other... Please describe:


## What is the current behavior?
The type of `file` is not specified.

## What is the new behavior?
Added the type explicitly for clarity.

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
