### PR TITLE
fix: suites documentation correct import path

### DIFF
--- a/content/recipes/suites.md
+++ b/content/recipes/suites.md
@@ -60,7 +60,7 @@ easily using the `.solitary()` method from `TestBed`.
 ```typescript
 @@filename(cats-http.service.spec)
 import { TestBed } from '@suites/unit';
-import type { Mocked } from "@suites/doubles.jest";
+import type { Mocked } from '@suites/doubles.jest';
 
 describe('Cats Http Service Unit Test', () => {
   let catsHttpService: CatsHttpService;
@@ -196,7 +196,7 @@ And now, let's test `CatsService` using sociable testing with Suites:
 ```typescript
 @@filename(cats.service.spec)
 import { TestBed } from '@suites/unit';
-import type { Mocked } from '@suites/doubles.jest"
+import type { Mocked } from '@suites/doubles.jest';
 import { PrismaClient } from '@prisma/client';
 
 describe('Cats Service Sociable Unit Test', () => {

--- a/content/recipes/suites.md
+++ b/content/recipes/suites.md
@@ -59,7 +59,8 @@ easily using the `.solitary()` method from `TestBed`.
 
 ```typescript
 @@filename(cats-http.service.spec)
-import { TestBed, Mocked } from '@suites/unit';
+import { TestBed } from '@suites/unit';
+import type { Mocked } from "@suites/doubles.jest";
 
 describe('Cats Http Service Unit Test', () => {
   let catsHttpService: CatsHttpService;
@@ -194,7 +195,8 @@ And now, let's test `CatsService` using sociable testing with Suites:
 
 ```typescript
 @@filename(cats.service.spec)
-import { TestBed, Mocked } from '@suites/unit';
+import { TestBed } from '@suites/unit';
+import type { Mocked } from '@suites/doubles.jest"
 import { PrismaClient } from '@prisma/client';
 
 describe('Cats Service Sociable Unit Test', () => {


### PR DESCRIPTION
## Issue Fixed

The `Mocked` type should be imported from `@suites/doubles.jest`, not from `@suites/unit`.

### Before (Incorrect)
```typescript
import { TestBed, Mocked } from "@suites/unit";
```

### After (Correct)
```typescript
import { TestBed } from "@suites/unit";
import type { Mocked } from "@suites/doubles.jest";
```

This fix ensures the code examples in the documentation actually work when developers try to follow them.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The documentation shows incorrect import statements for the `Mocked` type, importing it from `@suites/unit` instead of `@suites/doubles.jest`. This causes compilation errors when developers try to follow the examples.

## What is the new behavior?

The documentation now correctly imports the `Mocked` type from `@suites/doubles.jest`, ensuring that code examples work as expected.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

This is a documentation fix that corrects import paths in the Suites testing framework examples. No functional changes to the codebase.