### PR TITLE
docs: missing super() call in constructor

### DIFF
--- a/content/recipes/cqrs.md
+++ b/content/recipes/cqrs.md
@@ -89,7 +89,9 @@ export class KillDragonCommand extends Command<{
   constructor(
     public readonly heroId: string,
     public readonly dragonId: string,
-  ) {}
+  ) {
+    super();
+  }
 }
 @@switch
 export class KillDragonCommand extends Command {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
In the [CQRS documentation](https://docs.nestjs.com/recipes/cqrs), the `KillDragonCommand` class is shown extending the `Command<{ actionId: string }>` class, with a custom constructor:


```ts
export class KillDragonCommand extends Command<{ actionId: string }> {
  constructor(
    public readonly heroId: string,
    public readonly dragonId: string,
  ) {}
}
```

However, this constructor does not include a super() call.

This works only because the Command class from @nestjs/cqrs has no constructor. But if a developer defines their own custom Command<T> class with a constructor, TypeScript will throw error TS2377:

`Constructors for derived classes must contain a 'super' call.`

This can lead to confusion.

Issue Number: N/A


## What is the new behavior?

To improve clarity and prevent confusion, I suggest:

Adding a `super()` call in the constructor of the example.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
