### PR TITLE
docs(openapi): document OpenAPI 3.2 hierarchical tags

### DIFF
--- a/content/openapi/operations.md
+++ b/content/openapi/operations.md
@@ -12,6 +12,38 @@ To attach a controller to a specific tag, use the `@ApiTags(...tags)` decorator.
 export class CatsController {}
 ```
 
+Starting with OpenAPI 3.2, tags support a hierarchy via the `parent` and `kind` fields. You can define
+the hierarchy at the document level using `DocumentBuilder.addTag()`:
+
+```typescript
+const config = new DocumentBuilder()
+  .addTag('Animals', 'All animal operations')
+  .addTag('Cats', 'Cat operations', undefined, { parent: 'Animals' })
+  .addTag('Dogs', 'Dog operations', undefined, { parent: 'Animals', kind: 'navigation' })
+  .build();
+```
+
+`@ApiTags` also accepts an object form so controllers can reference a hierarchical tag:
+
+```typescript
+@ApiTags({ name: 'Cats', parent: 'Animals' })
+@Controller('cats')
+export class CatsController {}
+```
+
+String and object forms can be mixed:
+
+```typescript
+@ApiTags('Dogs', { name: 'Puppies', parent: 'Dogs' })
+@Controller('puppies')
+export class PuppiesController {}
+```
+
+> info **Hint** The `parent` and `kind` fields are part of the OpenAPI 3.2 specification. Tools that only
+support OpenAPI 3.0/3.1 will ignore them, so this is fully backward compatible. Hierarchy info is only
+meaningful at the document level. At the operation level, only tag names are emitted per the OpenAPI
+spec.
+
 #### Headers
 
 To define custom headers that are expected as part of the request, use `@ApiHeader()`.


### PR DESCRIPTION
 ## PR Checklist
  Please check if your PR fulfills the following requirements:

  - [x] The commit message follows our guidelines:
  https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


  ## PR Type
  What kind of change does this PR introduce?

  - [ ] Bugfix
  - [ ] Feature
  - [ ] Code style update (formatting, local variables)
  - [ ] Refactoring (no functional changes, no api changes)
  - [ ] Build related changes
  - [x] Docs
  - [ ] Other... Please describe:


  ## What is the current behavior?

  The OpenAPI "Operations" page only documents the string form of `@ApiTags` and the basic
  `DocumentBuilder.addTag(name, description?, externalDocs?)` signature. There is no mention of the
  `parent` / `kind` fields introduced in OpenAPI 3.2, nor of the object form of `@ApiTags`.

  Issue Number: N/A


  ## What is the new behavior?

  The "Tags" section of `content/openapi/operations.md` now documents:

  - `DocumentBuilder.addTag()` with the new optional 4th argument for hierarchy options (`parent`, `kind`)
  - The object form of `@ApiTags({ name, parent?, kind? })`
  - Mixing string and object forms
  - A hint clarifying OpenAPI 3.0/3.1 backward compatibility and that hierarchy info is only meaningful at
  the document level

  Related feature PR: https://github.com/nestjs/swagger/pull/3725


  ## Does this PR introduce a breaking change?
  - [ ] Yes
  - [x] No


  ## Other information

  - Docs updated: `content/openapi/operations.md`