### PR TITLE
docs(sse): document client disconnection and observable cleanup

### DIFF
--- a/content/techniques/server-sent-events.md
+++ b/content/techniques/server-sent-events.md
@@ -43,6 +43,24 @@ eventSource.onmessage = ({ data }) => {
 };
 ```
 
+#### Client disconnection
+
+When a client closes the SSE connection (e.g., `eventSource.close()`), NestJS automatically unsubscribes from the returned Observable, which stops the event stream and cleans up any associated resources — including the interval timer in the example above.
+
+To run custom teardown logic when a client disconnects, use the `finalize` operator:
+
+```typescript
+@Sse('sse')
+sse(): Observable<MessageEvent> {
+  return interval(1000).pipe(
+    map((_) => ({ data: { hello: 'world' } })),
+    finalize(() => console.log('Client disconnected')),
+  );
+}
+```
+
+> info **Hint** The `finalize` operator (imported from `rxjs`) executes its callback whenever the Observable terminates — by completion, error, or unsubscription (which includes client disconnect). This makes it the right place to release external resources such as database cursors or file handles tied to the stream.
+
 #### Example
 
 A working example is available [here](https://github.com/nestjs/nest/tree/master/sample/28-sse).


### PR DESCRIPTION
## Summary

Closes #3296.

Users reported confusion about whether the `interval(1000)` Observable in the SSE example continues running after `eventSource.close()` is called on the client, potentially causing memory leaks.

## Investigation

Inspecting `@nestjs/core`'s `router/router-response-controller.js` confirms that NestJS **already handles cleanup automatically**:

```js
const onClose = () => {
    subscription.unsubscribe();
    stream.end();
    response.end();
};
request.on('close', onClose);
```

When the client closes the connection, the `close` event fires and NestJS calls `subscription.unsubscribe()`, which properly tears down the RxJS chain — including the `setInterval` behind `interval()`. There is no memory leak in the basic example.

The problem was purely a documentation gap: the current SSE page says nothing about cleanup behavior.

## Change

Added a short `Client disconnection` section to `content/techniques/server-sent-events.md` that:

- Clarifies that NestJS automatically unsubscribes the Observable when the client disconnects
- Shows the `finalize` operator as the idiomatic hook for custom teardown logic (e.g., closing DB cursors, flushing logs)
- Keeps the same import style (`rxjs`) and writing style as the rest of the page

## Test plan

- [x] Verify the new section renders correctly on the docs site
- [x] Confirm the `finalize` code example is syntactically valid TypeScript