### PR TITLE
docs: remove stray backtick from prisma install command

### DIFF
--- a/content/recipes/prisma.md
+++ b/content/recipes/prisma.md
@@ -313,7 +313,7 @@ npm install @prisma/adapter-pg
 - For MySQL, MsSQL, AzureSQL:
 
 ```bash
-npm install @prisma/adapter-mariadb`
+npm install @prisma/adapter-mariadb
 ```
 
 </details>


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior
The documentation contains an incorrect `npm install` command with a trailing backtick (`), which can cause errors when users copy and paste the command.

Issue Number: N/A


## What is the new behavior?
The install command has been corrected by removing the stray backtick, ensuring it can be copied and executed correctly without errors.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


## Other information
This change improves documentation accuracy and developer experience. No functional or runtime behavior is affected.
