### PR TITLE
docs(controllers): mention the query http method

### DIFF
--- a/content/controllers.md
+++ b/content/controllers.md
@@ -189,7 +189,7 @@ export class CatsController {
 }
 ```
 
-It's that simple. Nest provides decorators for all of the standard HTTP methods: `@Get()`, `@Post()`, `@Put()`, `@Delete()`, `@Patch()`, `@Options()`, and `@Head()`. In addition, `@All()` defines an endpoint that handles all of them.
+It's that simple. Nest provides decorators for all of the standard HTTP methods: `@Get()`, `@Post()`, `@Put()`, `@Delete()`, `@Patch()`, `@Options()`, `@Head() and @QueryMethod()`. In addition, `@All()` defines an endpoint that handles all of them.
 
 #### Route wildcards
 

--- a/content/controllers.md
+++ b/content/controllers.md
@@ -205,7 +205,7 @@ export class CatsController {
 }
 ```
 
-It's that simple. Nest provides decorators for all of the standard HTTP methods: `@Get()`, `@Post()`, `@Put()`, `@Delete()`, `@Patch()`, `@Options()`, `@Head() and @QueryMethod()`. In addition, `@All()` defines an endpoint that handles all of them.
+It's that simple. Nest provides decorators for all of the standard HTTP methods: `@Get()`, `@Post()`, `@Put()`, `@Delete()`, `@Patch()`, `@Options()`, `@Head()`, and `@QueryMethod()` (which maps to the `QUERY` method and is named this way to avoid a clash with the `@Query()` parameter decorator). In addition, `@All()` defines an endpoint that handles all of them.
 
 #### Route wildcards
 

--- a/content/controllers.md
+++ b/content/controllers.md
@@ -205,7 +205,7 @@ export class CatsController {
 }
 ```
 
-It's that simple. Nest provides decorators for all of the standard HTTP methods: `@Get()`, `@Post()`, `@Put()`, `@Delete()`, `@Patch()`, `@Options()`, and `@Head()`. In addition, `@All()` defines an endpoint that handles all of them.
+It's that simple. Nest provides decorators for all of the standard HTTP methods: `@Get()`, `@Post()`, `@Put()`, `@Delete()`, `@Patch()`, `@Options()`, `@Head() and @QueryMethod()`. In addition, `@All()` defines an endpoint that handles all of them.
 
 #### Route wildcards
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [X] Docs
- [ ] Other... Please describe:


## What is the current behavior?
The `QUERY` HTTP method is not mentioned in the controllers documentation.

## What is the new behavior?
The controllers documentation now mentions the `QUERY` HTTP method alongside the other standard method decorators.


## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No


## Other information
Relates to [this issue on the NestJS repository](https://github.com/nestjs/nest/issues/17161)
and [this PR](https://github.com/nestjs/nest/pull/17162) that implements the actual feature.