### PR TITLE
docs(mongo): fix invalid objectid ref and pre-save hook examples

### DIFF
--- a/content/techniques/mongo.md
+++ b/content/techniques/mongo.md
@@ -92,7 +92,7 @@ owners: Owner[];
 If you don’t intend to always populate a reference to another collection, consider using `mongoose.Types.ObjectId` as the type instead:
 
 ```typescript
-@Prop({ type: { type: mongoose.Schema.Types.ObjectId, ref: 'Owner' } })
+@Prop({ type: mongoose.Schema.Types.ObjectId, ref: 'Owner' })
 // This ensures the field is not confused with a populated reference
 owner: mongoose.Types.ObjectId;
 ```
@@ -354,7 +354,7 @@ Like other [factory providers](https://docs.nestjs.com/fundamentals/custom-provi
           schema.pre('save', function() {
             console.log(
               `${configService.get('APP_NAME')}: Hello from pre save`,
-            ),
+            );
           });
           return schema;
         },


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

- [x] Docs


## What is the current behavior?

Issue Number: N/A

Two code samples in the Mongo chapter cannot be used as documented.

**1. `@Prop()` example for a reference that is not always populated**

The snippet under *"If you don't intend to always populate a reference to another collection"* nests `type` twice:

```ts
@Prop({ type: { type: mongoose.Schema.Types.ObjectId, ref: 'Owner' } })
owner: mongoose.Types.ObjectId;
```

Mongoose reads the inner object as a nested schema definition rather than as SchemaType options. Building both variants through `@Prop()` / `SchemaFactory.createForClass()` on `@nestjs/mongoose@11.0.4` with `mongoose@9.9.2` gives:

| | path `owner` | stored value | `ref` |
|---|---|---|---|
| `{ type: ObjectId, ref: 'Owner' }` (the example further up) | `SchemaObjectId` | `ObjectId('…')` | `'Owner'` |
| `{ type: { type: ObjectId, ref: 'Owner' } }` (current docs) | not created — only `owner.type` | `undefined` | dropped |

So an assigned `ObjectId` is silently discarded and `populate('owner')` can never resolve the reference. The failure is completely silent: `doc.validate()` resolves without error, and no warning is emitted.

The array variant shown just above it is **not** affected — for arrays the `ref` lives on the embedded schema type, so `{ type: [{ type: ObjectId, ref: 'Owner' }] }` is correct as written.

**2. `forFeatureAsync()` hook example with `ConfigService`**

Inside the `useFactory`, the `console.log()` call is terminated with a comma instead of a semicolon:

```ts
schema.pre('save', function() {
  console.log(
    `${configService.get('APP_NAME')}: Hello from pre save`,
  ),        // <-- comma, not semicolon
});
```

The comma operator has no right-hand operand, so the whole snippet fails to parse. `tsc` rejects it with `error TS1109: Expression expected.`


## What is the new behavior?

Both snippets now work as documented.

1. The `@Prop()` example uses the same schema options as the reference example above it, keeping `mongoose.Types.ObjectId` as the TypeScript property type — which is the point the surrounding paragraph makes. The path is now a real `SchemaObjectId` with `ref: 'Owner'`, the assigned value is preserved, and `populate()` works.
2. The `console.log()` call is terminated with a semicolon, so the snippet parses and compiles.

Only these two lines changed; no prose was touched.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


## Other information

Both fixes were verified by actually running the snippets:

- the hook example was compiled with `tsc --noEmit` before and after the change (`TS1109` → clean);
- the `@Prop()` variants were built through `SchemaFactory.createForClass()` against `@nestjs/mongoose@11.0.4` with `mongoose@9.9.2`, comparing the resulting schema paths, `ref` options and stored values.
