### PR TITLE
docs(websockets): add JWT connection authentication guide

### DIFF
--- a/content/websockets/guards.md
+++ b/content/websockets/guards.md
@@ -24,3 +24,104 @@ handleEvent(client, data) {
   return { event, data };
 }
 ```
+
+#### Authenticating connections
+
+Guards bound with `@UseGuards()` protect `@SubscribeMessage()` handlers, but the initial Socket.IO connection is established in `handleConnection()` before those handlers run. To reject unauthorized clients at connect time, validate credentials inside `OnGatewayConnection.handleConnection()` and call `client.disconnect()` when validation fails.
+
+With socket.io, clients can pass a JWT in `handshake.auth` (recommended) or the `Authorization` header:
+
+```typescript
+@@filename(events.gateway)
+import { ConnectedSocket, OnGatewayConnection, WebSocketGateway } from '@nestjs/websockets';
+import { Socket } from 'socket.io';
+import { JwtService } from '@nestjs/jwt';
+
+@WebSocketGateway({ namespace: 'events' })
+export class EventsGateway implements OnGatewayConnection {
+  constructor(private readonly jwtService: JwtService) {}
+
+  async handleConnection(@ConnectedSocket() client: Socket) {
+    const token = this.extractToken(client);
+
+    if (!token) {
+      client.disconnect();
+      return;
+    }
+
+    try {
+      const payload = await this.jwtService.verifyAsync(token);
+      await client.join(`user:${payload.sub}`);
+    } catch {
+      client.disconnect();
+    }
+  }
+
+  private extractToken(client: Socket): string | undefined {
+    const authToken = client.handshake.auth?.token;
+
+    if (typeof authToken === 'string') {
+      return authToken.replace(/^Bearer\s+/i, '');
+    }
+
+    const authorization = client.handshake.headers.authorization;
+
+    if (typeof authorization === 'string') {
+      return authorization.replace(/^Bearer\s+/i, '');
+    }
+  }
+}
+@@switch
+import { WebSocketGateway } from '@nestjs/websockets';
+
+@WebSocketGateway({ namespace: 'events' })
+export class EventsGateway {
+  constructor(jwtService) {
+    this.jwtService = jwtService;
+  }
+
+  async handleConnection(client) {
+    const token = this.extractToken(client);
+
+    if (!token) {
+      client.disconnect();
+      return;
+    }
+
+    try {
+      const payload = await this.jwtService.verifyAsync(token);
+      await client.join(`user:${payload.sub}`);
+    } catch {
+      client.disconnect();
+    }
+  }
+
+  extractToken(client) {
+    const authToken = client.handshake.auth?.token;
+
+    if (typeof authToken === 'string') {
+      return authToken.replace(/^Bearer\s+/i, '');
+    }
+
+    const authorization = client.handshake.headers.authorization;
+
+    if (typeof authorization === 'string') {
+      return authorization.replace(/^Bearer\s+/i, '');
+    }
+  }
+}
+```
+
+Client example:
+
+```typescript
+import { io } from 'socket.io-client';
+
+const socket = io('http://localhost:3000/events', {
+  auth: {
+    token: 'Bearer <jwt>',
+  },
+});
+```
+
+> info **Hint** Method-scoped guards still apply to incoming messages after the connection is accepted. Use both patterns when you need to protect the handshake and individual events.

--- a/src/app/homepage/pages/websockets/guards/guards.component.ts
+++ b/src/app/homepage/pages/websockets/guards/guards.component.ts
@@ -4,6 +4,7 @@ import { RouterLink } from '@angular/router';
 import { HeaderAnchorDirective } from '../../../../shared/directives/header-anchor.directive';
 import { CopyButtonComponent } from '../../../../shared/components/copy-button/copy-button.component';
 import { TabsComponent } from '../../../../shared/components/tabs/tabs.component';
+import { ExtensionPipe } from '../../../../shared/pipes/extension.pipe';
 
 @Component({
     selector: 'app-guards',
@@ -15,6 +16,7 @@ import { TabsComponent } from '../../../../shared/components/tabs/tabs.component
         HeaderAnchorDirective,
         CopyButtonComponent,
         TabsComponent,
+        ExtensionPipe,
     ],
 })
 export class WsGuardsComponent extends BasePageComponent {}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md

## PR Type

What kind of change does this PR introduce?

- [x] Docs

## What is the current behavior?

The WebSockets [Guards](https://docs.nestjs.com/websockets/guards) page documents `@UseGuards()` on `@SubscribeMessage()` handlers only. It does not explain how to authenticate clients during the initial Socket.IO `handleConnection()` handshake.

Related discussion: https://github.com/nestjs/nest/issues/882

Issue Number: N/A

## What is the new behavior?

Adds an **Authenticating connections** section to `content/websockets/guards.md` covering:

- Why connection-time auth differs from message-scoped guards
- Verifying a JWT from `handshake.auth` or the `Authorization` header
- Disconnecting invalid clients in `handleConnection()`
- Joining user-specific rooms after verification
- A matching `socket.io-client` example

## Does this PR introduce a breaking change?

- [x] No

## Other information

Verified locally:

```bash
npm run docs-only
```

Result: docs generated successfully (includes updated `websockets/guards` page).

Examples follow existing `@@filename` / `@@switch` conventions used elsewhere in the docs repo.