### PR TITLE
fix(router): redirect versioned deep-links to the correct page

### DIFF
--- a/src/app/app.routes.spec.ts
+++ b/src/app/app.routes.spec.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { UrlSegment } from '@angular/router';
+import { versionedUrlRedirect } from './shared/utils/versioned-redirect';
+
+function seg(path: string): UrlSegment {
+  return { path } as UrlSegment;
+}
+
+describe('versionedUrlRedirect', () => {
+  it('strips the version prefix and redirects to the matching page', () => {
+    expect(versionedUrlRedirect({ url: [seg('v10'), seg('migration-guide')] })).toBe(
+      '/migration-guide',
+    );
+  });
+
+  it('handles nested versioned paths', () => {
+    expect(
+      versionedUrlRedirect({ url: [seg('v10'), seg('techniques'), seg('caching')] }),
+    ).toBe('/techniques/caching');
+  });
+
+  it('redirects a versioned root URL to the homepage', () => {
+    expect(versionedUrlRedirect({ url: [seg('v10')] })).toBe('/');
+  });
+
+  it('redirects unknown paths to the homepage', () => {
+    expect(versionedUrlRedirect({ url: [seg('some-nonexistent-page')] })).toBe('/');
+  });
+
+  it('redirects an empty URL to the homepage', () => {
+    expect(versionedUrlRedirect({ url: [] })).toBe('/');
+  });
+});

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,4 +1,5 @@
 import { Routes, RouterModule, PreloadAllModules } from '@angular/router';
+import { versionedUrlRedirect } from './shared/utils/versioned-redirect';
 import { HomepageComponent } from './homepage/homepage.component';
 import { ApplicationContextComponent } from './homepage/pages/application-context/application-context.component';
 import { ComponentsComponent } from './homepage/pages/components/components.component';
@@ -186,7 +187,7 @@ export const routes: Routes = [
       },
     ],
   },
-  { path: '**', redirectTo: '', pathMatch: 'full' },
+  { path: '**', redirectTo: versionedUrlRedirect },
 ];
 
 export const RoutingModule = RouterModule.forRoot(routes, {

--- a/src/app/shared/utils/versioned-redirect.ts
+++ b/src/app/shared/utils/versioned-redirect.ts
@@ -1,0 +1,12 @@
+import { UrlSegment } from '@angular/router';
+
+export function versionedUrlRedirect({
+  url,
+}: {
+  url: UrlSegment[];
+}): string {
+  if (url.length > 0 && /^v\d+$/.test(url[0].path)) {
+    return '/' + url.slice(1).map((s) => s.path).join('/');
+  }
+  return '/';
+}


### PR DESCRIPTION
## Problem

Visiting a versioned deep-link (e.g. `https://docs.nestjs.com/v10/migration-guide`) hit the wildcard catch-all route and redirected to the homepage instead of the intended page. This broke:

- Search engine results linking directly to a page
- Shared deep-links
- Browser tab reloads

Reported in #3284 and #1819.

## Solution

Replace the static `redirectTo: ''` on the wildcard route with a `versionedUrlRedirect` function (Angular 17.1+ functional redirects). When the first URL segment matches a version prefix (`v` followed by digits), it strips that segment and redirects to the equivalent current-version path. All other unmatched URLs continue to redirect to the homepage.

Examples:
- `/v10/migration-guide` → `/migration-guide`
- `/v6/fundamentals/testing` → `/fundamentals/testing`
- `/v10/techniques/caching` → `/techniques/caching`
- `/v10` → `/`
- `/unknown-page` → `/`

## Changes

- `src/app/shared/utils/versioned-redirect.ts` — extracted redirect logic as a named, testable function
- `src/app/app.routes.ts` — wildcard route now uses `versionedUrlRedirect`
- `src/app/app.routes.spec.ts` — unit tests covering all cases

Closes #3284
Closes #1819