### PR TITLE
docs(throttler): note handleRequest runs per throttler in WebSockets example

### DIFF
--- a/content/security/rate-limiting.md
+++ b/content/security/rate-limiting.md
@@ -213,6 +213,7 @@ There's a few things to keep in mind when working with WebSockets:
 
 - Guard cannot be registered with the `APP_GUARD` or `app.useGlobalGuards()`
 - When a limit is reached, Nest will emit an `exception` event, so make sure there is a listener ready for this
+- When multiple named throttlers are configured (for example a `short` and a `long` limit), `handleRequest` is invoked once per throttler for the same message. The example above is safe for that case because the storage key is namespaced by `throttler.name`, but any extra logic you add inside `handleRequest` (logging, custom side effects) will also run per throttler
 
 > info **Hint** If you are using the `@nestjs/platform-ws` package you can use `client._socket.remoteAddress` instead.
 


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows the project's commit message guidelines

## PR Type

- [x] Docs

## What is the current behavior?

The WebSockets example under [Security > Rate Limiting](https://docs.nestjs.com/security/rate-limiting#websockets) doesn't mention that, when the user configures multiple named throttlers, the `WsThrottlerGuard.handleRequest` method is invoked once per throttler for the same message. The example code itself already works correctly in that case (the storage key is namespaced by `throttler.name`), but a reader copying the example may add per-request side effects assuming `handleRequest` only runs once.

Issue Number: #3041

## What is the new behavior?

Adds one bullet to the existing "things to keep in mind when working with WebSockets" list, calling out the per-throttler invocation and noting that the existing example is safe but extra side effects added by the user will also run per throttler.

Kept the change deliberately small — the existing example doesn't need to be rewritten, only the surrounding prose needed to fill the gap.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No