### PR TITLE
fix: update the custom microservices example to complete the callback

### DIFF
--- a/content/microservices/custom-transport.md
+++ b/content/microservices/custom-transport.md
@@ -192,7 +192,13 @@ class GoogleCloudPubSubClient extends ClientProxy {
     // In a real-world application, the "callback" function should be executed
     // with payload sent back from the responder. Here, we'll simply simulate (5 seconds delay)
     // that response came through by passing the same "data" as we've originally passed in.
-    setTimeout(() => callback({ response: packet.data }), 5000);
+    //
+    // The "isDisposed" bool on the WritePacket tells the response that no further data is
+    // expected. If not sent or is false, this will simply emit data to the Observable.
+    setTimeout(() => callback({ 
+      response: packet.data,
+      isDisposed: true,
+    }), 5000);
 
     return () => console.log('teardown');
   }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

The example in the docs never resolves due to the `isDisposed` boolean not being set.

I can't find any concrete documentation on this, but it appears that it's required to tell the `publish` method to resolve. Without it, the example runs the initial `console.log` and returns the packet data to the `Observable`, but the teardown never happens.


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
