### PR TITLE
docs(websockets): Add @Ack() section

### DIFF
--- a/content/websockets/gateways.md
+++ b/content/websockets/gateways.md
@@ -136,6 +136,28 @@ The `handleEvent()` method will be executed. In order to listen for messages emi
 socket.emit('events', { name: 'Nest' }, (data) => console.log(data));
 ```
 
+While returning a value from a message handler implicitly sends an acknowledgement, advanced scenarios often require direct control over the acknowledgement callback.
+
+The `@Ack()` parameter decorator allows injecting the `ack` callback function directly into a message handler.
+Without using the decorator, this callback is passed as the third argument of the method.
+
+```typescript
+@@filename(events.gateway)
+@SubscribeMessage('events')
+handleEvent(
+  @MessageBody() data: string,
+  @Ack() ack: (response: { status: string; data: string }) => void,
+) {
+  ack({ status: 'received', data });
+}
+@@switch
+@Bind(MessageBody(), Ack())
+@SubscribeMessage('events')
+handleEvent(data, ack) {
+  ack({ status: 'received', data });
+}
+```
+
 #### Multiple responses
 
 The acknowledgment is dispatched only once. Furthermore, it is not supported by native WebSockets implementation. To solve this limitation, you may return an object which consists of two properties. The `event` which is a name of the emitted event and the `data` that has to be forwarded to the client.


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

ack callback can be used in WebSocket handlers(https://github.com/nestjs/nest/pull/15543), but it isn’t documented yet.

## What is the new behavior?
Documentation updated to include @Ack() usage.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
