### PR TITLE
docs(auth): remove redundant jwt secret in authentication code samples

### DIFF
--- a/content/security/authentication.md
+++ b/content/security/authentication.md
@@ -242,6 +242,8 @@ export class AuthService {
     }
     const payload = { sub: user.userId, username: user.username };
     return {
+      // 💡 Here the JWT secret key that's used for signing the payload 
+      // is the key that was passsed in the JwtModule
       access_token: await this.jwtService.signAsync(payload),
     };
   }
@@ -266,6 +268,8 @@ export class AuthService {
     }
     const payload = { username: user.username, sub: user.userId };
     return {
+      // 💡 Here the JWT secret key that's used for signing the payload 
+      // is the key that was passsed in the JwtModule
       access_token: await this.jwtService.signAsync(payload),
     };
   }
@@ -368,7 +372,6 @@ import {
   UnauthorizedException,
 } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
-import { jwtConstants } from './constants';
 import { Request } from 'express';
 
 @Injectable()
@@ -382,12 +385,9 @@ export class AuthGuard implements CanActivate {
       throw new UnauthorizedException();
     }
     try {
-      const payload = await this.jwtService.verifyAsync(
-        token,
-        {
-          secret: jwtConstants.secret
-        }
-      );
+      // 💡 Here the JWT secret key that's used for verifying the payload 
+      // is the key that was passsed in the JwtModule
+      const payload = await this.jwtService.verifyAsync(token);
       // 💡 We're assigning the payload to the request object here
       // so that we can access it in our route handlers
       request['user'] = payload;
@@ -524,9 +524,9 @@ export class AuthGuard implements CanActivate {
       throw new UnauthorizedException();
     }
     try {
-      const payload = await this.jwtService.verifyAsync(token, {
-        secret: jwtConstants.secret,
-      });
+      // 💡 Here the JWT secret key that's used for verifying the payload 
+      // is the key that was passsed in the JwtModule
+      const payload = await this.jwtService.verifyAsync(token);
       // 💡 We're assigning the payload to the request object here
       // so that we can access it in our route handlers
       request['user'] = payload;


### PR DESCRIPTION
The secret is already configured in JwtModule and does not need to be passed again to `verifyAsync` method of `JwtService`.

Reference to issue raised: #3370

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
In the [Implementing the authentication guard](https://docs.nestjs.com/security/authentication#implementing-the-authentication-guard) and [Enable authentication globally](https://docs.nestjs.com/security/authentication#enable-authentication-globally) section (of [security/authentication](https://docs.nestjs.com/security/authentication) page) the verifyAsync method, of the JwtService, passed in the jwt secret key. However, it's not needed as we already pass in the jwt secret key in the configuration of the JwtModule in the auth.module.ts [here](https://docs.nestjs.com/security/authentication#jwt-token). When a jwt secret key isn't passed into the method it'll simply use the key that was passed in to the JwtModule configuration

Issue Number: #3370 


## What is the new behavior?
In the new behaviour, the redundant usage of jwt secret keys are removed from the verifyAsync methods (of the JwtService type). Additionally, a helper comment is added to above the method calls of signAsync and verifyAsync (of the JwtService type)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
