### PR TITLE
docs(caching): use millisecond ttl values in cachettl examples

### DIFF
--- a/content/techniques/caching.md
+++ b/content/techniques/caching.md
@@ -273,7 +273,7 @@ One approach is to use a factory function:
 ```typescript
 CacheModule.registerAsync({
   useFactory: () => ({
-    ttl: 5,
+    ttl: 5000,
   }),
 });
 ```
@@ -305,7 +305,7 @@ The above construction will instantiate `CacheConfigService` inside `CacheModule
 class CacheConfigService implements CacheOptionsFactory {
   createCacheOptions(): CacheModuleOptions {
     return {
-      ttl: 5,
+      ttl: 5000,
     };
   }
 }

--- a/content/techniques/caching.md
+++ b/content/techniques/caching.md
@@ -149,10 +149,10 @@ You can apply the `@CacheTTL()` decorator on a per-controller basis to set a cac
 
 ```typescript
 @Controller()
-@CacheTTL(50)
+@CacheTTL(5000)
 export class AppController {
   @CacheKey('custom_key')
-  @CacheTTL(20)
+  @CacheTTL(2000)
   findAll(): string[] {
     return [];
   }
@@ -190,14 +190,14 @@ Additionally, you may specify a cache expiration time (TTL) by using the `@Cache
 
 ```typescript
 @@filename()
-@CacheTTL(10)
+@CacheTTL(1000)
 @UseInterceptors(CacheInterceptor)
 @SubscribeMessage('events')
 handleEvent(client: Client, data: string[]): Observable<string[]> {
   return [];
 }
 @@switch
-@CacheTTL(10)
+@CacheTTL(1000)
 @UseInterceptors(CacheInterceptor)
 @SubscribeMessage('events')
 handleEvent(client, data) {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?

Follow-up to nestjs/cache-manager#1149, which clarified that `@CacheTTL()` values are in milliseconds.

This PR updates the `@CacheTTL()` example values in the caching docs (e.g. `50` → `5000`) so they read as realistic millisecond durations, preventing readers from mistaking them for seconds.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
