### PR TITLE
fix: enforce menu-background color to override inherited styles

### DIFF
--- a/src/app/homepage/menu/menu.component.scss
+++ b/src/app/homepage/menu/menu.component.scss
@@ -8,7 +8,7 @@
   
   padding: 90px 17px 40px 24px;
   width: 250px;
-  background: var(--menu-background);
+  background: var(--menu-background) !important;
   position: fixed !important;
   bottom: 0;
   top: 0;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md

## PR Type
What kind of change does this PR introduce?
- [x] Bugfix

## What is the current behavior?
Issue Number: #3476

On a fresh session (no cookies/local storage/cache), navigating from `https://nestjs.com/` into `docs.nestjs.com` leaves the left sidebar (`menu.component`) rendered with the wrong theme background compared to the header, content, and theme toggle button. The sidebar's `background: var(--menu-background)` declaration was being overridden by another, higher specificity rule, so it didn't consistently pick up the current theme's value, especially on that first cold navigation.

## What is the new behavior?
Marked the sidebar's `background: var(--menu-background)` declaration as `!important` in `menu.component.scss`, so the CSS custom property (which already correctly reflects the active `light`/`dark` mode) always takes precedence over any competing/inherited style, keeping the sidebar in sync with the rest of the layout on first load.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information
Verified by clearing all site data / using a fresh Incognito window in both light and dark OS preference, then navigating from `nestjs.com` → Docs. The sidebar background now matches the header/content/toggle state immediately on load, with no flash or mismatch.