### PR TITLE
docs: fix TypeORM entities page url reference on sql.md

### DIFF
--- a/content/techniques/sql.md
+++ b/content/techniques/sql.md
@@ -113,7 +113,7 @@ export class User {
 }
 ```
 
-> info **Hint** Learn more about entities in the [TypeORM documentation](https://typeorm.io/#/entities).
+> info **Hint** Learn more about entities in the [TypeORM documentation](https://typeorm.io/docs/entity/entities/).
 
 The `User` entity file sits in the `users` directory. This directory contains all files related to the `UsersModule`. You can decide where to keep your model files, however, we recommend creating them near their **domain**, in the corresponding module directory.
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

- The hint card on `https://docs.nestjs.com/techniques/database#repository-pattern` points to a TypeORM url that redirects to TypeORM's homepage instead of the entities docs:

https://github.com/user-attachments/assets/0dab67ed-6ae0-4736-9e19-f17df64a0e46

Issue Number: N/A


## What is the new behavior?

- The hint card on `https://docs.nestjs.com/techniques/database#repository-pattern` should point to [TypeORM's entities page](https://typeorm.io/docs/entity/entities/) instead.

https://github.com/user-attachments/assets/35c99972-eab2-4fc5-b634-a1682fd59352


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
