### PR TITLE
Fix TypeORM documentation link for entities

### DIFF
--- a/content/techniques/sql.md
+++ b/content/techniques/sql.md
@@ -113,7 +113,7 @@ export class User {
 }
 ```
 
-> info **Hint** Learn more about entities in the [TypeORM documentation](https://typeorm.io/#/entities).
+> info **Hint** Learn more about entities in the [TypeORM documentation](https://typeorm.io/docs/entity/entities/).
 
 The `User` entity file sits in the `users` directory. This directory contains all files related to the `UsersModule`. You can decide where to keep your model files, however, we recommend creating them near their **domain**, in the corresponding module directory.
 


### PR DESCRIPTION
This is a simple adjustment to `content/techniques/sql.md` reference to TypeORM's entities documentation, making the Repository Pattern section hint block correctly point to TypeORM's Entities article page.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?

- The hint card on `https://docs.nestjs.com/techniques/database#repository-pattern` points to a TypeORM url that seems to not exist, which causes it to redirect to TypeORM's homepage:

https://github.com/user-attachments/assets/0dab67ed-6ae0-4736-9e19-f17df64a0e46

## What is the new behavior?

- The hint card on `https://docs.nestjs.com/techniques/database#repository-pattern` should point to [TypeORM's entities page](https://typeorm.io/docs/entity/entities/).

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No
