### PR TITLE
docs: fix import clarification for Cache and CACHE_MANAGER

### DIFF
--- a/content/techniques/caching.md
+++ b/content/techniques/caching.md
@@ -38,7 +38,7 @@ To interact with the cache manager instance, inject it to your class using the `
 constructor(@Inject(CACHE_MANAGER) private cacheManager: Cache) {}
 ```
 
-> info **Hint** The `Cache` class is imported from the `cache-manager`, while `CACHE_MANAGER` token from the `@nestjs/cache-manager` package.
+> info **Hint** The `Cache` class and the `CACHE_MANAGER` token are both imported from the `@nestjs/cache-manager` package.
 
 The `get` method on the `Cache` instance (from the `cache-manager` package) is used to retrieve items from the cache. If the item does not exist in the cache, `null` will be returned.
 


### PR DESCRIPTION
## PR Checklist
  Please check if your PR fulfills the following requirements:

  - [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


  ## PR Type
  What kind of change does this PR introduce?

  <!-- Please check the one that applies to this PR using "x". -->

  - [ ] Bugfix
  - [ ] Feature
  - [ ] Code style update (formatting, local variables)
  - [ ] Refactoring (no functional changes, no api changes)
  - [ ] Build related changes
  - [x] Docs
  - [ ] Other... Please describe:


  ## What is the current behavior?
  <!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

  Issue Number: N/A

  The documentation incorrectly states that the `Cache` class is imported from `cache-manager` while the `CACHE_MANAGER` token is imported from `@nestjs/cache-manager` package.

  ## What is the new behavior?

  Clarifies that both the `Cache` class and `CACHE_MANAGER` token are imported from the `@nestjs/cache-manager` package.

  ## Does this PR introduce a breaking change?
  - [ ] Yes
  - [x] No


  <!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


  ## Other information

  This is a minor documentation fix to improve accuracy and clarity for developers using NestJS caching.
