### PR TITLE
Import '@fastify/view' for Fastify reply type augmentation

### DIFF
--- a/content/techniques/mvc.md
+++ b/content/techniques/mvc.md
@@ -164,6 +164,7 @@ import { NestFactory } from '@nestjs/core';
 import { FastifyAdapter } from '@nestjs/platform-fastify';
 import { AppModule } from './app.module';
 import { join } from 'path';
+import '@fastify/view'; // Needs to be imported to augment the fastify reply type with the view property
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule, new FastifyAdapter());


### PR DESCRIPTION
Added import statement for '@fastify/view' to enhance Fastify reply type with view property to avoid the type error below:

Property 'view' does not exist on type 'FastifyReply<RouteGenericInterface, RawServerDefault, IncomingMessage, ServerResponse<IncomingMessage>, unknown, FastifySchema, FastifyTypeProviderDefault, unknown>'.ts(2339)

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?

Calling reply.view() results in the folling error if `import '@fastify/view';` is not called in `main.ts`

`Property 'view' does not exist on type 'FastifyReply<RouteGenericInterface, RawServerDefault, IncomingMessage, ServerResponse<IncomingMessage>, unknown, FastifySchema, FastifyTypeProviderDefault, unknown>'.ts(2339)`

Issue Number: N/A


## What is the new behavior?

`view` property is found on reply object.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
