### PR TITLE
fix(docs): remove hardcoded ".ts" suffix from main file reference in trust proxy example

### DIFF
--- a/content/security/rate-limiting.md
+++ b/content/security/rate-limiting.md
@@ -112,7 +112,7 @@ If your application is running behind a proxy server, it’s essential to config
 Here's an example that demonstrates how to enable `trust proxy` for the Express adapter:
 
 ```typescript
-@@filename(main.ts)
+@@filename(main)
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { NestExpressApplication } from '@nestjs/platform-express';


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [X] Docs
- [ ] Other... Please describe:


## What is the current behavior?
Fix incorrect filename extension in "trust proxy" example under Security > Rate Limiting
The example hardcodes the ".ts" suffix when referencing the "main" file, resulting in incorrect filenames like "main.ts.ts" or "main.ts.js". This commit removes the fixed suffix to ensure correct file resolution based on the context.

Issue Number: N/A


## What is the new behavior?
The updated example now aligns with the behavior of other code examples in the documentation by dynamically adjusting the filename between ".js" and ".ts", depending on the context. This prevents incorrect filenames like "main.ts.ts" or "main.ts.js" and ensures consistency across the documentation.


## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
