### PR TITLE
docs(middleware): explain exception handling

### DIFF
--- a/content/exception-filters.md
+++ b/content/exception-filters.md
@@ -351,6 +351,8 @@ export class AppModule {}
 
 > info **Hint** When using this approach to perform dependency injection for the filter, note that regardless of the module where this construction is employed, the filter is, in fact, global. Where should this be done? Choose the module where the filter (`HttpExceptionFilter` in the example above) is defined. Also, `useClass` is not the only way of dealing with custom provider registration. Learn more [here](/fundamentals/custom-providers).
 
+> info **Hint** Exceptions thrown from [middleware](/middleware#error-handling) are also processed by the exceptions layer. Because middleware runs before a route handler is selected, only **global** exception filters apply (`app.useGlobalFilters()` or `APP_FILTER`). Method-scoped and controller-scoped `@UseFilters()` bindings are not invoked.
+
 You can add as many filters with this technique as needed; simply add each to the providers array.
 
 #### Catch everything

--- a/content/faq/request-lifecycle.md
+++ b/content/faq/request-lifecycle.md
@@ -60,7 +60,7 @@ then the `GeneralValidationPipe` will run for the `query`, then the `params`, an
 
 Filters are the only component that do not resolve global first. Instead, filters resolve from the lowest level possible, meaning execution starts with any route bound filters and proceeding next to controller level, and finally to global filters. Note that exceptions cannot be passed from filter to filter; if a route level filter catches the exception, a controller or global level filter cannot catch the same exception. The only way to achieve an effect like this is to use inheritance between the filters.
 
-> info **Hint** Filters are only executed if any uncaught exception occurs during the request process. Caught exceptions, such as those caught with a `try/catch` will not trigger Exception Filters to fire. As soon as an uncaught exception is encountered, the rest of the lifecycle is ignored and the request skips straight to the filter.
+> info **Hint** Filters are only executed if any uncaught exception occurs during the request process. Caught exceptions, such as those caught with a `try/catch` will not trigger Exception Filters to fire. As soon as an uncaught exception is encountered, the rest of the lifecycle is ignored and the request skips straight to the filter. Exceptions thrown from [middleware](/middleware#error-handling) are handled by the exceptions layer as well, but only **global** exception filters apply, because middleware runs before a route handler is selected.
 
 #### Summary
 

--- a/content/middlewares.md
+++ b/content/middlewares.md
@@ -318,8 +318,6 @@ export class AuthMiddleware implements NestMiddleware {
 }
 ```
 
-> warning **Warning** If you throw inside a nested `.then()` / `.catch()` callback and **do not return** that Promise from `use()`, the rejection is unhandled and Nest will not generate a response. Prefer `async`/`await`.
-
 You can also pass the error to `next()`. This is useful when wrapping existing Express-style middleware that reports failures through the callback:
 
 ```typescript
@@ -331,8 +329,6 @@ use(req: Request, res: Response, next: NextFunction) {
 }
 ```
 
-> warning **Warning** Method-scoped and controller-scoped exception filters (applied with `@UseFilters()` on a controller or route handler) **do not** catch exceptions thrown from middleware. Middleware runs before the route handler is selected. To customize the response, register a **global** exception filter with `app.useGlobalFilters()` or the `APP_FILTER` token (see [Exception filters](/exception-filters#binding-filters)).
-
-> warning **Warning** Applying `@UseFilters()` to a middleware class has no effect. Bind custom filters globally instead.
+> warning **Warning** Since middleware runs before a route handler is selected, only **global** exception filters (registered with `app.useGlobalFilters()` or the `APP_FILTER` token) catch exceptions thrown from middleware. Method-scoped and controller-scoped filters are not invoked, and applying `@UseFilters()` to a middleware class has no effect.
 
 > info **Hint** Middleware registered with `app.use()` is handled by the underlying HTTP platform (Express or Fastify), not by Nest's `MiddlewareModule`. Prefer throwing (or calling `next(err)`) from middleware bound with `MiddlewareConsumer` so the exceptions layer can process the error.

--- a/content/middlewares.md
+++ b/content/middlewares.md
@@ -262,3 +262,77 @@ await app.listen(process.env.PORT ?? 3000);
 ```
 
 > info **Hint** Accessing the DI container in a global middleware is not possible. You can use a [functional middleware](middleware#functional-middleware) instead when using `app.use()`. Alternatively, you can use a class middleware and consume it with `.forRoutes('*')` within the `AppModule` (or any other module).
+
+#### Error handling
+
+When middleware throws an exception, Nest's [exceptions layer](/exception-filters) catches it and sends an appropriate response, the same way it does for exceptions thrown from a route handler. The recommended approach is to throw an `HttpException` (or a built-in subclass such as `UnauthorizedException`):
+
+```typescript
+@@filename(auth.middleware)
+import {
+  Injectable,
+  NestMiddleware,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { Request, Response, NextFunction } from 'express';
+
+@Injectable()
+export class AuthMiddleware implements NestMiddleware {
+  use(req: Request, res: Response, next: NextFunction) {
+    if (!req.headers.authorization) {
+      throw new UnauthorizedException();
+    }
+    next();
+  }
+}
+@@switch
+import { Injectable, UnauthorizedException } from '@nestjs/common';
+
+@Injectable()
+export class AuthMiddleware {
+  use(req, res, next) {
+    if (!req.headers.authorization) {
+      throw new UnauthorizedException();
+    }
+    next();
+  }
+}
+```
+
+If the middleware is asynchronous, declare `use()` as `async` (or return a `Promise`) so a rejected promise is forwarded to the exceptions layer:
+
+```typescript
+@@filename(auth.middleware)
+@Injectable()
+export class AuthMiddleware implements NestMiddleware {
+  constructor(private readonly authService: AuthService) {}
+
+  async use(req: Request, res: Response, next: NextFunction) {
+    const user = await this.authService.verify(req.headers.authorization);
+    if (!user) {
+      throw new UnauthorizedException();
+    }
+    req['user'] = user;
+    next();
+  }
+}
+```
+
+> warning **Warning** If you throw inside a nested `.then()` / `.catch()` callback and **do not return** that Promise from `use()`, the rejection is unhandled and Nest will not generate a response. Prefer `async`/`await`.
+
+You can also pass the error to `next()`. This is useful when wrapping existing Express-style middleware that reports failures through the callback:
+
+```typescript
+use(req: Request, res: Response, next: NextFunction) {
+  if (!req.headers.authorization) {
+    return next(new UnauthorizedException());
+  }
+  next();
+}
+```
+
+> warning **Warning** Method-scoped and controller-scoped exception filters (applied with `@UseFilters()` on a controller or route handler) **do not** catch exceptions thrown from middleware. Middleware runs before the route handler is selected. To customize the response, register a **global** exception filter with `app.useGlobalFilters()` or the `APP_FILTER` token (see [Exception filters](/exception-filters#binding-filters)).
+
+> warning **Warning** Applying `@UseFilters()` to a middleware class has no effect. Bind custom filters globally instead.
+
+> info **Hint** Middleware registered with `app.use()` is handled by the underlying HTTP platform (Express or Fastify), not by Nest's `MiddlewareModule`. Prefer throwing (or calling `next(err)`) from middleware bound with `MiddlewareConsumer` so the exceptions layer can process the error.


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?

The middleware and exception-filters pages do not explain how to handle errors thrown from middleware. `@UseFilters()` on a middleware class has no effect, which is a common source of confusion.

Issue Number: #215


## What is the new behavior?

Adds an **Error handling** section to the middleware docs covering:

- throwing `HttpException` / built-in HTTP exceptions
- `async` `use()` so rejected promises reach the exceptions layer
- `next(err)` when wrapping Express-style middleware
- that only **global** exception filters (`APP_FILTER` / `useGlobalFilters`) apply

Also adds short cross-links on the exception filters and request lifecycle pages.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


## Other information
