### PR TITLE
docs(openapi): note enableVersioning/createDocument call order

### DIFF
--- a/content/openapi/introduction.md
+++ b/content/openapi/introduction.md
@@ -45,6 +45,8 @@ await bootstrap();
 
 > info **Hint** The factory method `SwaggerModule.createDocument()` is used specifically to generate the Swagger document when you request it. This approach helps save some initialization time, and the resulting document is a serializable object that conforms to the [OpenAPI Document](https://swagger.io/specification/#openapi-document) specification. Instead of serving the document over HTTP, you can also save it as a JSON or YAML file and use it in various ways.
 
+> warning **Warning** If you call `createDocument()` eagerly (rather than in a factory function, as shown above), make sure `app.enableVersioning()` runs first — otherwise the generated `paths` will be missing the version prefix. The factory pattern is unaffected, since the document is not built until it is first requested.
+
 The `DocumentBuilder` helps to structure a base document that conforms to the OpenAPI Specification. It provides several methods that allow you to set properties such as title, description, and version. In order to create a full document (with all HTTP routes defined) we use the `createDocument()` method of the `SwaggerModule` class. This method takes two arguments, an application instance and a Swagger options object. Alternatively, we can provide a third argument, which should be of type `SwaggerDocumentOptions`. More on this in the [Document options section](/openapi/introduction#document-options).
 
 Once we create a document, we can call the `setup()` method. It accepts:


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
Issue Number: #2377

The Bootstrap section of the OpenAPI docs does not mention that the call order of `app.enableVersioning()` (URI versioning) relative to `SwaggerModule.createDocument()` affects the generated `paths`.

## What is the new behavior?

Adds a Warning callout right after the Bootstrap example explaining:
1. The factory-wrapped `createDocument()` pattern already shown in the example (`() => SwaggerModule.createDocument(app, config)` passed to `SwaggerModule.setup()`) is safe regardless of ordering, because the factory is only evaluated on the first request — by which point `enableVersioning()` has always already run.
2. If `createDocument()` is instead called eagerly and the resulting document reused, `app.enableVersioning()` must be called first, or the generated `paths` will be missing the version prefix.
3. The position of `SwaggerModule.setup()` itself has no effect on this in either case.

I verified this behavior directly against `@nestjs/swagger@11.4.7` / `@nestjs/core@11.2.1` with a minimal repro app (`VersioningType.URI`): calling `enableVersioning()` before an eager `createDocument()` call produces `["/v1", "/v1/cats"]`, calling it after produces `["/", "/cats"]` (version prefix silently dropped), and the factory pattern is unaffected by `setup()`'s position either way. I read `swagger-module.js`'s `setup()`/`serveDocuments()` source to confirm the factory is only invoked lazily via `getBuiltDocument()` on the first request, which is why that pattern is unaffected.

This has only been verified with `VersioningType.URI`; the warning is scoped accordingly.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information

Closes #2377