### PR TITLE
docs(versioning): remove redundant bracket

### DIFF
--- a/content/techniques/versioning.md
+++ b/content/techniques/versioning.md
@@ -107,7 +107,7 @@ For example, if an incoming request specifies it supports versions `1`, `2`, and
 If versions `[3, 2, 1]` are extracted, but routes only exist for version `2` and `1`, the route that matches version `2`
 is selected (version `3` is automatically ignored).
 
-> warning **Notice** Selecting the highest matching version based on the array returned from `extractor` > **does not reliably work** with the Express adapter due to design limitations. A single version (either a string or
+> warning **Notice** Selecting the highest matching version based on the array returned from `extractor` **does not reliably work** with the Express adapter due to design limitations. A single version (either a string or
 > array of 1 element) works just fine in Express. Fastify correctly supports both highest matching version
 > selection and single version selection.
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md

## Description
There is a redundant `>`  bracket in the Versioning article. It's a result of commit https://github.com/nestjs/docs.nestjs.com/commit/a722d1e4b305be0b8a5bb04ba4065253ead37df6 and I think that it should be removed :)

![screenshot](https://github.com/user-attachments/assets/37e599e3-862e-4848-af4a-e57ffbafa5e4)

