### PR TITLE
fix(unit-testing.md): Auto mocking is now appropriately typed.

### DIFF
--- a/content/fundamentals/unit-testing.md
+++ b/content/fundamentals/unit-testing.md
@@ -186,7 +186,9 @@ describe('CatsController', () => {
           const mockMetadata = moduleMocker.getMetadata(
             token,
           ) as MockMetadata<any, any>;
-          const Mock = moduleMocker.generateFromMetadata(mockMetadata);
+          const Mock = moduleMocker.generateFromMetadata(
+            mockMetadata,
+          ) as ObjectConstructor;
           return new Mock();
         }
       })


### PR DESCRIPTION
NestJS 11's stricter linting threw a bunch of no-unsafe-* errors. This commit makes the linter happy.

Fixes #3288

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #3288

## What is the new behavior?

Using appropriate type, so that the linter doesn't think it's unsafe.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
