### PR TITLE
fix(unit-testing.md): unit-testing.md to use MockMetadata from jest-mock 30+

### DIFF
--- a/content/fundamentals/unit-testing.md
+++ b/content/fundamentals/unit-testing.md
@@ -166,7 +166,7 @@ Nest also allows you to define a mock factory to apply to all of your missing de
 
 ```typescript
 // ...
-import { ModuleMocker, MockFunctionMetadata } from 'jest-mock';
+import { ModuleMocker, MockMetadata } from 'jest-mock';
 
 const moduleMocker = new ModuleMocker(global);
 
@@ -185,7 +185,7 @@ describe('CatsController', () => {
         if (typeof token === 'function') {
           const mockMetadata = moduleMocker.getMetadata(
             token,
-          ) as MockFunctionMetadata<any, any>;
+          ) as MockMetadata<any, any>;
           const Mock = moduleMocker.generateFromMetadata(mockMetadata);
           return new Mock();
         }


### PR DESCRIPTION
unit-testing.md referenced MockFunctionMetadata, which was removed in version 30 of jest-mock. This commit changes references of MockFunctionMetadata to MockMetadata, updating it to work with the newer versions of jest-mock.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
unit-testing.md refers to MockFunctionMetadata, which has been removed in jest-mock version 30.

Issue Number: #15309 (in @nestjs/nest)


## What is the new behavior?
unit-testing.md now refers to MockMetadata, allowing the example code to proceed.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
