### PR TITLE
docs: update fastify.io links to fastify.dev

### DIFF
--- a/content/techniques/performance.md
+++ b/content/techniques/performance.md
@@ -39,7 +39,7 @@ async function bootstrap() {
 bootstrap();
 ```
 
-By default, Fastify listens only on the `localhost 127.0.0.1` interface ([read more](https://www.fastify.io/docs/latest/Guides/Getting-Started/#your-first-server)). If you want to accept connections on other hosts, you should specify `'0.0.0.0'` in the `listen()` call:
+By default, Fastify listens only on the `localhost 127.0.0.1` interface ([read more](https://fastify.dev/docs/latest/Guides/Getting-Started/#your-first-server)). If you want to accept connections on other hosts, you should specify `'0.0.0.0'` in the `listen()` call:
 
 ```typescript
 async function bootstrap() {
@@ -76,7 +76,7 @@ new FastifyAdapter({ logger: true });
 
 #### Middleware
 
-Middleware functions retrieve the raw `req` and `res` objects instead of Fastify's wrappers. This is how the `middie` package works (that's used under the hood) and `fastify` - check out this [page](https://www.fastify.io/docs/latest/Reference/Middleware/) for more information,
+Middleware functions retrieve the raw `req` and `res` objects instead of Fastify's wrappers. This is how the `middie` package works (that's used under the hood) and `fastify` - check out this [page](https://fastify.dev/docs/latest/Reference/Middleware/) for more information,
 
 ```typescript
 @@filename(logger.middleware)


### PR DESCRIPTION
Two Fastify links still use the retired www.fastify.io domain; the same file already uses fastify.dev elsewhere.