### PR TITLE
fix(toc): only reserve ad space when an ad is rendered

### DIFF
--- a/src/app/shared/components/toc/toc.component.scss
+++ b/src/app/shared/components/toc/toc.component.scss
@@ -2,11 +2,8 @@
 @use '../../../../scss/variables.scss';
 
 .toc-wrapper {
-  // The carbon ad is fixed to the bottom of this same right-hand rail, so the
-  // TOC is capped short of it and scrolls internally instead of growing into
-  // it. Reserve = tallest ad (~330px) + its 20px bottom offset + a gap.
   --toc-top: 106px;
-  --ad-reserve: 370px;
+  --ad-reserve: 0px;
 
   width: var(--rail-outer-width, 250px);
   padding-left: var(--rail-indent, 45px);
@@ -66,4 +63,14 @@
     border-left-color: var(--primary);
     font-weight: 600;
   }
+}
+
+// The carbon ad is fixed to the bottom of this same right-hand rail, so when an
+// ad is actually rendered the TOC is capped short of it and scrolls internally
+// instead of growing into it. Reserve = tallest ad (~330px) + its 20px bottom
+// offset + a gap. With no ad on screen (blocked, not yet loaded, or hidden by
+// hideAdIfTocOverflow) there is nothing to avoid, so the TOC gets the full rail.
+:host-context(.page-wrapper:has(.carbon-wrapper:not(.hide) #carbonads))
+  .toc-wrapper {
+  --ad-reserve: 370px;
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type

The TOC always subtracted 370px of rail height for the carbon ad, so with no ad on screen (blocked, not yet loaded, or hidden by hideAdIfTocOverflow) the list was cut short and scrolled internally for no reason. Default the reserve to 0 and apply it only when a visible #carbonads element exists.

**The code changed is totally produced by Claude Code. I chose to create this PR because it is a relatively small change and easy to review.**

Images comparing NestJS 11 docs and NestJS 12 docs below:

<img width="1418" height="1005" alt="image" src="https://github.com/user-attachments/assets/44d83c21-3868-4172-a5db-1689b4d05ebf" />
<img width="1418" height="1005" alt="image2" src="https://github.com/user-attachments/assets/fb8f00ba-c55d-49bd-8d63-2df054fd19f7" />

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

I noticed that every page should render an ad, but the Techniques -> Queues page will not render an ad if you navigate to that page with a full sized browser window. It will only render an ad under the "On this page" side bar, when you first navigate to that page in a smaller sized browser window, and then resize it.

https://github.com/user-attachments/assets/5cd01622-a019-47ae-a008-5e5c5c5deb79

