### PR TITLE
docs(custom-decorators): specify getRequest type

### DIFF
--- a/content/custom-decorators.md
+++ b/content/custom-decorators.md
@@ -95,6 +95,21 @@ async findOne(user) {
 }
 ```
 
+> info **Hint** For TypeScript users, note that `ctx.switchToHttp().getRequest<T>()` depends on the framework used, for example if you are using express you can specify the appropriate type
+> 
+> ```typescript
+> @@filename(user.decorator)
+> import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+> import type { Request } from 'express';
+> export const Page = createParamDecorator(
+>  (data: never, ctx: ExecutionContext) => {
+>    const request = ctx.switchToHttp().getRequest<Request>();
+>    return request.query['page'] ?? 0;
+>  },
+> );
+> ```
+
+
 #### Passing data
 
 When the behavior of your decorator depends on some conditions, you can use the `data` parameter to pass an argument to the decorator's factory function. One use case for this is a custom decorator that extracts properties from the request object by key. Let's assume, for example, that our <a href="techniques/authentication#implementing-passport-strategies">authentication layer</a> validates requests and attaches a user entity to the request object. The user entity for an authenticated request might look like:


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

I was a bit lost trying to create a decorator which parse the query parameter of my request, because by default using the provided example, the request is typed as `any`.