### PR TITLE
docs(cqrs): fix property typo in QueryHandler example

### DIFF
--- a/content/recipes/cqrs.md
+++ b/content/recipes/cqrs.md
@@ -185,7 +185,7 @@ export class GetHeroHandler implements IQueryHandler<GetHeroQuery> {
   constructor(private repository: HeroesRepository) {}
 
   async execute(query: GetHeroQuery) {
-    return this.repository.findOneById(query.hero);
+    return this.repository.findOneById(query.heroId);
   }
 }
 @@switch


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
In the **CQRS → Queries** example, the `GetHeroHandler` incorrectly uses `query.hero`,  
even though the `GetHeroQuery` class defines the property as `heroId`.  
This causes an inconsistency in the example code and may confuse readers following the docs.

## What is the new behavior?
The example has been corrected to use `query.heroId`, matching the property defined in the `GetHeroQuery` class.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information
