### PR TITLE
docs(migration-guide): update hint for global module initalization

### DIFF
--- a/content/migration.md
+++ b/content/migration.md
@@ -178,7 +178,7 @@ While the `OnModuleDestroy` hooks are executed in the reverse order:
 A -> B -> C
 ```
 
-> info **Hint** Global modules are treated as if they depend on all other modules. This means that global modules are initialized first and destroyed last.
+> info **Hint** Global modules are treated as a dependency of all other modules. This means that global modules are initialized first and destroyed last.
 
 #### Middleware registration order
 


### PR DESCRIPTION
The hint for global module initialization is invalid. Global modules not treated as if they depend on all other modules. Instead, all other modules are treated as if they depend on global modules.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md

## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No
