### PR TITLE
docs(pipes): example of zod validation on specific method parameter

### DIFF
--- a/content/pipes.md
+++ b/content/pipes.md
@@ -330,6 +330,18 @@ async create(createCatDto) {
 
 > info **Hint** The `@UsePipes()` decorator is imported from the `@nestjs/common` package.
 
+The `ZodValidationPipe` can be applied to specific parameters and alongside built-in pipes. For example, where we want to validate the route path `id` parameter with the `ParseIntPipe` seperately from the request body:
+
+```typescript
+@Post('/:id')
+async update(
+  @Param('id', ParseIntPipe) id: number,
+  @Body(new ZodValidationPipe(createCatSchema)) body: CreateCatDto
+): void {
+  this.catsService.update(id, body);
+}
+```
+
 > warning **Warning** `zod` library requires the `strictNullChecks` configuration to be enabled in your `tsconfig.json` file.
 
 #### Class validator

--- a/content/pipes.md
+++ b/content/pipes.md
@@ -333,7 +333,7 @@ async create(createCatDto) {
 The `ZodValidationPipe` can be applied to specific parameters and alongside built-in pipes. For example, where we want to validate the route path `id` parameter with the `ParseIntPipe` seperately from the request body:
 
 ```typescript
-@Post('/:id')
+@Put('/:id')
 async update(
   @Param('id', ParseIntPipe) id: number,
   @Body(new ZodValidationPipe(createCatSchema)) body: CreateCatDto


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
Current docs provide an example of the `ZodValidationPipe` applied to the entire method using the `UsePipes` decorator. It is also possible to only apply to the body and allow other pipe validation for example for the route parameters.

## What is the new behavior?
Example included for applying `ZodValidationPipe` only to the request body alongside route paramater validation via `ParseIntPipe`.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information
This is good to include as having both a route parameter and a Zod validated request body is a common use case.

Attempting to extend the existing example with a route parameter will apply the `ZodValidationPipe` to the route parameter. This causes an HTTP 400 request to be returned (the route parameter will be a `number` not an `object` and will therefore fail Zod validation).

Screenshot:
<img width="744" height="610" alt="Screenshot from 2026-01-07 21-46-20" src="https://github.com/user-attachments/assets/ad12cabf-8d0b-43ff-8057-e4ea7aa74832" />
