### PR TITLE
docs(graphql): document registerIn option for module-scoped types

### DIFF
--- a/content/graphql/quick-start.md
+++ b/content/graphql/quick-start.md
@@ -365,6 +365,41 @@ GraphQLModule.forRoot({
 }),
 ```
 
+In the **code first** approach, the `include` option only filters which modules are scanned for resolvers — types decorated with `@ObjectType()`, `@InputType()`, `@InterfaceType()`, `@ArgsType()`, or registered through `registerEnumType()` / `createUnionType()` are still included in every generated schema. To restrict a type to a specific module, set the `registerIn` option on the type:
+
+```typescript
+@ObjectType({ registerIn: () => CatsModule })
+export class Cat {
+  @Field()
+  name: string;
+}
+```
+
+When the schema is built with `include: [CatsModule]`, types tagged with `registerIn: () => CatsModule` are included; types tagged with another module are excluded. Types **without** `registerIn` keep the existing default behavior and are available in every schema that references them.
+
+The same option is supported on `@InputType()`, `@InterfaceType()`, `@ArgsType()`, `registerEnumType()`, and `createUnionType()`:
+
+```typescript
+@InputType({ registerIn: () => CatsModule })
+export class CreateCatInput {
+  @Field()
+  name: string;
+}
+
+registerEnumType(CatBreed, {
+  name: 'CatBreed',
+  registerIn: () => CatsModule,
+});
+
+export const CatsUnion = createUnionType({
+  name: 'CatsUnion',
+  types: () => [Lion, Tiger] as const,
+  registerIn: () => CatsModule,
+});
+```
+
+> info **Hint** `registerIn` accepts either a module class directly or a factory function returning the class. The factory form (`() => CatsModule`) is recommended when the type and module reference each other, since it defers module resolution and avoids temporal dead zone errors from circular imports.
+
 > warning **Warning** If you use the `@apollo/server` with `@as-integrations/fastify` package with multiple GraphQL endpoints in a single application, make sure to enable the `disableHealthCheck` setting in the `GraphQLModule` configuration.
 
 #### Third-party integrations

--- a/content/graphql/quick-start.md
+++ b/content/graphql/quick-start.md
@@ -439,7 +439,7 @@ GraphQLModule.forRoot({
 }),
 ```
 
-In the **code first** approach, the `include` option only filters which modules are scanned for resolvers — types decorated with `@ObjectType()`, `@InputType()`, `@InterfaceType()`, `@ArgsType()`, or registered through `registerEnumType()` / `createUnionType()` are still included in every generated schema. To restrict a type to a specific module, set the `registerIn` option on the type:
+In the **code first** approach, the `include` option only determines which modules are scanned for resolvers. Types decorated with `@ObjectType()`, `@InputType()`, `@InterfaceType()`, `@ArgsType()`, or registered through `registerEnumType()` / `createUnionType()` still end up in every generated schema. To scope a type to a specific module, use the `registerIn` option:
 
 ```typescript
 @ObjectType({ registerIn: () => CatsModule })
@@ -449,9 +449,9 @@ export class Cat {
 }
 ```
 
-When the schema is built with `include: [CatsModule]`, types tagged with `registerIn: () => CatsModule` are included; types tagged with another module are excluded. Types **without** `registerIn` keep the existing default behavior and are available in every schema that references them.
+Now, when a schema is built with `include: [CatsModule]`, only types assigned to `CatsModule` become part of it, while types assigned to other modules are left out. Types without `registerIn` keep the default behavior and are available in every schema that references them.
 
-The same option is supported on `@InputType()`, `@InterfaceType()`, `@ArgsType()`, `registerEnumType()`, and `createUnionType()`:
+The `registerIn` option is available on `@InputType()`, `@InterfaceType()`, and `@ArgsType()`, as well as `registerEnumType()` and `createUnionType()`:
 
 ```typescript
 @InputType({ registerIn: () => CatsModule })
@@ -472,7 +472,7 @@ export const CatsUnion = createUnionType({
 });
 ```
 
-> info **Hint** `registerIn` accepts either a module class directly or a factory function returning the class. The factory form (`() => CatsModule`) is recommended when the type and module reference each other, since it defers module resolution and avoids temporal dead zone errors from circular imports.
+> info **Hint** You can pass either the module class itself or a factory function returning it. Prefer the factory form (`() => CatsModule`) whenever the type and the module reference each other, as it defers the module resolution and so avoids errors caused by circular imports.
 
 > warning **Warning** If you use the `@apollo/server` with `@as-integrations/fastify` package with multiple GraphQL endpoints in a single application, make sure to enable the `disableHealthCheck` setting in the `GraphQLModule` configuration.
 

--- a/content/graphql/quick-start.md
+++ b/content/graphql/quick-start.md
@@ -439,6 +439,41 @@ GraphQLModule.forRoot({
 }),
 ```
 
+In the **code first** approach, the `include` option only filters which modules are scanned for resolvers — types decorated with `@ObjectType()`, `@InputType()`, `@InterfaceType()`, `@ArgsType()`, or registered through `registerEnumType()` / `createUnionType()` are still included in every generated schema. To restrict a type to a specific module, set the `registerIn` option on the type:
+
+```typescript
+@ObjectType({ registerIn: () => CatsModule })
+export class Cat {
+  @Field()
+  name: string;
+}
+```
+
+When the schema is built with `include: [CatsModule]`, types tagged with `registerIn: () => CatsModule` are included; types tagged with another module are excluded. Types **without** `registerIn` keep the existing default behavior and are available in every schema that references them.
+
+The same option is supported on `@InputType()`, `@InterfaceType()`, `@ArgsType()`, `registerEnumType()`, and `createUnionType()`:
+
+```typescript
+@InputType({ registerIn: () => CatsModule })
+export class CreateCatInput {
+  @Field()
+  name: string;
+}
+
+registerEnumType(CatBreed, {
+  name: 'CatBreed',
+  registerIn: () => CatsModule,
+});
+
+export const CatsUnion = createUnionType({
+  name: 'CatsUnion',
+  types: () => [Lion, Tiger] as const,
+  registerIn: () => CatsModule,
+});
+```
+
+> info **Hint** `registerIn` accepts either a module class directly or a factory function returning the class. The factory form (`() => CatsModule`) is recommended when the type and module reference each other, since it defers module resolution and avoids temporal dead zone errors from circular imports.
+
 > warning **Warning** If you use the `@apollo/server` with `@as-integrations/fastify` package with multiple GraphQL endpoints in a single application, make sure to enable the `disableHealthCheck` setting in the `GraphQLModule` configuration.
 
 #### Third-party integrations

--- a/content/graphql/resolvers-map.md
+++ b/content/graphql/resolvers-map.md
@@ -80,6 +80,8 @@ title: string;
 
 > info **Hint** You can also add a description to, or deprecate, the whole object type: `@ObjectType({{ '{' }} description: 'Author model' {{ '}' }})`.
 
+> info **Hint** In the code first approach, when serving multiple GraphQL endpoints, pass `@ObjectType({{ '{' }} registerIn: () => YourModule {{ '}' }})` to scope the type to a specific module. The same option is available on `@InputType()`, `@InterfaceType()`, `@ArgsType()`, `registerEnumType()`, and `createUnionType()`. See [Multiple endpoints](/graphql/quick-start#multiple-endpoints) for details.
+
 When the field is an array, we must manually indicate the array type in the `Field()` decorator's type function, as shown below:
 
 ```typescript

--- a/content/graphql/resolvers-map.md
+++ b/content/graphql/resolvers-map.md
@@ -78,9 +78,7 @@ For example:
 title: string;
 ```
 
-> info **Hint** You can also add a description to, or deprecate, the whole object type: `@ObjectType({{ '{' }} description: 'Author model' {{ '}' }})`.
-
-> info **Hint** In the code first approach, when serving multiple GraphQL endpoints, pass `@ObjectType({{ '{' }} registerIn: () => YourModule {{ '}' }})` to scope the type to a specific module. The same option is available on `@InputType()`, `@InterfaceType()`, `@ArgsType()`, `registerEnumType()`, and `createUnionType()`. See [Multiple endpoints](/graphql/quick-start#multiple-endpoints) for details.
+> info **Hint** You can also add a description to, or deprecate, the whole object type: `@ObjectType({{ '{' }} description: 'Author model' {{ '}' }})`. Likewise, if your application serves [multiple GraphQL endpoints](/graphql/quick-start#multiple-endpoints), you can scope a type to a specific module: `@ObjectType({{ '{' }} registerIn: () => AuthorsModule {{ '}' }})`.
 
 When the field is an array, we must manually indicate the array type in the `Field()` decorator's type function, as shown below:
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:

## What is the current behavior?
The newly introduced `registerIn` option (see nestjs/graphql#3811) is not yet documented in the GraphQL section.

Related PR: https://github.com/nestjs/graphql/pull/3811

## What is the new behavior?
- Add a `registerIn` description to the **Multiple endpoints** section of `content/graphql/quick-start.md`, covering decorators (`@ObjectType`, `@InputType`, `@InterfaceType`, `@ArgsType`) and type factories (`registerEnumType`, `createUnionType`), plus the recommended factory form (`() => YourModule`) for circular references.
- Add a cross-reference **Hint** in `content/graphql/resolvers-map.md` next to the existing `@ObjectType` description Hint.

Both additions explicitly note that `registerIn` is a code-first only option.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
