### PR TITLE
feat(cli): document includeLibraryAssets option

### DIFF
--- a/content/cli/workspaces.md
+++ b/content/cli/workspaces.md
@@ -191,6 +191,7 @@ These properties specify the compiler to use as well as various options that aff
 | `deleteOutDir`      | boolean             | If `true`, whenever the compiler is invoked, it will first remove the compilation output directory (as configured in `tsconfig.json`, where the default is `./dist`).                                                                                                     |
 | `assets`            | array               | Enables automatically distributing non-TypeScript assets whenever a compilation step begins (asset distribution does **not** happen on incremental compiles in `--watch` mode). See below for details.                                                                    |
 | `watchAssets`       | boolean             | If `true`, run in watch-mode, watching **all** non-TypeScript assets. (For more fine-grained control of the assets to watch, see [Assets](cli/monorepo#assets) section below).                                                                                            |
+| `includeLibraryAssets` | array            | (**monorepo only**) An array of library project names whose assets should also be copied into the application's output during build. See [Including library assets](cli/monorepo#including-library-assets) below for details.                                              |
 | `manualRestart`     | boolean             | If `true`, enables the shortcut `rs` to manually restart the server. Default value is `false`.                                                                                                                                                                            |
 | `builder`           | string/object       | Instructs CLI on what `builder` to use to compile the project (`tsc`, `swc`, or `webpack`). To customize builder's behavior, you can pass an object containing two attributes: `type` (`tsc`, `swc`, or `webpack`) and `options`.                                         |
 | `typeCheck`         | boolean             | If `true`, enables type checking for SWC-driven projects (when `builder` is `swc`). Default value is `false`.                                                                                                                                                             |
@@ -330,6 +331,23 @@ For example:
 ```
 
 > warning **Warning** Setting `watchAssets` in a top-level `compilerOptions` property overrides any `watchAssets` settings within the `assets` property.
+
+#### Including library assets
+
+In a monorepo, libraries can declare their own `compilerOptions.assets` to ship non-TypeScript files (such as `.graphql`, `.proto`, or `.hbs` templates) alongside their compiled output. By default, however, those assets are **not** copied when an application that consumes the library is built — only the application's own `assets` entries are processed.
+
+The `includeLibraryAssets` option closes that gap. It accepts an array of library project names; during the application's build, the assets declared under each listed library's `compilerOptions.assets` are resolved relative to that library's `sourceRoot` and copied into the application's output directory.
+
+```typescript
+"compilerOptions": {
+  "assets": ["**/*.graphql"],
+  "includeLibraryAssets": ["common", "shared-schemas"]
+}
+```
+
+In the example above, building the application will distribute its own `.graphql` files **and** every asset declared by the `common` and `shared-schemas` libraries.
+
+> info **Hint** Library names that are not present in `projects` and libraries that do not declare any `compilerOptions.assets` are silently skipped, so it is safe to list optional libraries.
 
 #### Project properties
 

--- a/content/cli/workspaces.md
+++ b/content/cli/workspaces.md
@@ -191,7 +191,7 @@ These properties specify the compiler to use as well as various options that aff
 | `deleteOutDir`      | boolean             | If `true`, whenever the compiler is invoked, it will first remove the compilation output directory (as configured in `tsconfig.json`, where the default is `./dist`).                                                                                                     |
 | `assets`            | array               | Enables automatically distributing non-TypeScript assets whenever a compilation step begins (asset distribution does **not** happen on incremental compiles in `--watch` mode). See below for details.                                                                    |
 | `watchAssets`       | boolean             | If `true`, run in watch-mode, watching **all** non-TypeScript assets. (For more fine-grained control of the assets to watch, see [Assets](cli/monorepo#assets) section below).                                                                                            |
-| `includeLibraryAssets` | array            | (**monorepo only**) An array of library project names whose assets should also be copied into the application's output during build. See [Including library assets](cli/monorepo#including-library-assets) below for details.                                              |
+| `includeLibraryAssets` | boolean          | (**monorepo only**) If `true`, assets declared by library projects are also copied into the application's output during build. See [Including library assets](cli/monorepo#including-library-assets) below for details. Default: `false`.                                  |
 | `manualRestart`     | boolean             | If `true`, enables the shortcut `rs` to manually restart the server. Default value is `false`.                                                                                                                                                                            |
 | `builder`           | string/object       | Instructs CLI on what `builder` to use to compile the project (`tsc`, `swc`, or `webpack`). To customize builder's behavior, you can pass an object containing two attributes: `type` (`tsc`, `swc`, or `webpack`) and `options`.                                         |
 | `typeCheck`         | boolean             | If `true`, enables type checking for SWC-driven projects (when `builder` is `swc`). Default value is `false`.                                                                                                                                                             |
@@ -336,18 +336,18 @@ For example:
 
 In a monorepo, libraries can declare their own `compilerOptions.assets` to ship non-TypeScript files (such as `.graphql`, `.proto`, or `.hbs` templates) alongside their compiled output. By default, however, those assets are **not** copied when an application that consumes the library is built — only the application's own `assets` entries are processed.
 
-The `includeLibraryAssets` option closes that gap. It accepts an array of library project names; during the application's build, the assets declared under each listed library's `compilerOptions.assets` are resolved relative to that library's `sourceRoot` and copied into the application's output directory.
+The `includeLibraryAssets` option closes that gap. When set to `true`, building an application also processes the assets declared by each library project in the monorepo: every library's `compilerOptions.assets` entries are resolved relative to that library's `sourceRoot` and copied into the application's output directory.
 
 ```typescript
 "compilerOptions": {
   "assets": ["**/*.graphql"],
-  "includeLibraryAssets": ["common", "shared-schemas"]
+  "includeLibraryAssets": true
 }
 ```
 
-In the example above, building the application will distribute its own `.graphql` files **and** every asset declared by the `common` and `shared-schemas` libraries.
+In the example above, building the application will distribute its own `.graphql` files **and** every asset declared by the monorepo's library projects. The option can be set globally (top-level `compilerOptions`) or per application (in the project's own `compilerOptions`).
 
-> info **Hint** Library names that are not present in `projects` and libraries that do not declare any `compilerOptions.assets` are silently skipped, so it is safe to list optional libraries.
+> info **Hint** Library projects that do not declare any `compilerOptions.assets` are silently skipped, as are sibling `application`-type projects — only `library`-type projects are considered.
 
 #### Project properties
 

--- a/content/cli/workspaces.md
+++ b/content/cli/workspaces.md
@@ -191,7 +191,7 @@ These properties specify the compiler to use as well as various options that aff
 | `deleteOutDir`      | boolean             | If `true`, whenever the compiler is invoked, it will first remove the compilation output directory (as configured in `tsconfig.json`, where the default is `./dist`).                                                                                                     |
 | `assets`            | array               | Enables automatically distributing non-TypeScript assets whenever a compilation step begins (asset distribution does **not** happen on incremental compiles in `--watch` mode). See below for details.                                                                    |
 | `watchAssets`       | boolean             | If `true`, run in watch-mode, watching **all** non-TypeScript assets. (For more fine-grained control of the assets to watch, see [Assets](cli/monorepo#assets) section below).                                                                                            |
-| `includeLibraryAssets` | boolean          | (**monorepo only**) If `true`, assets declared by library projects are also copied into the application's output during build. See [Including library assets](cli/monorepo#including-library-assets) below for details. Default: `false`.                                  |
+| `includeLibraryAssets` | array            | (**monorepo only**) An array of library project names whose assets should also be copied into the application's output during build. See [Including library assets](cli/monorepo#including-library-assets) below for details.                                              |
 | `manualRestart`     | boolean             | If `true`, enables the shortcut `rs` to manually restart the server. Default value is `false`.                                                                                                                                                                            |
 | `builder`           | string/object       | Instructs CLI on what `builder` to use to compile the project (`tsc`, `swc`, or `webpack`). To customize builder's behavior, you can pass an object containing two attributes: `type` (`tsc`, `swc`, or `webpack`) and `options`.                                         |
 | `typeCheck`         | boolean             | If `true`, enables type checking for SWC-driven projects (when `builder` is `swc`). Default value is `false`.                                                                                                                                                             |
@@ -336,18 +336,18 @@ For example:
 
 In a monorepo, libraries can declare their own `compilerOptions.assets` to ship non-TypeScript files (such as `.graphql`, `.proto`, or `.hbs` templates) alongside their compiled output. By default, however, those assets are **not** copied when an application that consumes the library is built — only the application's own `assets` entries are processed.
 
-The `includeLibraryAssets` option closes that gap. When set to `true`, building an application also processes the assets declared by each library project in the monorepo: every library's `compilerOptions.assets` entries are resolved relative to that library's `sourceRoot` and copied into the application's output directory.
+The `includeLibraryAssets` option closes that gap. It accepts an array of library project names; during the application's build, the assets declared under each listed library's `compilerOptions.assets` are resolved relative to that library's `sourceRoot` and copied into the application's output directory.
 
 ```typescript
 "compilerOptions": {
   "assets": ["**/*.graphql"],
-  "includeLibraryAssets": true
+  "includeLibraryAssets": ["common", "shared-schemas"]
 }
 ```
 
-In the example above, building the application will distribute its own `.graphql` files **and** every asset declared by the monorepo's library projects. The option can be set globally (top-level `compilerOptions`) or per application (in the project's own `compilerOptions`).
+In the example above, building the application will distribute its own `.graphql` files **and** every asset declared by the `common` and `shared-schemas` libraries.
 
-> info **Hint** Library projects that do not declare any `compilerOptions.assets` are silently skipped, as are sibling `application`-type projects — only `library`-type projects are considered.
+> info **Hint** Library names that are not present in `projects` and libraries that do not declare any `compilerOptions.assets` are silently skipped, so it is safe to list optional libraries.
 
 #### Project properties
 


### PR DESCRIPTION
## Summary

Documents the new `includeLibraryAssets` compiler option introduced in nestjs/nest-cli#3343.

In a monorepo, libraries can declare their own `compilerOptions.assets`, but those assets were silently ignored when the consuming application was built. The new option lets users opt in by listing library names whose assets should be copied into the application's output during `nest build`.

## Changes

- Adds an `includeLibraryAssets` row to the **Global compiler options** table in `content/cli/workspaces.md`.
- Adds a new **Including library assets** sub-section after the existing **Assets** section, with a `nest-cli.json` example and a hint that missing libraries / libraries without assets are silently skipped.

## Related

- Companion CLI PR: nestjs/nest-cli#3343
- Closes nestjs/nest-cli#1845 (the docs portion requested by the original reporter)