### PR TITLE
fix(styles): prevent scrollbar width shift when toggling themes

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -62,6 +62,47 @@ html[mode='dark'] {
 html:not([mode='dark']):not([mode='light']),
 html[mode='light'] {
   @extend .light-mode;
+
+  ::-webkit-scrollbar {
+    width: 10px;
+  }
+
+  ::-webkit-scrollbar-thumb {
+    background: #c0c0c0 !important;
+    border-radius: 6px;
+  }
+
+  ::-webkit-scrollbar-thumb:hover {
+    background: #a0a0a0;
+  }
+
+  ::-webkit-scrollbar-track {
+    background: var(--background-3dp);
+  }
+
+  ::-webkit-scrollbar-corner {
+    background: var(--background-3dp);
+  }
+
+  .app-menu {
+    &::-webkit-scrollbar {
+      width: 6px;
+    }
+  }
+
+  .app-menu:not(:hover) {
+    &::-webkit-scrollbar-thumb {
+      background: var(--menu-background) !important;
+    }
+
+    &::-webkit-scrollbar-track {
+      background: var(--menu-background);
+    }
+
+    &::-webkit-scrollbar-corner {
+      background: var(--menu-background);
+    }
+  }
 }
 
 body {


### PR DESCRIPTION

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Docs
- [ ] Other... Please describe:


## What is the current behavior?
In light mode, the scrollbar uses the browser's default styling, while dark mode applies a custom scrollbar with a fixed width of 10px. This inconsistency causes a horizontal layout shift when switching between light and dark themes due to the difference in scrollbar width.

https://github.com/user-attachments/assets/5c0882b6-be3c-4dba-a2f3-e9f4683b3786


<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
Added explicit scrollbar styling for light mode to match the dark mode configuration (10px width).  This ensures consistent scrollbar width across both themes and prevents layout shift when toggling between light and dark modes.

https://github.com/user-attachments/assets/2821e0fe-59f3-48cf-a7d5-fb4258588ae1




## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information