### PR TITLE
docs(events): Remove await from eventEmitter.emit example

### DIFF
--- a/content/techniques/events.md
+++ b/content/techniques/events.md
@@ -149,7 +149,7 @@ To avoid this issue, you can use the `waitUntilReady` method of the `EventEmitte
 
 ```typescript
 await this.eventEmitterReadinessWatcher.waitUntilReady();
-await this.eventEmitter.emit(
+this.eventEmitter.emit(
   'order.created',
   new OrderCreatedEvent({ orderId: 1, payload: {} }),
 );


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
Documentation is indicating a synchronous method call with unnecessary `await` keyword.

Issue Number: N/A


## What is the new behavior?
Documentation is a little more "accurate", as a synchronous function does not need `await` keyword during call.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


