### PR TITLE
docs(controller): Add missing `type` to express' `Request` import

### DIFF
--- a/content/controllers.md
+++ b/content/controllers.md
@@ -78,7 +78,7 @@ Handlers often need access to the client’s **request** details. Nest provides 
 ```typescript
 @@filename(cats.controller)
 import { Controller, Get, Req } from '@nestjs/common';
-import { Request } from 'express';
+import type { Request } from 'express';
 
 @Controller('cats')
 export class CatsController {


### PR DESCRIPTION
Hi, 

I'm following the official docs to learn Nest.js, and in the `Controllers` docs the snippet introducing `Request object` didn't compile  in `app.controllers.ts` when doing `npm run start:dev` with the following error:

```
src/app.controller.ts:15:24 - error TS1272: A type referenced in a decorated signature must be imported with 'import type' or a namespace import when 'isolatedModules' and 'emitDecoratorMetadata' are enabled.

15   test(@Req() request: Request): string {
                          ~~~~~~~

  src/app.controller.ts:3:10
    3 import { Request } from 'express';
               ~~~~~~~
    'Request' was imported here.
```

Error was fixed when I added `type` to the import.

Using Node.js v24.8.0 and Nest.js 11.0.10, bootstrapped from the official CLI with `nest new <app>`. (`nest -v` => 11.0.10).

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
