### PR TITLE
docs: fix "class-base" -> "class-based" comment

### DIFF
--- a/content/fundamentals/dependency-injection.md
+++ b/content/fundamentals/dependency-injection.md
@@ -276,7 +276,7 @@ const connectionProvider = {
 @Module({
   providers: [
     connectionProvider,
-    MyOptionsProvider, // class-base provider
+    MyOptionsProvider, // class-based provider
     // { provide: 'SomeOptionalProvider', useValue: 'anything' },
   ],
 })


### PR DESCRIPTION
The JS variant comment was missing the trailing "d"; matches the TS variant above.