### PR TITLE
fix(docs): enable fragment navigation and anchor linking (#3291)

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,6 +1,7 @@
 import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
 import { Meta, Title } from '@angular/platform-browser';
 import { ActivatedRoute, NavigationEnd, Router } from '@angular/router';
+import { ViewportScroller } from '@angular/common';
 import { filter } from 'rxjs/operators';
 import { HOMEPAGE_TITLE, TITLE_SUFFIX } from './constants';
 
@@ -17,6 +18,7 @@ export class AppComponent implements OnInit {
     private readonly metaService: Meta,
     private readonly router: Router,
     private readonly activatedRoute: ActivatedRoute,
+    private readonly viewportScroller: ViewportScroller,
   ) {}
 
   async ngOnInit() {
@@ -25,6 +27,7 @@ export class AppComponent implements OnInit {
       .subscribe((ev: NavigationEnd) => {
         this.updateTitle();
         this.updateMeta(ev);
+        this.handleFragmentScroll(ev);
       });
   }
 
@@ -56,6 +59,22 @@ export class AppComponent implements OnInit {
     } else if (this.robotsElement) {
       this.metaService.removeTagElement(this.robotsElement);
       this.robotsElement = undefined;
+    }
+  }
+
+  private handleFragmentScroll(event: NavigationEnd) {
+    const fragment = event.url.split('#')[1];
+    if (fragment) {
+      setTimeout(() => {
+        const element = document.getElementById(fragment);
+        if (element) {
+          const offsetTop = element.offsetTop - 100;
+          window.scrollTo({
+            top: offsetTop,
+            behavior: 'smooth'
+          });
+        }
+      }, 100);
     }
   }
 }

--- a/src/app/shared/components/toc/toc.component.ts
+++ b/src/app/shared/components/toc/toc.component.ts
@@ -103,7 +103,13 @@ export class TocComponent implements OnInit, OnDestroy, OnChanges {
   }
 
   navigateToAnchor($event: MouseEvent, elementRef: HTMLElement) {
+    $event.preventDefault();
     if (elementRef) {
+      const offsetTop = elementRef.offsetTop - this.scrollTopOffset;
+      window.scrollTo({
+        top: offsetTop,
+        behavior: 'smooth'
+      });
       this.findCurrentHeading();
     }
   }


### PR DESCRIPTION
- Add fragment handling in the app component for direct URL navigation
- Fix TOC anchor navigation with smooth scrolling
- Enable sharing of direct links to specific sections

Fixes #3291

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md

## PR Type
What kind of change does this PR introduce?

- [x] Feature
- [x] Docs

## What is the current behavior?
Fragment navigation (e.g., `/some-page#section`) doesn't work as expected.
TOC links jump abruptly or don't scroll properly.

## What is the new behavior?
- URL fragments now scroll to the correct section on page load
- Users can copy and share links to specific sections
- Clicking TOC entries scrolls smoothly to the section

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information
This improves UX when navigating long docs pages and referencing specific sections.
