### PR TITLE
docs(recipes): Added required moduleFormat config to Prisma recipe

### DIFF
--- a/content/recipes/prisma.md
+++ b/content/recipes/prisma.md
@@ -79,6 +79,19 @@ generator client {
 }
 ```
 
+#### Configure the module format
+
+Set `moduleFormat` in the generator to `cjs`:
+
+```groovy
+generator client {
+  provider        = "prisma-client"
+  output          = "../src/generated/prisma"
+  moduleFormat    = "cjs"
+}
+```
+
+> info **Note** The `moduleFormat` configuration is required because Prisma v7 ships as an ES module by default, which does not work with NestJS's CommonJS setup. Setting `moduleFormat` to `cjs` forces Prisma to generate a CommonJS module instead of ESM.
 
 #### Set the database connection
 
@@ -90,8 +103,9 @@ datasource db {
 }
 
 generator client {
-  provider = "prisma-client"
-  output          = "../src/generated/prisma"
+  provider      = "prisma-client"
+  output        = "../src/generated/prisma"
+  moduleFormat  = "cjs"
 }
 ```
 
@@ -123,6 +137,7 @@ datasource db {
 generator client {
   provider = "prisma-client"
   output          = "../src/generated/prisma"
+  moduleFormat  = "cjs"
 }
 ```
 
@@ -154,6 +169,7 @@ datasource db {
 generator client {
   provider = "prisma-client"
   output          = "../src/generated/prisma"
+  moduleFormat  = "cjs"
 }
 ```
 
@@ -179,6 +195,7 @@ datasource db {
 generator client {
   provider = "prisma-client"
   output          = "../src/generated/prisma"
+  moduleFormat  = "cjs"
 }
 ```
 
@@ -265,7 +282,7 @@ CREATE UNIQUE INDEX "User.email_unique" ON "User"("email");
 
 #### Install and generate Prisma Client
 
-Prisma Client is a type-safe database client that's _generated_ from your Prisma model definition. Because of this approach, Prisma Client can expose [CRUD](https://www.prisma.io/docs/concepts/components/prisma-client/crud) operations that are _tailored_ specifically to your models. 
+Prisma Client is a type-safe database client that's _generated_ from your Prisma model definition. Because of this approach, Prisma Client can expose [CRUD](https://www.prisma.io/docs/concepts/components/prisma-client/crud) operations that are _tailored_ specifically to your models.
 
 To install Prisma Client in your project, run the following command in your terminal:
 
@@ -288,11 +305,13 @@ npm install @prisma/adapter-better-sqlite3
 <details> <summary>Expand if you're using PostgreSQL, MySQL, MsSQL, or AzureSQL</summary>
 
 - For PostgreSQL
+
 ```bash
 npm install @prisma/adapter-pg
 ```
 
-- For MySQL, MsSQL, AzureSQL: 
+- For MySQL, MsSQL, AzureSQL:
+
 ```bash
 npm install @prisma/adapter-mariadb`
 ```


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #3350

Current [Prisma guide](https://docs.nestjs.com/recipes/prisma) does not fully document the required configuration for Prisma v7 compatibility. Prisma v7, by default, ships as an ES module which NestJS does not natively support.

## What is the new behavior?
This PR adds the solution of adding `moduleFormat = "cjs"` in the prisma generator to force Prisma to output a cjs module instead of an esm.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Credits to @Amitava7 for this solution [here](https://github.com/nestjs/docs.nestjs.com/issues/3350#issuecomment-3577319638)