### PR TITLE
docs(cli): document --format flag for nest new and nest generate

### DIFF
--- a/content/cli/usages.md
+++ b/content/cli/usages.md
@@ -35,6 +35,7 @@ Creates and initializes a new Nest project. Prompts for package manager.
 | `--language [language]`               | Specify programming language (`TS` or `JS`).<br/> Alias: `-l`                                                                                                                                        |
 | `--collection [collectionName]`       | Specify schematics collection. Use package name of installed npm package containing schematic.<br/> Alias: `-c`                                                                                      |
 | `--strict`                            | Start the project with the following TypeScript compiler flags enabled: `strictNullChecks`, `noImplicitAny`, `strictBindCallApply`, `forceConsistentCasingInFileNames`, `noFallthroughCasesInSwitch` |
+| `--format`                            | Format generated files using Prettier before writing them to disk. Off by default; Prettier must be available in the project.                                                                        |
 
 #### nest generate
 
@@ -84,6 +85,7 @@ $ nest g <schematic> <name> [options]
 | `--collection [collectionName]` | Specify schematics collection. Use package name of installed npm package containing schematic.<br/> Alias: `-c` |
 | `--spec`                        | Enforce spec files generation (default)                                                                         |
 | `--no-spec`                     | Disable spec files generation                                                                                   |
+| `--format`                      | Format generated files using Prettier before writing them to disk. Off by default; Prettier must be available in the project. |
 
 #### nest build
 


### PR DESCRIPTION
## Summary

Follow-up to [nestjs/nest-cli#3363](https://github.com/nestjs/nest-cli/pull/3363), which added an opt-in \`--format\` flag to \`nest new\` and \`nest generate\`.

Adds a row for \`--format\` to the options tables in the \`nest new\` and \`nest generate\` sections of the CLI command reference (\`content/cli/usages.md\`).

## Behaviour documented

- \`--format\` is **off by default** — existing workflows are unchanged.
- When passed, the CLI forwards the option to the schematic, which formats generated files using Prettier (if available in the consuming project) before writing them to disk.
- The actual formatting logic lives in [@nestjs/schematics (#2322)](https://github.com/nestjs/schematics/pull/2322).

## Test plan

- [x] Manually inspected the rendered markdown table for both \`nest new\` and \`nest generate\`.
- [x] Verified the new row aligns with surrounding rows (pipe alignment is cosmetic and handled by the existing formatting).