### PR TITLE
chore(faq): add route conflict detection faq and controllers hint for v12.0.0

### DIFF
--- a/content/controllers.md
+++ b/content/controllers.md
@@ -269,6 +269,8 @@ Routes with static paths won’t work when you need to accept **dynamic data** a
 
 > info **Hint** Routes with parameters should be declared after any static paths. This prevents the parameterized paths from intercepting traffic destined for the static paths.
 
+> info **Hint** As of v12, Nest provides built-in guardrails for this problem. You can enable `routeConflictPolicy` to detect silent route shadowing at bootstrap time, and `routeResolutionStrategy: 'specificity'` to have Nest automatically register more-specific routes first — regardless of declaration order. See the [Route conflict detection](/faq/route-conflict) page for details.
+
 ```typescript
 @@filename()
 @Get(':id')

--- a/content/faq/route-conflict.md
+++ b/content/faq/route-conflict.md
@@ -1,0 +1,132 @@
+### Route conflict detection
+
+When using Express (the default adapter), NestJS registers routes in the order they are declared. This means a parametric route like `@Get(':id')` can silently steal traffic meant for a more specific route like `@Get('me')` if it happens to be declared first. The tricky part is that nothing goes wrong at startup. The application boots cleanly and the problem only shows up at runtime when requests start going to the wrong handler.
+
+> warning **Warning** Adding a pipe like `ParseIntPipe` to the parametric route does not help here. Pipes run **after** the router has already picked a handler, so the wrong handler is still called.
+
+As of v12, Nest provides two opt-in options on `NestApplicationOptions` that give you more control over this.
+
+#### Route conflict policy
+
+The `routeConflictPolicy` option tells Nest to inspect routes at bootstrap time and report any conflicts it finds. It accepts an object with two independent keys, `duplicate` and `shadow`. Each key can be set to `'off'` (the default, no check performed), `'warn'` (log a warning), or `'error'` (throw at startup).
+
+| Kind | Triggers when |
+| --- | --- |
+| `duplicate` | Two routes share the same method, path, host, and version. |
+| `shadow` | Two routes can match the same request, e.g. `/users/me` and `/users/:id`. |
+
+```typescript
+const app = await NestFactory.create(AppModule, {
+  routeConflictPolicy: { duplicate: 'error', shadow: 'warn' },
+});
+```
+
+With `'warn'`, Nest prints a warning for each conflicting pair before the server starts. With `'error'`, every conflict is collected into a single `RouteConflictException` that is thrown during `app.listen()`, so you see all problems at once rather than one per application restart.
+
+```typescript
+import { RouteConflictException } from '@nestjs/core';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule, {
+    routeConflictPolicy: { duplicate: 'error', shadow: 'error' },
+  });
+
+  try {
+    await app.listen(3000);
+  } catch (err) {
+    if (err instanceof RouteConflictException) {
+      console.error(err.message);
+      process.exit(1);
+    }
+    throw err;
+  }
+}
+bootstrap();
+```
+
+#### Route resolution strategy
+
+The `routeResolutionStrategy` option controls the order in which routes are handed to the underlying HTTP adapter. It accepts either `'declaration'` (the default, keeps existing behavior) or `'specificity'`.
+
+With `'specificity'`, Nest sorts routes before registering them so that the most specific ones are always registered first. Literal segments win over parametric segments, which win over wildcards. This means the example below works correctly no matter which handler is declared first:
+
+```typescript
+@@filename(users.controller)
+@Controller('users')
+export class UsersController {
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return `User #${id}`;
+  }
+
+  @Get('me')
+  getMe() {
+    return 'the current user';
+  }
+}
+@@switch
+@Controller('users')
+export class UsersController {
+  @Get(':id')
+  @Bind(Param('id'))
+  findOne(id) {
+    return `User #${id}`;
+  }
+
+  @Get('me')
+  getMe() {
+    return 'the current user';
+  }
+}
+```
+
+```typescript
+@@filename(main)
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule, {
+    routeResolutionStrategy: 'specificity',
+  });
+  await app.listen(3000);
+}
+bootstrap();
+```
+
+Even though `@Get(':id')` is declared first, `GET /users/me` will reach `getMe()` because Nest registers `/me` before `/:id`.
+
+Both options can be combined:
+
+```typescript
+@@filename(main)
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule, {
+    routeConflictPolicy: { duplicate: 'error', shadow: 'warn' },
+    routeResolutionStrategy: 'specificity',
+  });
+  await app.listen(3000);
+}
+bootstrap();
+```
+
+#### Adapter differences
+
+These options work slightly differently depending on which HTTP adapter your application uses.
+
+**Express** is order-sensitive, so both conflict kinds (`duplicate` and `shadow`) are active, and `'specificity'` re-orders routes before they are registered.
+
+**Fastify** uses a radix-tree router (`find-my-way`) that already handles route specificity internally, so literal segments always win over parametric ones regardless of registration order. For this reason:
+
+- The `shadow` kind is automatically suppressed when running on Fastify. Since Fastify's router never misroutes these cases, reporting them would just be false positives.
+- The `duplicate` kind remains active. Registering two routes with the same method, path, host, and version is a genuine bug on any adapter. When Fastify encounters one it throws `FST_ERR_DUPLICATED_ROUTE` and crashes. Setting `duplicate: 'warn'` or `duplicate: 'error'` lets Nest catch these before the adapter does and surface a descriptive `RouteConflictException` instead.
+- Setting `routeResolutionStrategy: 'specificity'` on Fastify is a no-op since the adapter already handles ordering itself.
+
+#### Available types
+
+The following types are exported from `@nestjs/common`:
+
+```typescript
+import {
+  RouteConflictPolicy,
+  RouteConflictPolicyLevel,
+  RouteResolutionStrategy,
+} from '@nestjs/common';
+```

--- a/src/app/homepage/menu/menu.component.ts
+++ b/src/app/homepage/menu/menu.component.ts
@@ -271,6 +271,7 @@ export class MenuComponent implements OnInit {
           path: '/faq/keep-alive-connections',
         },
         { title: 'Global path prefix', path: '/faq/global-prefix' },
+        { title: 'Route conflict detection', path: '/faq/route-conflict' },
         { title: 'Raw body', path: '/faq/raw-body' },
         { title: 'Hybrid application', path: '/faq/hybrid-application' },
         { title: 'HTTPS & multiple servers', path: '/faq/multiple-servers' },

--- a/src/app/homepage/pages/faq/faq.routes.ts
+++ b/src/app/homepage/pages/faq/faq.routes.ts
@@ -7,6 +7,7 @@ import { KeepAliveConnectionsComponent } from './keep-alive-connections/keep-ali
 import { MultipleServersComponent } from './multiple-servers/multiple-servers.component';
 import { RawBodyComponent } from './raw-body/raw-body.component';
 import { RequestLifecycleComponent } from './request-lifecycle/request-lifecycle.component';
+import { RouteConflictComponent } from './route-conflict/route-conflict.component';
 import { ServerlessComponent } from './serverless/serverless.component';
 
 export const FAQ_ROUTES: Routes = [
@@ -49,6 +50,11 @@ export const FAQ_ROUTES: Routes = [
     path: 'common-errors',
     component: ErrorsComponent,
     data: { title: 'Common errors - FAQ' },
+  },
+  {
+    path: 'route-conflict',
+    component: RouteConflictComponent,
+    data: { title: 'Route conflict detection - FAQ' },
   },
   {
     path: 'serverless',

--- a/src/app/homepage/pages/faq/route-conflict/route-conflict.component.ts
+++ b/src/app/homepage/pages/faq/route-conflict/route-conflict.component.ts
@@ -1,0 +1,15 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { BasePageComponent } from '../../page/page.component';
+import { HeaderAnchorDirective } from '../../../../shared/directives/header-anchor.directive';
+import { CopyButtonComponent } from '../../../../shared/components/copy-button/copy-button.component';
+import { TabsComponent } from '../../../../shared/components/tabs/tabs.component';
+import { ExtensionPipe } from '../../../../shared/pipes/extension.pipe';
+
+@Component({
+  selector: 'app-route-conflict',
+  templateUrl: './route-conflict.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  standalone: true,
+  imports: [HeaderAnchorDirective, CopyButtonComponent, TabsComponent, ExtensionPipe],
+})
+export class RouteConflictComponent extends BasePageComponent {}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?

The Controllers page mentions that parametric routes should be declared after static paths to avoid shadowing, but gives no further guidance. There is no documentation for the `routeConflictPolicy` and `routeResolutionStrategy` options introduced in v12.

Issue Number: N/A


## What is the new behavior?

- A hint is added to the **Controllers > Route parameters** section pointing users to the new guardrails available in v12.
- A new **FAQ page** (`/faq/route-conflict`) is added that covers:
  - What route shadowing is and why it is hard to catch
  - `routeConflictPolicy` — how to detect duplicate and shadow conflicts at bootstrap time with `'off'`, `'warn'`, or `'error'` severity levels
  - `routeResolutionStrategy: 'specificity'` — how to have Nest automatically register more-specific routes first regardless of declaration order
  - Adapter differences between Express and Fastify
  - The public types exported from `@nestjs/common`


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


## Other information

Related to nestjs/nest#16954, which introduced these features in v12.