### PR TITLE
docs: add errorFormat option to ValidationPipe documentation

### DIFF
--- a/content/techniques/validation.md
+++ b/content/techniques/validation.md
@@ -31,6 +31,7 @@ export interface ValidationPipeOptions extends ValidatorOptions {
   transform?: boolean;
   disableErrorMessages?: boolean;
   exceptionFactory?: (errors: ValidationError[]) => any;
+  errorFormat?: 'list' | 'grouped';
 }
 ```
 
@@ -128,6 +129,11 @@ In addition to these, all `class-validator` options (inherited from the `Validat
     <td><code>stopAtFirstError</code></td>
     <td><code>boolean</code></td>
     <td>When set to true, validation of the given property will stop after encountering the first error. Defaults to false.</td>
+  </tr>
+  <tr>
+    <td><code>errorFormat</code></td>
+    <td><code>'list' | 'grouped'</code></td>
+    <td>Specifies the format of validation error messages. <code>'list'</code> (default) returns an array of error message strings. <code>'grouped'</code> returns an object with property paths as keys and arrays of unmodified error messages as values, preserving custom validation messages without prepending parent path prefixes.</td>
   </tr>
 </table>
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: [nestjs/nest#16268](https://github.com/nestjs/nest/pull/16329)


## What is the new behavior?
Document the new `errorFormat` option for ValidationPipe that allows users to choose between 'list' (default) and 'grouped' error formats.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
