### PR TITLE
docs(logger): clarify cascading behavior of log levels

### DIFF
--- a/content/techniques/logger.md
+++ b/content/techniques/logger.md
@@ -36,7 +36,7 @@ await app.listen(process.env.PORT ?? 3000);
 
 Values in the array can be any combination of `'log'`, `'fatal'`, `'error'`, `'warn'`, `'debug'`, and `'verbose'`.
 
-> **Hint** Log levels in NestJS are cascading (inherited). This means that providing a specific log level (like `'log'`) will automatically include all higher-severity levels (e.g., `'warn'`, `'error'`, and `'fatal'`).
+> info **Hint** Log levels in Nest are cascading (inherited). This means that providing a specific log level (like `'log'`) will automatically include all higher-severity levels (e.g., `'warn'`, `'error'`, and `'fatal'`).
 
 To disable colorized output, pass the `ConsoleLogger` object with the `colors` property set to `false` as the value of the `logger` property.
 


### PR DESCRIPTION
This PR adds a note to explicitly clarify the cascading (inherited) behavior of log levels, as requested and discussed in the related issue.

Closes #3306