### PR TITLE
docs: validate uploaded file arrays

### DIFF
--- a/content/techniques/file-upload.md
+++ b/content/techniques/file-upload.md
@@ -197,6 +197,33 @@ uploadFile(files) {
 
 > info **Hint** The `FilesInterceptor()` decorator is exported from the `@nestjs/platform-express` package. The `@UploadedFiles()` decorator is exported from `@nestjs/common`.
 
+#### Validate uploaded files array
+
+To validate every file in an array, apply `ParseFilePipeBuilder` to `@UploadedFiles()`.
+
+```typescript
+@@filename()
+@Post('upload')
+@UseInterceptors(FilesInterceptor('files', 5))
+uploadFiles(
+  @UploadedFiles(
+    new ParseFilePipeBuilder()
+      .addFileTypeValidator({
+        fileType: /^image\/(jpeg|png|gif)$/,
+      })
+      .addMaxSizeValidator({ maxSize: 5242880 })
+      .build({
+        errorHttpStatusCode: HttpStatus.UNPROCESSABLE_ENTITY,
+      }),
+  )
+  files: Array<Express.Multer.File>,
+) {
+  console.log(files);
+}
+```
+
+> info **Hint** The `ParseFilePipeBuilder` API is the same as in single-file validation, and the validators are executed for every file in the uploaded array.
+
 #### Multiple files
 
 To upload multiple files (all with different field name keys), use the `FileFieldsInterceptor()` decorator. This decorator takes two arguments:

--- a/content/techniques/file-upload.md
+++ b/content/techniques/file-upload.md
@@ -197,9 +197,9 @@ uploadFile(files) {
 
 > info **Hint** The `FilesInterceptor()` decorator is exported from the `@nestjs/platform-express` package. The `@UploadedFiles()` decorator is exported from `@nestjs/common`.
 
-#### Validate uploaded files array
+#### Validating an array of files
 
-To validate every file in an array, apply `ParseFilePipeBuilder` to `@UploadedFiles()`.
+To validate an array of uploaded files, pass a pipe built with `ParseFilePipeBuilder` to the `@UploadedFiles()` decorator. The registered validators run against each file in the array.
 
 ```typescript
 @@filename()
@@ -221,8 +221,6 @@ uploadFiles(
   console.log(files);
 }
 ```
-
-> info **Hint** The `ParseFilePipeBuilder` API is the same as in single-file validation, and the validators are executed for every file in the uploaded array.
 
 #### Multiple files
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Documentation content changes

## What is the current behavior?

The file upload technique page shows validation for a single uploaded file, but the `FilesInterceptor()` section does not show how to validate each file in an uploaded array.

Issue Number: Fixes #2424

## What is the new behavior?

The `FilesInterceptor()` section now includes a `ParseFilePipeBuilder` example for `@UploadedFiles()` with MIME type and max size validation. The note clarifies that the validators are executed for every file in the uploaded array.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Local checks:

- `npm run docs-only` (passes; reports existing dangling-link warnings)
- `git diff --check`

Note: `npm ci --ignore-scripts` currently fails in this checkout because `package.json` and `package-lock.json` are out of sync for `chokidar`. I used `npm install --ignore-scripts --no-package-lock` to install dependencies without changing the lockfile before running `docs-only`.
