### PR TITLE
docs(faq): document multiple global prefixes

### DIFF
--- a/content/faq/global-prefix.md
+++ b/content/faq/global-prefix.md
@@ -7,6 +7,17 @@ const app = await NestFactory.create(AppModule);
 app.setGlobalPrefix('v1');
 ```
 
+To serve the same routes under more than one prefix, pass an array. Every route is then registered once per prefix:
+
+```typescript
+app.setGlobalPrefix(['api', 'v1']);
+// GET /api/cats and GET /v1/cats reach the same route handler
+```
+
+> info **Hint** In Nest v10 and earlier, a regular expression prefix such as `(api|v1)` could be used for this. That syntax is no longer supported, so use an array instead.
+
+> warning **Warning** `@nestjs/swagger` only reads the first prefix. With `app.setGlobalPrefix(['api', 'v1'])`, the generated OpenAPI document lists routes under `/api` only, and the [`useGlobalPrefix`](/openapi/introduction#setup-options) option serves Swagger UI under `/api` only.
+
 You can exclude routes from the global prefix using the following construction:
 
 ```typescript
@@ -22,3 +33,9 @@ app.setGlobalPrefix('v1', { exclude: ['cats'] });
 ```
 
 > info **Hint** The `path` property supports wildcard parameters using the [path-to-regexp](https://github.com/pillarjs/path-to-regexp#parameters) package. Note: this does not accept wildcard asterisks `*`. Instead, you must use parameters (`:param`) or named wildcards (`*splat`).
+
+The `exclude` option works the same way with multiple prefixes: excluded routes are served without any prefix. In the following example, `health` is only available at `/health`, while every other route is available under both `/api` and `/v1`:
+
+```typescript
+app.setGlobalPrefix(['api', 'v1'], { exclude: ['health'] });
+```


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?

Issue Number: nestjs/nest#16095

The global prefix FAQ only shows a single string prefix. Regex prefixes like `'(prefixOne|prefixTwo)'` stopped working in v11, and the docs don't mention an alternative.


## What is the new behavior?

Documents the array form of `setGlobalPrefix()` added in nestjs/nest#17713:

- `app.setGlobalPrefix(['api', 'v1'])` registers every route under each prefix, and a hint presents it as the replacement for regex prefixes.
- `exclude` works with multiple prefixes: excluded routes are served without any prefix.
- A warning that `@nestjs/swagger` only reads the first prefix, both in the generated document and for `useGlobalPrefix`.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


## Other information

nestjs/nest#17713 is merged, so this is ready for review. It is not in a release yet (`@nestjs/core` is at 12.0.4 as of this writing), so the page does not name a version — happy to add "available since vX.Y" in a follow-up, or here, once you know which release it lands in.

Rebased onto current `master`; the conflict with 2c57865 (FAQ language pass) is resolved in favour of the new wording on that page.

How the content was checked:
- The documented behavior was confirmed with a temporary integration test against nestjs/nest#17713, on Express and Fastify: routes and middleware respond under each prefix, and excluded routes respond only without a prefix.
- The Swagger warning is based on `lib/utils/get-global-prefix.ts` in nestjs/swagger, which calls `getGlobalPrefix()` and so only gets the first prefix.
- `npm run docs-only` generated all 137 docs, with no unmatched-link warnings from this page.
