### PR TITLE
docs(changelog): fix typo prodocuer to producer

### DIFF
--- a/content/microservices/kafka.md
+++ b/content/microservices/kafka.md
@@ -617,7 +617,7 @@ server.status.subscribe((status: KafkaStatus) => {
 
 #### Underlying producer and consumer
 
-For more advanced use cases, you may need to access the underlying prodocuer and consumer instances. This can be useful for scenarios like manually closing the connection or using driver-specific methods. However, keep in mind that for most cases, you **shouldn't need** to access the driver directly.
+For more advanced use cases, you may need to access the underlying producer and consumer instances. This can be useful for scenarios like manually closing the connection or using driver-specific methods. However, keep in mind that for most cases, you **shouldn't need** to access the driver directly.
 
 To do so, you can use `producer` and `consumer` getters exposed by the `ClientKafkaProxy` instance.
 


### PR DESCRIPTION
docs(changelog): change from prodocuer to producer

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

It fixes a typo in the documentation for kafka

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
The word producer is misspelt as prodocuer

Issue Number: N/A


## What is the new behavior?
Fixed the typo

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information
