### PR TITLE
docs(caching): use keyv storage adapter in alternative cache stores section

### DIFF
--- a/content/techniques/caching.md
+++ b/content/techniques/caching.md
@@ -238,7 +238,7 @@ import { CacheModule } from '@nestjs/cache-manager';
 import { AppController } from './app.controller';
 import KeyvRedis from '@keyv/redis';
 import { Keyv } from 'keyv';
-import { CacheableMemory } from 'cacheable';
+import { KeyvCacheableMemory } from 'cacheable';
 
 @Module({
   imports: [
@@ -247,7 +247,7 @@ import { CacheableMemory } from 'cacheable';
         return {
           stores: [
             new Keyv({
-              store: new CacheableMemory({ ttl: 60000, lruSize: 5000 }),
+              store: new KeyvCacheableMemory({ ttl: 60000, lruSize: 5000 }),
             }),
             new KeyvRedis('redis://localhost:6379'),
           ],
@@ -260,7 +260,7 @@ import { CacheableMemory } from 'cacheable';
 export class AppModule {}
 ```
 
-In this example, we've registered two stores: `CacheableMemory` and `KeyvRedis`. The `CacheableMemory` store is a simple in-memory store, while `KeyvRedis` is a Redis store. The `stores` array is used to specify the stores you want to use. The first store in the array is the default store, and the rest are fallback stores.
+In this example, we've registered two stores: `CacheableMemory` and `KeyvRedis`. The `CacheableMemory` store is a simple in-memory store, which is created via the `KeyvCacheableMemory` storage adapter, while `KeyvRedis` is a Redis store. The `stores` array is used to specify the stores you want to use. The first store in the array is the default store, and the rest are fallback stores.
 
 Check out the [Keyv documentation](https://keyv.org/docs/) for more information on available stores.
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently, NestJS gives this example, using `CacheableMemory`:
```ts
new Keyv({
  store: new CacheableMemory({ ttl: 60000, lruSize: 5000 }),
}),
```

while the official `cacheable` docs recommend using `KeyvCacheableMemory`, which is a storage adapter specifically designed for Keyv.

https://cacheable.org/docs/memory/

## What is the new behavior?

The new example uses `KeyvCacheableMemory` instead of plain `CacheableMemory`.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
