### PR TITLE
fix(docs): correct search title color and who-uses grammar

### DIFF
--- a/content/discover/who-uses.md
+++ b/content/discover/who-uses.md
@@ -1,7 +1,7 @@
 ### Who is using Nest?
 
 We are proudly helping various companies building their products at scale.
-If you are using Nest and would you like to be listed here, see this [thread](https://github.com/nestjs/nest/issues/1006).
+If you are using Nest and would like to be listed here, see this [thread](https://github.com/nestjs/nest/issues/1006).
 We are willing to put your logo here!
 
 #### Companies

--- a/src/app/homepage/homepage.component.scss
+++ b/src/app/homepage/homepage.component.scss
@@ -636,7 +636,7 @@
 
 .algolia-autocomplete .algolia-docsearch-suggestion--title {
   font-weight: 600;
-  color: 151515;
+  color: #151515;
 }
 
 .algolia-autocomplete .algolia-docsearch-suggestion--text {


### PR DESCRIPTION
## Summary

- Fix invalid CSS color value for Algolia search suggestion titles (`151515` -> `#151515`)
- Fix grammar on the Who uses Nest page (`would you like` -> `would like`)

## Test plan

- [x] Verified the CSS property uses a valid hex color
- [x] Verified the Who uses Nest copy reads correctly
