### PR TITLE
docs(prisma): Update outdated Prisma Migrate URL

### DIFF
--- a/content/recipes/prisma.md
+++ b/content/recipes/prisma.md
@@ -194,7 +194,7 @@ DATABASE_URL="sqlserver://HOST:PORT;database=DATABASE;user=USER;password=PASSWOR
 
 #### Create two database tables with Prisma Migrate
 
-In this section, you'll create two new tables in your database using [Prisma Migrate](https://www.prisma.io/docs/concepts/components/prisma-migrate). Prisma Migrate generates SQL migration files for your declarative data model definition in the Prisma schema. These migration files are fully customizable so that you can configure any additional features of the underlying database or include additional commands, e.g. for seeding.
+In this section, you'll create two new tables in your database using [Prisma Migrate](https://www.prisma.io/docs/orm/prisma-migrate/getting-started). Prisma Migrate generates SQL migration files for your declarative data model definition in the Prisma schema. These migration files are fully customizable so that you can configure any additional features of the underlying database or include additional commands, e.g. for seeding.
 
 Add the following two models to your `schema.prisma` file:
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [X] Docs
- [ ] Other... Please describe:


## What is the current behavior?
The Prisma Migrate link in the Prisma recipe points to an outdated page that returns a 404 on prisma.io.

Issue Number: N/A


## What is the new behavior?
The outdated Prisma Migrate URL is replaced with the current official Prisma documentation link, ensuring users are directed to valid and up-to-date content.

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No


## Other information
This update improves the developer experience by fixing a broken external link in the Prisma documentation page.