### PR TITLE
docs(microservices): add prerequest hooks section

### DIFF
--- a/content/microservices/pre-request-hooks.md
+++ b/content/microservices/pre-request-hooks.md
@@ -1,0 +1,192 @@
+### Pre-request hooks
+
+Pre-request hooks are functions that run before all enhancers (guards, interceptors, pipes) for every incoming pattern handler invocation. They are the microservices equivalent of HTTP middleware: a place to establish per-request context that must be visible to guards and the rest of the pipeline.
+
+> info **Hint** The `PreRequestHook` interface is exported from the `@nestjs/common` package.
+
+Hooks execute in the following order:
+
+```
+Incoming message
+  └─ Pre-request hooks  (registration order)
+       └─ Guards
+            └─ Interceptors
+                 └─ Pipes
+                      └─ Handler
+```
+
+Exceptions thrown inside a hook are caught by the same `RpcProxy` wrapper that covers the entire pipeline, so existing [exception filters](/microservices/exception-filters) handle them without extra configuration.
+
+#### Binding hooks
+
+Register hooks on the application instance before calling `app.listen()` using `registerPreRequestHook`. Multiple calls accumulate hooks in registration order.
+
+Each hook receives an `ExecutionContext` and a `next` function. Calling `next()` advances to the next hook or, when no hooks remain, to the guard → interceptor → pipe → handler pipeline. The hook must return the `Observable` produced by `next()`.
+
+> warning **Warning** If a hook does not call `next()`, the handler is never executed — the same contract as HTTP middleware.
+
+```typescript
+@@filename(main)
+import { NestFactory } from '@nestjs/core';
+import { Transport, MicroserviceOptions } from '@nestjs/microservices';
+import { AppModule } from './app.module';
+
+async function bootstrap() {
+  const app = await NestFactory.createMicroservice<MicroserviceOptions>(
+    AppModule,
+    { transport: Transport.TCP },
+  );
+
+  app.registerPreRequestHook((ctx, next) => {
+    return next();
+  });
+
+  await app.listen();
+}
+bootstrap();
+@@switch
+import { NestFactory } from '@nestjs/core';
+import { Transport } from '@nestjs/microservices';
+import { AppModule } from './app.module';
+
+async function bootstrap() {
+  const app = await NestFactory.createMicroservice(AppModule, {
+    transport: Transport.TCP,
+  });
+
+  app.registerPreRequestHook((ctx, next) => {
+    return next();
+  });
+
+  await app.listen();
+}
+bootstrap();
+```
+
+#### AsyncLocalStorage propagation
+
+A common use case is initializing `AsyncLocalStorage` before guards run, making the store available throughout the entire pipeline.
+
+```typescript
+@@filename(main)
+import { NestFactory } from '@nestjs/core';
+import { Transport, MicroserviceOptions } from '@nestjs/microservices';
+import { Observable } from 'rxjs';
+import { AsyncLocalStorage } from 'async_hooks';
+import { randomUUID } from 'crypto';
+import { AppModule } from './app.module';
+
+export const als = new AsyncLocalStorage<{ correlationId: string }>();
+
+async function bootstrap() {
+  const app = await NestFactory.createMicroservice<MicroserviceOptions>(
+    AppModule,
+    { transport: Transport.TCP },
+  );
+
+  app.registerPreRequestHook((ctx, next) => {
+    return new Observable(subscriber => {
+      als.run({ correlationId: randomUUID() }, () => {
+        next().subscribe(subscriber);
+      });
+    });
+  });
+
+  await app.listen();
+}
+bootstrap();
+@@switch
+import { NestFactory } from '@nestjs/core';
+import { Transport } from '@nestjs/microservices';
+import { Observable } from 'rxjs';
+import { AsyncLocalStorage } from 'async_hooks';
+import { randomUUID } from 'crypto';
+import { AppModule } from './app.module';
+
+export const als = new AsyncLocalStorage();
+
+async function bootstrap() {
+  const app = await NestFactory.createMicroservice(AppModule, {
+    transport: Transport.TCP,
+  });
+
+  app.registerPreRequestHook((ctx, next) => {
+    return new Observable(subscriber => {
+      als.run({ correlationId: randomUUID() }, () => {
+        next().subscribe(subscriber);
+      });
+    });
+  });
+
+  await app.listen();
+}
+bootstrap();
+```
+
+Because the hook runs before guards, `als.getStore()` returns the initialized store in any guard, interceptor, or handler:
+
+```typescript
+@@filename(correlation.guard)
+import { Injectable, CanActivate, ExecutionContext } from '@nestjs/common';
+import { als } from './main';
+
+@Injectable()
+export class CorrelationGuard implements CanActivate {
+  canActivate(context: ExecutionContext): boolean {
+    const { correlationId } = als.getStore()!;
+    return true;
+  }
+}
+@@switch
+import { Injectable } from '@nestjs/common';
+import { als } from './main';
+
+@Injectable()
+export class CorrelationGuard {
+  canActivate(context) {
+    const { correlationId } = als.getStore();
+    return true;
+  }
+}
+```
+
+#### Logging and metrics
+
+RxJS operators can be applied to the `Observable` returned by `next()` to observe the full handler lifecycle:
+
+```typescript
+@@filename(main)
+import { tap, catchError } from 'rxjs/operators';
+import { throwError } from 'rxjs';
+
+app.registerPreRequestHook((ctx, next) => {
+  const handler = ctx.getHandler().name;
+  const start = Date.now();
+
+  return next().pipe(
+    tap(() => console.log(`[${handler}] completed in ${Date.now() - start}ms`)),
+    catchError(err => {
+      console.error(`[${handler}] failed:`, err.message);
+      return throwError(() => err);
+    }),
+  );
+});
+@@switch
+const { tap, catchError } = require('rxjs/operators');
+const { throwError } = require('rxjs');
+
+app.registerPreRequestHook((ctx, next) => {
+  const handler = ctx.getHandler().name;
+  const start = Date.now();
+
+  return next().pipe(
+    tap(() => console.log(`[${handler}] completed in ${Date.now() - start}ms`)),
+    catchError(err => {
+      console.error(`[${handler}] failed:`, err.message);
+      return throwError(() => err);
+    }),
+  );
+});
+```
+
+> info **Hint** `registerPreRequestHook` is global-only — per-pattern registration is not supported. When no hooks are registered, the pipeline takes the same fast path as before this feature was introduced. WebSocket gateway support is intentionally out of scope.

--- a/src/app/homepage/menu/menu.component.ts
+++ b/src/app/homepage/menu/menu.component.ts
@@ -191,6 +191,10 @@ export class MenuComponent implements OnInit {
           path: '/microservices/exception-filters',
         },
         { title: 'Pipes', path: '/microservices/pipes' },
+        {
+          title: 'Pre-request hooks',
+          path: '/microservices/pre-request-hooks',
+        },
         { title: 'Guards', path: '/microservices/guards' },
         { title: 'Interceptors', path: '/microservices/interceptors' },
       ],

--- a/src/app/homepage/pages/microservices/microservices.routes.ts
+++ b/src/app/homepage/pages/microservices/microservices.routes.ts
@@ -11,6 +11,7 @@ import { MicroservicesPipesComponent } from './pipes/pipes.component';
 import { RabbitMQComponent } from './rabbitmq/rabbitmq.component';
 import { KafkaComponent } from './kafka/kafka.component';
 import { RedisComponent } from './redis/redis.component';
+import { PreRequestHooksComponent } from './pre-request-hooks/pre-request-hooks.component';
 
 export const MICROSERVICES_ROUTES: Routes = [
   {
@@ -67,6 +68,11 @@ export const MICROSERVICES_ROUTES: Routes = [
     path: 'interceptors',
     component: MicroservicesInterceptorsComponent,
     data: { title: 'Interceptors - Microservices' },
+  },
+  {
+    path: 'pre-request-hooks',
+    component: PreRequestHooksComponent,
+    data: { title: 'Pre-request hooks - Microservices' },
   },
   {
     path: 'custom-transport',

--- a/src/app/homepage/pages/microservices/pre-request-hooks/pre-request-hooks.component.ts
+++ b/src/app/homepage/pages/microservices/pre-request-hooks/pre-request-hooks.component.ts
@@ -1,0 +1,22 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { BasePageComponent } from '../../page/page.component';
+import { RouterLink } from '@angular/router';
+import { HeaderAnchorDirective } from '../../../../shared/directives/header-anchor.directive';
+import { CopyButtonComponent } from '../../../../shared/components/copy-button/copy-button.component';
+import { TabsComponent } from '../../../../shared/components/tabs/tabs.component';
+import { ExtensionPipe } from '../../../../shared/pipes/extension.pipe';
+
+@Component({
+    selector: 'app-pre-request-hooks',
+    templateUrl: './pre-request-hooks.component.html',
+    changeDetection: ChangeDetectionStrategy.OnPush,
+    standalone: true,
+    imports: [
+        RouterLink,
+        HeaderAnchorDirective,
+        CopyButtonComponent,
+        TabsComponent,
+        ExtensionPipe,
+    ],
+})
+export class PreRequestHooksComponent extends BasePageComponent {}

--- a/tools/transforms/shared/utils/markdown-utils.ts
+++ b/tools/transforms/shared/utils/markdown-utils.ts
@@ -13,6 +13,13 @@ export function escapeAts(text: string) {
 export function appendEmptyLine(text: string) {
   const codeEscape = '">';
   const codeEscId = text.indexOf(codeEscape);
+  if (codeEscId < 0) {
+    // language-less code block: no class attribute to anchor on
+    const openingTag = '<pre><code>';
+    return text.startsWith(openingTag)
+      ? openingTag + '\n' + text.slice(openingTag.length)
+      : text;
+  }
   return (
     text.slice(0, codeEscId + codeEscape.length) +
     '\n' +


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
There is no dedicated documentation describing the new microservices **preRequest hooks** API, its execution order (before guards), or recommended usage patterns (e.g., AsyncLocalStorage context propagation and request-scoped logging/metrics).

Issue Number: #1627 


## What is the new behavior?
This PR adds a new documentation section for **microservices preRequest hooks**, including:

- What preRequest hooks are and when to use them
- Execution order (runs before guards, similar to HTTP middleware)
- Global registration API
- Examples:
  - AsyncLocalStorage-based correlation id/context propagation (available in guards)
  - Wrapping the handler pipeline for logging/metrics using RxJS operators

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


## Other information

### Related

### Notes
- The docs focus on **microservices only** and **global-only registration**, matching the current implementation.
- Examples use `next()` as an Observable-returning function to demonstrate `next().pipe(...)` patterns.

```
preRequest hooks -> guards -> interceptors -> pipes -> handler
```