### PR TITLE
docs: document client shim usage

### DIFF
--- a/content/graphql/sharing-models.md
+++ b/content/graphql/sharing-models.md
@@ -2,23 +2,27 @@
 
 > warning **Warning** This chapter applies only to the code first approach.
 
-One of the biggest advantages of using Typescript for the backend of your project is the ability to reuse the same models in a Typescript-based frontend application, by using a common Typescript package.    
+One of the biggest advantages of using TypeScript for the backend of your project is the ability to reuse the same models in a TypeScript-based frontend application, by using a common TypeScript package.
 
 But there's a problem: the models created using the code first approach are heavily decorated with GraphQL related decorators. Those decorators are irrelevant in the frontend, negatively impacting performance.
 
 #### Using the model shim
 
-To solve this issue, NestJS provides a "shim" which allows you to replace the original decorators with inert code by using a `webpack` (or similar) configuration.
-To use this shim, configure an alias between the `@nestjs/graphql` package and the shim.
+To solve this issue, NestJS provides a shim that replaces the original decorators with inert code in browser and React Native builds. Modern bundlers that honor package export conditions can resolve the shim automatically through the `browser` or `react-native` condition in `@nestjs/graphql`.
 
-For example, for webpack this is resolved this way:
+If your bundler or custom setup does not use these conditions, configure an alias between the `@nestjs/graphql` package and the shim. For example, with webpack:
 
 ```typescript
-resolve: { // see: https://webpack.js.org/configuration/resolve/
+resolve: {
   alias: {
-      "@nestjs/graphql": path.resolve(__dirname, "../node_modules/@nestjs/graphql/dist/extra/graphql-model-shim")
-  }
-}
+    '@nestjs/graphql': path.resolve(
+      __dirname,
+      '../node_modules/@nestjs/graphql/dist/extra/graphql-model-shim',
+    ),
+  },
+},
 ```
+
+Use the shim only for client-side bundles. Server-side code must keep resolving `@nestjs/graphql` to the normal package so Nest can generate the GraphQL schema at runtime.
 
 > info **Hint** The [TypeORM](/techniques/database) package has a similar shim that can be found [here](https://github.com/typeorm/typeorm/blob/master/extra/typeorm-model-shim.js).

--- a/content/openapi/cli-plugin.md
+++ b/content/openapi/cli-plugin.md
@@ -63,6 +63,25 @@ The plugin adds appropriate decorators on the fly based on the **Abstract Syntax
 
 > info **Hint** The plugin will automatically generate any missing swagger properties, but if you need to override them, you simply set them explicitly via `@ApiProperty()`.
 
+#### Sharing DTOs with a client application
+
+If you share decorated DTO classes with a browser or another client-side bundle, importing `@nestjs/swagger` can pull server-side Nest packages into that bundle. The Swagger package ships a lightweight shim at `@nestjs/swagger/dist/extra/swagger-shim` that exports no-op versions of decorators and helpers such as `ApiProperty`, `PartialType`, and `PickType`.
+
+Configure your bundler to alias `@nestjs/swagger` to this shim for client builds only. For example, with webpack:
+
+```typescript
+resolve: {
+  alias: {
+    '@nestjs/swagger': path.resolve(
+      __dirname,
+      '../node_modules/@nestjs/swagger/dist/extra/swagger-shim',
+    ),
+  },
+},
+```
+
+Keep the normal `@nestjs/swagger` package in your server build so Nest can still generate the OpenAPI document at runtime.
+
 #### Comments introspection
 
 With the comments introspection feature enabled, CLI plugin will generate descriptions and example values for properties based on comments.


### PR DESCRIPTION
Fixes #2554.\n\n## What changed\n- Document the Swagger client shim in the OpenAPI CLI plugin page.\n- Clarify GraphQL model shim resolution through browser/react-native conditions.\n- Keep manual webpack alias examples for custom bundler setups.\n\n## Validation\n- npm run docs-only\n- git diff --check\n\nNote: docs generation reports the repository's existing dangling-link warnings.