### PR TITLE
docs(deployment): include Hostinger Web Apps Hosting in production environment examples

### DIFF
--- a/content/deployment.md
+++ b/content/deployment.md
@@ -35,7 +35,7 @@ Upon successful compilation, you should see a `dist` directory in your project r
 
 #### Production environment
 
-Your production environment is where your application will be accessible to external users. This could be a cloud-based platform like [AWS](https://aws.amazon.com/) (with EC2, ECS, etc.), [Azure](https://azure.microsoft.com/), or [Google Cloud](https://cloud.google.com/), or even a dedicated server you manage, such as [Hetzner](https://www.hetzner.com/).
+Your production environment is where your application will be accessible to external users. This could be a cloud-based platform like [AWS](https://aws.amazon.com/) (with EC2, ECS, etc.), [Azure](https://azure.microsoft.com/), or [Google Cloud](https://cloud.google.com/), or even a dedicated server you manage, such as [Hetzner](https://www.hetzner.com/), or a managed Node.js option like [Hostinger Web Apps Hosting](https://www.hostinger.com/web-apps-hosting).
 
 To simplify the deployment process and avoid manual setup, you can use a service like [Mau](https://mau.nestjs.com/ 'Deploy Nest'), our official platform for deploying NestJS applications on AWS. For more details, check out [this section](todo).
 


### PR DESCRIPTION
This proposal adds Hostinger Web Apps Hosting as one additional deployment option in existing deployment documentation.

- Keeps language provider-neutral
- No runtime or code behavior changes
- Keeps current structure and recommendations intact

Link used: https://www.hostinger.com/web-apps-hosting