### PR TITLE
docs(microservices): document mqtt pattern qos

### DIFF
--- a/content/microservices/mqtt.md
+++ b/content/microservices/mqtt.md
@@ -143,7 +143,7 @@ const app = await NestFactory.createMicroservice(AppModule, {
 });
 ```
 
-##### Per-pattern QoS
+#### Per-pattern QoS
 
 You can override the MQTT subscription QoS on a per-pattern basis by providing `qos` in the `extras` field of the pattern decorator. When not specified, the global `subscribeOptions.qos` is used as the default.
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
The Microservices MQTT transport documentation currently only describes configuring a global `subscribeOptions` (including `qos`) for all subscriptions.
It does not mention that QoS can be overridden per pattern/handler.

Issue Number: N/A


## What is the new behavior?
The MQTT transport docs now include a small section describing how to override the subscription QoS per pattern/handler using `extras.qos`.
This showcases the feature added in `nestjs/nest` and clarifies that:
- when `extras.qos` is provided, it overrides the QoS for that pattern
- when not provided, the global `subscribeOptions` remains the default

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


## Other information
- Docs updated: `content/microservices/mqtt.md`
- Related feature PR: https://github.com/nestjs/nest/pull/16286