### PR TITLE
docs(websockets): clarify @WebSocketServer() with namespace

### DIFF
--- a/content/websockets/gateways.md
+++ b/content/websockets/gateways.md
@@ -244,9 +244,14 @@ server: Server;
 Also, you can retrieve the corresponding namespace using the `namespace` attribute, as follows:
 
 ```typescript
-@WebSocketServer({ namespace: 'my-namespace' })
-namespace: Namespace;
+@WebSocketGateway({ namespace: 'my-namespace' })
+export class EventsGateway {
+  @WebSocketServer()
+  namespace: Namespace;
+}
 ```
+
+`@WebSocketServer()` decorator injects a server instance by referencing the metadata stored by the `@WebSocketGateway()` decorator. If you provide the namespace option to the `@WebSocketGateway()` decorator, `@WebSocketServer()` decorator returns a `Namespace` instance instead of a `Server` instance.
 
 > warning **Notice** The `@WebSocketServer()` decorator is imported from the `@nestjs/websockets` package.
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The documentation does not explain that the type of the instance injected into the `@WebSocketServer()` decorator changes when the `namespace` option is used in the `@WebSocketGateway()` decorator.

Issue Number: #2934


## What is the new behavior?

The documentation now explains how the type of the instance injected into the `@WebSocketServer()` decorator changes when using the `namespace` option in the `@WebSocketGateway()` decorator.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
