### PR TITLE
feat: cqrs with flexible aggregate roots

### DIFF
--- a/content/recipes/cqrs.md
+++ b/content/recipes/cqrs.md
@@ -426,9 +426,6 @@ export class CustomEntity implements IAggregateRoot {
 ```
 
 All three approaches work seamlessly with `EventPublisher`, which accepts any object implementing the `IAggregateRoot` interface.
-
----
-
 #### Manual event publishing
 
 ```typescript

--- a/content/recipes/cqrs.md
+++ b/content/recipes/cqrs.md
@@ -307,7 +307,7 @@ export class KillDragonHandler {
 }
 ```
 
-The `EventPublisher#mergeObjectContext` method merges the event publisher into the provided object, which means that the object will now be able to publish events to the events stream.
+The `EventPublisher#mergeObjectContext` method merges the event publisher into the provided object. This object must implement the `IAggregateRoot` interface (or extend the `AggregateRoot` class). Once merged, the object will be able to publish events to the events stream.
 
 Notice that in this example we also call the `commit()` method on the model. This method is used to dispatch any outstanding events. To automatically dispatch events, we can set the `autoCommit` property to `true`:
 
@@ -329,7 +329,107 @@ const hero = new HeroModel('id'); // <-- HeroModel is a class
 
 Now every instance of the `HeroModel` class will be able to publish events without using `mergeObjectContext()` method.
 
-Additionally, we can emit events manually using `EventBus`:
+#### Flexible Aggregate Roots
+
+The `AggregateRoot` class is a concrete implementation that you can extend to add event-driven capabilities to your domain models. However, this approach requires domain entities to directly extend `AggregateRoot`, which can be a limitation if your applications already have an established entity inheritance hierarchy (e.g., a base `Entity` class or domain-specific base classes like `Monster`, `Vehicle`, etc.).
+
+To provide more flexibility, the `@nestjs/cqrs` package offers three different approaches to implementing aggregate roots:
+
+**Approach 1: Traditional (Class Inheritance)**
+
+This is the standard approach shown in the previous examples. It works perfectly for simple scenarios or greenfield projects.
+
+```typescript
+export class Hero extends AggregateRoot {
+  constructor(private id: string) {
+    super();
+  }
+
+  killEnemy(enemyId: string) {
+    this.apply(new HeroKilledDragonEvent(this.id, enemyId));
+  }
+}
+```
+
+**Approach 2: Mixin (For existing hierarchies)**
+
+If you already have a base class and cannot extend `AggregateRoot` directly, you can use the `WithAggregateRoot<EventBase, TBase>()` mixin function. This allows you to apply aggregate root behavior to any existing base class.
+
+```typescript
+@@filename(dragon.model)
+abstract class Monster {
+  constructor(protected readonly id: string) {}
+  abstract roar(): void;
+}
+
+export class Dragon extends WithAggregateRoot(Monster) {
+  roar(): void {
+    console.log('Roarrrr!');
+  }
+
+  die(): void {
+    this.roar();
+    this.apply(new DragonDiedEvent(this.id)); // Now available via mixin!
+  }
+}
+@@switch
+abstract class Monster {
+  constructor(id) {
+    this.id = id;
+  }
+}
+
+export class Dragon extends WithAggregateRoot(Monster) {
+  roar() {
+    console.log('Roarrrr!');
+  }
+
+  die() {
+    this.roar();
+    this.apply(new DragonDiedEvent(this.id));
+  }
+}
+```
+
+**Approach 3: Custom Implementation**
+
+For maximum control, or if you want to keep your domain layer completely framework-agnostic, you can implement the `IAggregateRoot` interface directly. The `EventPublisher` accepts any object that implements this interface.
+
+```typescript
+export class CustomEntity implements IAggregateRoot {
+  private events: IEvent[] = [];
+
+  getUncommittedEvents() {
+    return this.events;
+  }
+
+  publish(event: IEvent) {
+    // custom logic
+  }
+
+  commit() {
+    // custom logic
+  }
+
+  uncommit() {
+    // custom logic
+  }
+
+  apply(event: IEvent) {
+    this.events.push(event);
+  }
+
+  loadFromHistory(history: IEvent[]) {
+    // custom logic
+  }
+}
+```
+
+All three approaches work seamlessly with `EventPublisher`, which accepts any object implementing the `IAggregateRoot` interface.
+
+---
+
+#### Manual event publishing
 
 ```typescript
 this.eventBus.publish(new HeroKilledDragonEvent());


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
The current documentation for aggregate roots in the CQRS recipe lacks clarity regarding the requirements for using `EventPublisher#mergeObjectContext`. It does not explicitly state that the target object must implement `IAggregateRoot` or extend `AggregateRoot`.

Additionally, the documentation assumes a single approach (class inheritance) for implementing aggregate roots, which may not fit all domain model designs.

Issue Number: N/A


## What is the new behavior?
This PR improves the CQRS documentation by:

- Clarifying that `EventPublisher#mergeObjectContext` requires the target object to implement `IAggregateRoot` or extend `AggregateRoot` in order to support event publishing.
- Introducing a new section that outlines three flexible approaches for implementing aggregate roots:
  1. Extending the `AggregateRoot` base class (traditional approach).
  2. Using the `WithAggregateRoot` mixin for compatibility with existing inheritance hierarchies.
  3. Implementing the `IAggregateRoot` interface directly for maximum flexibility.

These additions make the documentation more accessible and adaptable to different architectural patterns.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


## Other information
https://github.com/Manuel-Antunes/docs.nestjs.com


## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md