### PR TITLE
docs(throttler): clarify websocket throttler definitions

### DIFF
--- a/content/security/rate-limiting.md
+++ b/content/security/rate-limiting.md
@@ -216,6 +216,8 @@ There's a few things to keep in mind when working with WebSockets:
 
 > info **Hint** If you are using the `@nestjs/platform-ws` package you can use `client._socket.remoteAddress` instead.
 
+> info **Hint** When you configure [multiple throttler definitions](/security/rate-limiting#multiple-throttler-definitions), `handleRequest()` runs once for each throttler set. Use the `throttler.name` from `ThrottlerRequest` when generating the storage key and when reporting the `ThrottlerLimitDetail`, as shown above, so each named throttler tracks its own limit.
+
 #### GraphQL
 
 The `ThrottlerGuard` can also be used to work with GraphQL requests. Again, the guard can be extended, but this time the `getRequestResponse` method will be overridden


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md#commit
- [x] Docs have been added / updated

## PR Type
What kind of change does this PR introduce?

- [x] Documentation content changes

## What is the current behavior?
The WebSocket throttler example does not explicitly mention that `handleRequest()` is called for each configured throttler definition when multiple throttler sets are used.

Issue Number: #3041

## What is the new behavior?
Adds a hint to the WebSocket rate limiting section explaining that `handleRequest()` runs once for each throttler set and that `throttler.name` should be used when generating keys/reporting limit details so named throttlers are tracked independently.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information
Verified with:

```bash
npm run docs-only
```