### PR TITLE
docs: correct pipe name FileParsePipe to ParseFilePipe in file upload guide

### DIFF
--- a/content/techniques/file-upload.md
+++ b/content/techniques/file-upload.md
@@ -133,7 +133,7 @@ export abstract class FileValidator<TValidationOptions = Record<string, any>> {
 - `MaxFileSizeValidator` - Checks if a given file's size is less than the provided value (measured in `bytes`)
 - `FileTypeValidator` - Checks if a given file's mime-type matches a given string or RegExp.  By default, validates the mime-type using file content [magic number](https://www.ibm.com/support/pages/what-magic-number)
 
-To understand how these can be used in conjunction with the aforementioned `FileParsePipe`, we'll use an altered snippet of the last presented example:
+To understand how these can be used in conjunction with the aforementioned `ParseFilePipe`, we'll use an altered snippet of the last presented example:
 
 ```typescript
 @UploadedFile(


### PR DESCRIPTION
The file upload techniques page refers to `FileParsePipe` once, in the sentence introducing the validators snippet:

> To understand how these can be used in conjunction with the aforementioned `FileParsePipe`...

The class is actually `ParseFilePipe`. Every other mention in the same guide uses the correct name, and the code block right after this sentence instantiates `new ParseFilePipe({...})`. A reader searching for `FileParsePipe` in the API would come up empty, so this swaps the one stray reference to the real class name.