### PR TITLE
docs: fix typos and incorrect identifiers in code examples

### DIFF
--- a/content/devtools/overview.md
+++ b/content/devtools/overview.md
@@ -40,7 +40,7 @@ export class AppModule {}
 
 > warning **Warning** The reason we are checking the `NODE_ENV` environment variable here is that you should never use this module in production!
 
-Once the `DevtoolsModule` is imported and your application is up and running (`npm run start:dev`), you should be able to navigate to [Devtools](https://devtools.nestjs.com) URL and see the instrospected graph.
+Once the `DevtoolsModule` is imported and your application is up and running (`npm run start:dev`), you should be able to navigate to [Devtools](https://devtools.nestjs.com) URL and see the introspected graph.
 
 <figure><img src="/assets/devtools/modules-graph.png" /></figure>
 

--- a/content/faq/request-lifecycle.md
+++ b/content/faq/request-lifecycle.md
@@ -26,7 +26,7 @@ export class CatsController {
 
 `Guard1` will execute before `Guard2` and both will execute before `Guard3`.
 
-> info **Hint** When speaking about globally bound vs controller or locally bound, the difference is where the guard (or other component is bound). If you are using `app.useGlobalGuard()` or providing the component via a module, it is globally bound. Otherwise, it is bound to a controller if the decorator precedes a controller class, or to a route if the decorator precedes a route declaration.
+> info **Hint** When speaking about globally bound vs controller or locally bound, the difference is where the guard (or other component is bound). If you are using `app.useGlobalGuards()` or providing the component via a module, it is globally bound. Otherwise, it is bound to a controller if the decorator precedes a controller class, or to a route if the decorator precedes a route declaration.
 
 #### Interceptors
 

--- a/content/graphql/federation.md
+++ b/content/graphql/federation.md
@@ -214,7 +214,7 @@ import { PostsResolver } from './posts.resolver';
       typePaths: ['**/*.graphql'],
     }),
   ],
-  providers: [PostsResolvers],
+  providers: [PostsResolver],
 })
 export class AppModule {}
 ```
@@ -320,8 +320,8 @@ import {
 } from '@nestjs/apollo';
 import { Module } from '@nestjs/common';
 import { User } from './user.entity';
-import { PostsResolvers } from './posts.resolvers';
-import { UsersResolvers } from './users.resolvers';
+import { PostsResolver } from './posts.resolvers';
+import { UsersResolver } from './users.resolvers';
 import { PostsService } from './posts.service'; // Not included in example
 
 @Module({
@@ -585,7 +585,7 @@ import { PostsResolver } from './posts.resolver';
       typePaths: ['**/*.graphql'],
     }),
   ],
-  providers: [PostsResolvers],
+  providers: [PostsResolver],
 })
 export class AppModule {}
 ```
@@ -691,8 +691,8 @@ import {
 } from '@nestjs/mercurius';
 import { Module } from '@nestjs/common';
 import { User } from './user.entity';
-import { PostsResolvers } from './posts.resolvers';
-import { UsersResolvers } from './users.resolvers';
+import { PostsResolver } from './posts.resolvers';
+import { UsersResolver } from './users.resolvers';
 import { PostsService } from './posts.service'; // Not included in example
 
 @Module({
@@ -847,8 +847,8 @@ import {
 } from '@nestjs/apollo';
 import { Module } from '@nestjs/common';
 import { User } from './user.entity';
-import { PostsResolvers } from './posts.resolvers';
-import { UsersResolvers } from './users.resolvers';
+import { PostsResolver } from './posts.resolvers';
+import { UsersResolver } from './users.resolvers';
 import { PostsService } from './posts.service'; // Not included in example
 
 @Module({

--- a/content/graphql/schema-generator.md
+++ b/content/graphql/schema-generator.md
@@ -25,7 +25,7 @@ The `gqlSchemaFactory.create()` method takes an array of resolver class referenc
 const schema = await gqlSchemaFactory.create([
   RecipesResolver,
   AuthorsResolver,
-  PostsResolvers,
+  PostsResolver,
 ]);
 ```
 
@@ -33,7 +33,7 @@ It also takes a second optional argument with an array of scalar classes:
 
 ```typescript
 const schema = await gqlSchemaFactory.create(
-  [RecipesResolver, AuthorsResolver, PostsResolvers],
+  [RecipesResolver, AuthorsResolver, PostsResolver],
   [DurationScalar, DateScalar],
 );
 ```

--- a/content/microservices/custom-transport.md
+++ b/content/microservices/custom-transport.md
@@ -269,7 +269,7 @@ If you need to add some custom logic around the serialization of responses on th
 
 ```typescript
 @@filename(error-handling.proxy)
-import { ClientTcp, RpcException } from '@nestjs/microservices';
+import { ClientTCP, RpcException } from '@nestjs/microservices';
 
 class ErrorHandlingProxy extends ClientTCP {
   serializeError(err: Error) {

--- a/content/migration.md
+++ b/content/migration.md
@@ -95,7 +95,7 @@ bootstrap();
 By default, only [CORS-safelisted methods](https://fetch.spec.whatwg.org/#methods) are allowed. If you need to enable additional methods (such as `PUT`, `PATCH`, or `DELETE`), you must explicitly define them in the `methods` option.
 
 ```typescript
-const methods = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE']; // OR comma-delimited string 'GET,POST,PUT,PATH,DELETE'
+const methods = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE']; // OR comma-delimited string 'GET,POST,PUT,PATCH,DELETE'
 
 const app = await NestFactory.create<NestFastifyApplication>(
   AppModule,

--- a/content/recipes/mongodb.md
+++ b/content/recipes/mongodb.md
@@ -69,7 +69,7 @@ export const CatSchema = new mongoose.Schema({
 });
 ```
 
-The `CatsSchema` belongs to the `cats` directory. This directory represents the `CatsModule`.
+The `CatSchema` belongs to the `cats` directory. This directory represents the `CatsModule`.
 
 Now it's time to create a **Model** provider:
 

--- a/content/recipes/nest-commander.md
+++ b/content/recipes/nest-commander.md
@@ -38,7 +38,7 @@ By default, Nest's logger is disabled when using the `CommandFactory`. It's poss
 ```ts
 import { CommandFactory } from 'nest-commander';
 import { AppModule } from './app.module';
-import { LogService } './log.service';
+import { LogService } from './log.service';
 
 async function bootstrap() {
   await CommandFactory.run(AppModule, new LogService());

--- a/content/security/rate-limiting.md
+++ b/content/security/rate-limiting.md
@@ -258,7 +258,7 @@ The following options are valid for the object passed to the array of the `Throt
   </tr>
   <tr>
     <td><code>skipIf</code></td>
-    <td>a function that takes in the <code>ExecutionContext</code> and returns a <code>boolean</code> to short circuit the throttler logic. Like <code>@SkipThrottler()</code>, but based on the request</td>
+    <td>a function that takes in the <code>ExecutionContext</code> and returns a <code>boolean</code> to short circuit the throttler logic. Like <code>@SkipThrottle()</code>, but based on the request</td>
   </tr>
 </table>
 
@@ -275,7 +275,7 @@ If you need to set up storage instead, or want to use some of the above options 
   </tr>
   <tr>
     <td><code>skipIf</code></td>
-    <td>a function that takes in the <code>ExecutionContext</code> and returns a <code>boolean</code> to short circuit the throttler logic. Like <code>@SkipThrottler()</code>, but based on the request</td>
+    <td>a function that takes in the <code>ExecutionContext</code> and returns a <code>boolean</code> to short circuit the throttler logic. Like <code>@SkipThrottle()</code>, but based on the request</td>
   </tr>
   <tr>
     <td><code>throttlers</code></td>

--- a/content/techniques/mongo.md
+++ b/content/techniques/mongo.md
@@ -327,7 +327,7 @@ Middleware (also called pre and post hooks) are functions which are passed contr
       {
         name: Cat.name,
         useFactory: () => {
-          const schema = CatsSchema;
+          const schema = CatSchema;
           schema.pre('save', function () {
             console.log('Hello from pre save');
           });
@@ -350,7 +350,7 @@ Like other [factory providers](https://docs.nestjs.com/fundamentals/custom-provi
         name: Cat.name,
         imports: [ConfigModule],
         useFactory: (configService: ConfigService) => {
-          const schema = CatsSchema;
+          const schema = CatSchema;
           schema.pre('save', function() {
             console.log(
               `${configService.get('APP_NAME')}: Hello from pre save`,
@@ -377,7 +377,7 @@ To register a [plugin](https://mongoosejs.com/docs/plugins.html) for a given sch
       {
         name: Cat.name,
         useFactory: () => {
-          const schema = CatsSchema;
+          const schema = CatSchema;
           schema.plugin(require('mongoose-autopopulate'));
           return schema;
         },
@@ -435,7 +435,7 @@ export const EventSchema = SchemaFactory.createForClass(Event);
 > info **Hint** The way mongoose tells the difference between the different discriminator models is by the "discriminator key", which is `__t` by default. Mongoose adds a String path called `__t` to your schemas that it uses to track which discriminator this document is an instance of.
 > You may also use the `discriminatorKey` option to define the path for discrimination.
 
-`SignedUpEvent` and `ClickedLinkEvent` instances will be stored in the same collection as generic events.
+`SignUpEvent` and `ClickedLinkEvent` instances will be stored in the same collection as generic events.
 
 Now, let's define the `ClickedLinkEvent` class, as follows:
 


### PR DESCRIPTION
While reading through the docs I found a handful of code examples and references that name things that do not match the surrounding code or the framework API. Each one would leave a reader copying the snippet with something that does not compile or that points at a class/method that does not exist. All are one-token fixes:

- **migration.md**: the comma-delimited `methods` string spells the verb `PATH` instead of `PATCH` (the array on the same line uses `PATCH`).
- **techniques/mongo.md**: three schema-factory snippets use `CatsSchema`, which is never defined; the schema is `CatSchema`. Prose also calls the discriminator class `SignedUpEvent`, but it is defined as `SignUpEvent`.
- **recipes/mongodb.md**: prose calls the schema `CatsSchema`; the file defines and uses `CatSchema`.
- **faq/request-lifecycle.md**: `app.useGlobalGuard()` should be `app.useGlobalGuards()`.
- **security/rate-limiting.md**: the `skipIf` rows reference `@SkipThrottler()`; the decorator is `@SkipThrottle()`.
- **microservices/custom-transport.md**: the import is `ClientTcp` while the class on the next line extends `ClientTCP`.
- **graphql/federation.md** and **graphql/schema-generator.md**: `PostsResolvers` and `UsersResolvers` are imported and listed as providers, but the classes are `PostsResolver` and `UsersResolver` (singular), consistent with `RecipesResolver` and `AuthorsResolver`.
- **recipes/nest-commander.md**: an import is missing the `from` keyword.
- **devtools/overview.md**: `instrospected` -> `introspected`.

Happy to split this into separate PRs if you'd prefer.