### PR TITLE
docs(recipes): mention Rspack for hot reload

### DIFF
--- a/content/recipes/hot-reload.md
+++ b/content/recipes/hot-reload.md
@@ -4,6 +4,8 @@ The highest impact on your application's bootstrapping process is **TypeScript c
 
 > warning **Warning** Note that `webpack` won't automatically copy your assets (e.g. `graphql` files) to the `dist` folder. Similarly, `webpack` is not compatible with glob static paths (e.g., the `entities` property in `TypeOrmModule`).
 
+> info **Hint** If you prefer a faster bundler, [Rspack](https://rspack.rs/guide/tech/nestjs) also supports NestJS applications with Hot Module Replacement.
+
 ### With CLI
 
 If you are using the [Nest CLI](https://docs.nestjs.com/cli/overview), the configuration process is pretty straightforward. The CLI wraps `webpack`, which allows use of the `HotModuleReplacementPlugin`.
@@ -173,3 +175,7 @@ $ npm run start:dev
 #### Example
 
 A working example is available [here](https://github.com/nestjs/nest/tree/master/sample/08-webpack).
+
+#### Third-party bundlers
+
+The Nest CLI wraps `webpack`, but you can also use [Rspack](https://rspack.rs/) for a similar Hot Module Replacement workflow. Rspack compiles TypeScript with SWC and preserves Nest decorator metadata. See the official [NestJS + Rspack guide](https://rspack.rs/guide/tech/nestjs) (includes a [working example](https://github.com/rstackjs/rstack-examples/tree/main/rspack/nestjs)).


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?

The hot-reload recipe only documents webpack. Rspack has an official NestJS HMR guide, but it is not linked from the Nest docs.

Issue Number: #2896


## What is the new behavior?

Adds a short hint and a **Third-party bundlers** note that points to the official [NestJS + Rspack guide](https://rspack.rs/guide/tech/nestjs), matching the approach discussed in the issue (link instead of duplicating a full setup section).


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


## Other information
