### PR TITLE
docs: fix TypeORM Subscribers section TypeORM link

### DIFF
--- a/content/techniques/sql.md
+++ b/content/techniques/sql.md
@@ -436,7 +436,7 @@ async createMany(users: User[]) {
 
 #### Subscribers
 
-With TypeORM [subscribers](https://typeorm.io/#/listeners-and-subscribers/what-is-a-subscriber), you can listen to specific entity events.
+With TypeORM [subscribers](https://typeorm.io/docs/advanced-topics/listeners-and-subscribers#what-is-a-subscriber), you can listen to specific entity events.
 
 ```typescript
 import {
@@ -483,7 +483,7 @@ import { UserSubscriber } from './user.subscriber';
 export class UsersModule {}
 ```
 
-> info **Hint** Learn more about entity subscribers [here](https://typeorm.io/#/listeners-and-subscribers/what-is-a-subscriber).
+> info **Hint** Learn more about entity subscribers [here](https://typeorm.io/docs/advanced-topics/listeners-and-subscribers#what-is-a-subscriber).
 
 #### Migrations
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

- The **Subscribers** section TypeORM link redirects to the home page of TypeORM's website:


https://github.com/user-attachments/assets/b7b8f2c7-322d-4941-a620-fbda10a21552


Issue Number: N/A


## What is the new behavior?

- The **Subscribers** section TypeORM link redirects to the correct subscribers page on TypeORM's website:


https://github.com/user-attachments/assets/5c4957ee-7832-45e1-a637-12f5848cbbec


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
