### PR TITLE
docs(caching): use createkeyv helper in redis store examples

### DIFF
--- a/content/techniques/caching.md
+++ b/content/techniques/caching.md
@@ -236,7 +236,7 @@ With this in place, you can register the `CacheModule` with multiple stores as s
 import { Module } from '@nestjs/common';
 import { CacheModule } from '@nestjs/cache-manager';
 import { AppController } from './app.controller.js';
-import KeyvRedis from '@keyv/redis';
+import { createKeyv } from '@keyv/redis';
 import { Keyv } from 'keyv';
 import { KeyvCacheableMemory } from 'cacheable';
 
@@ -249,7 +249,7 @@ import { KeyvCacheableMemory } from 'cacheable';
             new Keyv({
               store: new KeyvCacheableMemory({ ttl: 60000, lruSize: 5000 }),
             }),
-            new KeyvRedis('redis://localhost:6379'),
+            createKeyv('redis://localhost:6379'),
           ],
         };
       },
@@ -260,7 +260,7 @@ import { KeyvCacheableMemory } from 'cacheable';
 export class AppModule {}
 ```
 
-In this example, we've registered two stores: `CacheableMemory` and `KeyvRedis`. The `CacheableMemory` store is a simple in-memory store, which is created via the `KeyvCacheableMemory` storage adapter, while `KeyvRedis` is a Redis store. The `stores` array is used to specify the stores you want to use. The first store in the array is the default store, and the rest are fallback stores.
+In this example, we've registered two stores: `CacheableMemory` and a Redis store. The `CacheableMemory` store is a simple in-memory store, which is created via the `KeyvCacheableMemory` storage adapter, while the Redis store is created via the `createKeyv` helper from `@keyv/redis`. The `stores` array is used to specify the stores you want to use. The first store in the array is the default store, and the rest are fallback stores.
 
 Check out the [Keyv documentation](https://keyv.org/docs/) for more information on available stores.
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

```ts
stores: [new KeyvRedis('redis://localhost:6379')]
```

The Redis examples in `techniques/caching.md` and `migration.md` pass a bare `KeyvRedis` adapter to `stores`. `@nestjs/cache-manager` wraps bare adapters in `new Keyv({ store, ... })`, and the `Keyv` constructor overwrites the adapter's `namespace`. So users who extend the example with `new KeyvRedis(url, { namespace: '...' })` get their namespace silently discarded.

Issue Number: N/A


## What is the new behavior?

The examples use `createKeyv` from `@keyv/redis`, the helper provided for this exact composition. It returns a ready-made `Keyv` instance (no re-wrapping), applies the namespace correctly, and sets `useKeyPrefix: false` to avoid double prefixing. The in-memory `new Keyv({ store: new KeyvCacheableMemory(...) })` example is unchanged, as it already passes a `Keyv` instance.

```ts
stores: [createKeyv('redis://localhost:6379')]
```



## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
