### PR TITLE
doc(components): make async `findAll` sync

### DIFF
--- a/content/components.md
+++ b/content/components.md
@@ -82,7 +82,7 @@ export class CatsController {
   }
 
   @Get()
-  async findAll(): Promise<Cat[]> {
+  findAll(): Cat[] {
     return this.catsService.findAll();
   }
 }
@@ -104,7 +104,7 @@ export class CatsController {
   }
 
   @Get()
-  async findAll() {
+  findAll() {
     return this.catsService.findAll();
   }
 }


### PR DESCRIPTION
Hello,

I'm following the official docs to learn Nest.js, and in the `Components` doc `CatsController.findAll` is `async` whereas it calls and returns from `CatsService.findAll` which is actually synchronous (returns `Cat[]`.

The code snippet creates an ESLint error on `CatsController.findAll` method because there's no `await` (`@typescript-eslint/require-await`). Adding the `await` in front of `this.catsService.findAll()` creates another ESlint error `@typescript-eslint/await-thenable` because the code `await`s something synchronous.

The fix is to simply make all the code synchronous, as in this PR.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
