### PR TITLE
docs(mongo): pass ref in PropOptions root

### DIFF
--- a/content/techniques/mongo.md
+++ b/content/techniques/mongo.md
@@ -85,14 +85,14 @@ owner: Owner;
 In case there are multiple owners, your property configuration should look as follows:
 
 ```typescript
-@Prop({ type: [{ type: mongoose.Schema.Types.ObjectId, ref: 'Owner' }] })
+@Prop({ type: [{ type: mongoose.Schema.Types.ObjectId }], ref: 'Owner' })
 owners: Owner[];
 ```
 
 If you don’t intend to always populate a reference to another collection, consider using `mongoose.Types.ObjectId` as the type instead:
 
 ```typescript
-@Prop({ type: { type: mongoose.Schema.Types.ObjectId, ref: 'Owner' } })
+@Prop({ type: mongoose.Schema.Types.ObjectId, ref: 'Owner' })
 // This ensures the field is not confused with a populated reference
 owner: mongoose.Types.ObjectId;
 ```


### PR DESCRIPTION
In the mongoose `@Prop` decorator code snippets, the `ref` option is being passed nested inside the `type` option. However, as seen in the [implementation here](https://github.com/nestjs/mongoose/blob/fd26d39a393aadce7451697dea4e7e062b9072df/lib/factories/definitions.factory.ts#L101), ref is expected at the root of `PropOptions`, not nested within `PropOptions.type`.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

`ref` is being passed nested inside `type`, causing population to not work.

## What is the new behavior?

`ref` is being passed correctly, causing population to work correctly.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
