### PR TITLE
docs: fix typos and grammar in pipes and authorization

### DIFF
--- a/content/pipes.md
+++ b/content/pipes.md
@@ -330,7 +330,7 @@ async create(createCatDto) {
 
 > info **Hint** The `@UsePipes()` decorator is imported from the `@nestjs/common` package.
 
-The `ZodValidationPipe` can be applied to specific parameters and alongside built-in pipes. For example, where we want to validate the route path `id` parameter with the `ParseIntPipe` seperately from the request body:
+The `ZodValidationPipe` can be applied to specific parameters and alongside built-in pipes. For example, where we want to validate the route path `id` parameter with the `ParseIntPipe` separately from the request body:
 
 ```typescript
 @Put('/:id')

--- a/content/security/authorization.md
+++ b/content/security/authorization.md
@@ -265,9 +265,9 @@ export class CaslAbilityFactory {
 
 > info **Hint** `MongoAbility`, `AbilityBuilder`, `AbilityClass`, and `ExtractSubjectType` classes are exported from the `@casl/ability` package.
 
-> info **Hint** `detectSubjectType` option let CASL understand how to get subject type out of an object. For more information read [CASL documentation](https://casl.js.org/v6/en/guide/subject-type-detection#use-classes-as-subject-types) for details.
+> info **Hint** The `detectSubjectType` option lets CASL understand how to get the subject type out of an object. For more information, read the [CASL documentation](https://casl.js.org/v6/en/guide/subject-type-detection#use-classes-as-subject-types).
 
-In the example above, we created the `MongoAbility` instance using the `AbilityBuilder` class. As you probably guessed, `can` and `cannot` accept the same arguments but have different meanings, `can` allows to do an action on the specified subject and `cannot` forbids. Both may accept up to 4 arguments. To learn more about these functions, visit the official [CASL documentation](https://casl.js.org/v6/en/guide/intro).
+In the example above, we created the `MongoAbility` instance using the `AbilityBuilder` class. As you probably guessed, `can` and `cannot` accept the same arguments but have different meanings, `can` allows you to perform an action on the specified subject and `cannot` forbids it. Both may accept up to 4 arguments. To learn more about these functions, visit the official [CASL documentation](https://casl.js.org/v6/en/guide/intro).
 
 Lastly, make sure to add the `CaslAbilityFactory` to the `providers` and `exports` arrays in the `CaslModule` module definition:
 


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md

## PR Type

- [x] Docs

## What is the current behavior?

Three small text issues in the documentation:

1. **`content/pipes.md`** — "seperately" misspelled.
2. **`content/security/authorization.md`** (hint about `detectSubjectType`) — subject-verb agreement ("option let CASL") and redundant "for more information ... for details".
3. **`content/security/authorization.md`** (CASL `can`/`cannot` paragraph) — ungrammatical "allows to do an action".

Issue Number: N/A

## What is the new behavior?

1. "seperately" → "separately".
2. "`detectSubjectType` option let CASL understand how to get subject type" → "The `detectSubjectType` option lets CASL understand how to get the subject type", and removed the redundant trailing "for details".
3. "`can` allows to do an action on the specified subject and `cannot` forbids" → "`can` allows you to perform an action on the specified subject and `cannot` forbids it".

## Does this PR introduce a breaking change?

- [x] No