### PR TITLE
docs(migration): add slash for Express named wildcard

### DIFF
--- a/content/migration.md
+++ b/content/migration.md
@@ -51,10 +51,10 @@ forRoutes('*'); // <-- This should not work in Express v5
 Instead, you can update the path to use a named wildcard:
 
 ```typescript
-forRoutes('{*splat}'); // <-- This will work in Express v5
+forRoutes('/{*splat}'); // <-- This will work in Express v5
 ```
 
-Note that `{{ '{' }}*splat&#125;` is a named wildcard that matches any path including the root path. Outer braces make path optional.
+Note that `{{ '{' }}*splat&#125;` is a named wildcard that matches any path without the root path. Outer braces make path optional.
 
 #### Query parameters parsing
 


### PR DESCRIPTION
Add slash for Express route matching syntax

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
Incorrect mentioning of `{*splat}` that it is a named wildcard that matches any path including the root path. It actually does not include the root path. See the [Express migration docs](https://expressjs.com/en/guide/migrating-5.html#path-syntax)

Issue Number: N/A


## What is the new behavior?
Adding a slash in the example, and mentioning that it doesn't include the root path.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
