### PR TITLE
docs(cache): note that get() returns undefined in cache-manager v7+

### DIFF
--- a/content/techniques/caching.md
+++ b/content/techniques/caching.md
@@ -40,7 +40,7 @@ constructor(@Inject(CACHE_MANAGER) private cacheManager: Cache) {}
 
 > info **Hint** The `Cache` class and the `CACHE_MANAGER` token are both imported from the `@nestjs/cache-manager` package.
 
-The `get` method on the `Cache` instance (from the `cache-manager` package) is used to retrieve items from the cache. If the item does not exist in the cache, `null` will be returned.
+The `get` method on the `Cache` instance (from the `cache-manager` package) is used to retrieve items from the cache. If the item does not exist in the cache, `undefined` will be returned (in `cache-manager` v6 and earlier, `null` was returned instead). Treat both as falsy when migrating.
 
 ```typescript
 const value = await this.cacheManager.get('key');


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?

Issue Number: N/A

The "Interacting with the Cache store" section of `content/techniques/caching.md` states that `cacheManager.get('key')` returns `null` on a cache miss:

> The `get` method on the `Cache` instance (from the `cache-manager` package) is used to retrieve items from the cache. If the item does not exist in the cache, `null` will be returned.

That hasn't been true since `cache-manager` v7 (Jun 2025), which is the version a fresh `npm install @nestjs/cache-manager cache-manager` resolves today. The current type signature is `Cache.get<T>(key: string): Promise<T | undefined>`, and the upstream change is [jaredwray/cacheable@ea37202](https://github.com/jaredwray/cacheable/commit/ea37202931e255b0dfd2f62d7121c84671b1f4fd) (PR [jaredwray/cacheable#1134](https://github.com/jaredwray/cacheable/pull/1134)), commit subject *"BREAKING: moving to undefined instead of null"* — every `null` return path was rewritten to `undefined` and the test suite migrated from `toBeNull()` to `toBeUndefined()`.

`@nestjs/cache-manager@3.1.2` declares `peerDependencies["cache-manager"]: ">=6"`, so a new install picks up cache-manager v7.x. The `CACHE_MANAGER` provider returns the upstream `cache-manager` instance as-is (`lib/cache.providers.ts` calls `createCache(...)` directly), so there is no Nest-side wrapper that would re-introduce `null`.

Reader impact: anyone copy-pasting after Jun 2025 who writes `if (value === null) { ... }` will silently miss every cache-miss branch. Invisible at compile time (the type is `T | undefined`, not `T | null`) and at runtime until a key actually expires.


## What is the new behavior?

The sentence is now version-aware:

```diff
-The `get` method on the `Cache` instance (from the `cache-manager` package) is used to retrieve items from the cache. If the item does not exist in the cache, `null` will be returned.
+The `get` method on the `Cache` instance (from the `cache-manager` package) is used to retrieve items from the cache. If the item does not exist in the cache, `undefined` will be returned (in `cache-manager` v6 and earlier, `null` was returned instead). Treat both as falsy when migrating.
```


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


## Other information

Happy to drop the parenthetical and use a `> info` callout instead if that fits the page's style better.